### PR TITLE
Release 0.2.0 (resilience + crypto polish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,19 +71,15 @@ jobs:
         with:
           node-version: 20
 
-      - name: Bump manifest version (all packages except go)
-        if: ${{ env.PACKAGE != 'go' && env.PACKAGE != 'php' }}
-        run: node tools/bump-version.mjs "$PACKAGE" "$VERSION"
-
-      - name: Commit manifest bump to main
+      - name: Verify the manifest is already at the target version
         if: ${{ env.PACKAGE != 'go' && env.PACKAGE != 'php' }}
         run: |
-          if git diff --quiet; then
-            echo "::error::bump-version made no changes for ${PACKAGE} ${VERSION}"
+          node tools/bump-version.mjs "$PACKAGE" "$VERSION"
+          if ! git diff --quiet; then
+            echo "::error::${PACKAGE} manifest is not at ${VERSION} — bump it via a PR and merge to main before releasing"
+            git checkout -- .
             exit 1
           fi
-          git commit -am "release(${PACKAGE}): v${VERSION}"
-          git push origin HEAD:main
 
       - name: Create and push tag
         run: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing
 
-This monorepo ships **seven independent client SDKs** from one repo. Each is
-released on its own, and **only the package you tag gets published**.
+This monorepo ships **eight independent client SDKs** from one repo. Each is released on its own, and
+**only the package you tag gets published**.
 
 ## The tag scheme (the contract)
 
@@ -11,72 +11,58 @@ Every release is a **package-prefixed git tag**:
 <dir>/vX.Y.Z
 ```
 
-where `<dir>` is one of: `dotnet`, `node`, `python`, `rust`, `java`, `go`, `ruby`,
-and `X.Y.Z` is a [SemVer](https://semver.org) version (no leading `v` in the
-version part — the literal `v` is part of the prefix, e.g. `node/v0.2.0`).
+where `<dir>` ∈ `dotnet`, `node`, `python`, `rust`, `java`, `go`, `ruby`, `php`, and `X.Y.Z` is a
+[SemVer](https://semver.org) version (the literal `v` is part of the prefix, e.g. `node/v0.2.0`).
 
-Each `publish-<dir>.yml` workflow triggers **only** on its own `<dir>/v*` tags, so
-tagging `node/v0.2.0` publishes the Node package and nothing else.
+Each `publish-<dir>.yml` triggers **only** on its own `<dir>/v*` tags, so tagging `node/v0.2.0` publishes
+the Node package and nothing else.
 
 ## Where each package's version lives
 
-For all packages except Go, the version is kept in a manifest and **must match the
-tag** — each `publish-<dir>.yml` has a gate that fails the publish if `tag != manifest`.
-
-| Package | Manifest (source of truth) | Also updated |
+| Package | Source of truth | Also updated |
 |---|---|---|
 | `dotnet` | `dotnet/src/OpenBankingIO.Client/OpenBankingIO.Client.csproj` (`<Version>`) | — |
 | `node`   | `node/package.json` (`version`) | `node/package-lock.json` |
 | `python` | `python/pyproject.toml` (`[project].version`) | — |
 | `rust`   | `rust/Cargo.toml` (`[package].version`) | `rust/Cargo.lock` |
 | `java`   | `java/pom.xml` (project `<version>`) | — |
-| `ruby`   | `ruby/lib/open_banking_io/version.rb` (`VERSION`) / gemspec | — |
-| `go`     | **none** — the version *is* the tag | — |
+| `ruby`   | `ruby/lib/open_banking_io/version.rb` (`VERSION`) | gemspec |
+| `go`     | **none** — version *is* the tag; `Version` const in `go/client.go` is cosmetic (User-Agent) | — |
+| `php`    | **none** — Packagist derives version from the tag; `Client::VERSION` const is cosmetic | — |
 
-## Cutting a release (the normal path)
+## Cutting a release (two steps — `main` is protected)
 
-Use the **Release** workflow — it does the manifest bump, the commit, and the tag
-for you.
+`main` is a protected branch (PRs + status checks required), so releases do **not** push to `main`
+directly. A release is two steps:
 
-1. Go to **Actions → Release → Run workflow**.
-2. Pick the **package** (e.g. `node`) and enter the **version** (e.g. `0.2.0`).
-3. Run it. The workflow will:
-   - validate the version is semver and **refuse if the tag already exists**;
-   - for every package **except `go`**: run `node tools/bump-version.mjs <pkg> <version>`
-     to update the manifest (and lockfiles), then commit
-     `release(<pkg>): v<version>` to `main` as the release bot;
-   - create and push the tag `<pkg>/v<version>`.
-4. Pushing the tag triggers `publish-<pkg>.yml`, which verifies the tag matches the
-   manifest and publishes to the registry (NuGet / npm / PyPI / crates.io / Maven
-   Central / pkg.go.dev / RubyGems).
+**1. Bump the version in a PR.** For `dotnet/node/python/rust/java/ruby`, bump the manifest:
 
-### Go specifics
+```bash
+node tools/bump-version.mjs <package> <version>   # e.g. node 0.2.0  (updates manifest + lockfiles)
+```
 
-Go has no manifest — the module version is the tag itself. The Release workflow
-**skips the bump/commit** for `go` and just pushes `go/vX.Y.Z`. Consumers then get
-that version via `go get github.com/open-banking-io/clients/go@vX.Y.Z`.
+For `go`/`php`, update the cosmetic `Version`/`VERSION` const to match. Open the PR, let CI pass, merge.
+
+**2. Tag via the Release workflow.** Go to **Actions → Release → Run workflow**, pick the **package** and
+**version**. It will:
+- validate semver and **refuse if the tag already exists**;
+- for non-`go`/`php`: verify the manifest on `main` is **already** at that version (fails with a clear
+  message if you forgot step 1);
+- create and push the tag `<pkg>/v<version>` and a **GitHub Release** with auto-generated notes.
+
+Pushing the tag triggers `publish-<pkg>.yml`, which re-checks `tag == manifest` and publishes to the
+registry (NuGet / npm / PyPI / crates.io / Maven Central / pkg.go.dev / RubyGems / Packagist).
+
+> You can also just push the tag by hand (`git tag <pkg>/v<version> && git push origin <pkg>/v<version>`)
+> once the version is on `main` — tags aren't branch-protected. The Release workflow just adds the guards
+> and release notes.
 
 ## The version-consistency gate
 
-Don't hand-edit a manifest and tag separately unless you keep them identical — the
-`publish-<pkg>.yml` gate compares `tag == manifest` and **fails** on mismatch. The
-Release workflow keeps them in lockstep, so prefer it.
-
-## Manual bump (advanced / local)
-
-If you need to bump a manifest without releasing (e.g. in a PR), run the same
-script the workflow uses:
-
-```bash
-node tools/bump-version.mjs <package> <version>   # e.g. node 0.2.0
-```
-
-Runs on Node 20+, no dependencies. It validates semver, edits the correct
-manifest(s), and throws for `go` (which has no manifest).
+Each `publish-<pkg>.yml` compares `tag == manifest` and **fails** on mismatch (skipped for `go`/`php`,
+which are tag-only). So the manifest must be on `main` at the released version before you tag.
 
 ## What changed in a PR?
 
-Every PR gets a **Changed packages** comment listing which client directories
-changed and which package(s) to release after merge. A change under `fixtures/**`
-(shared test vectors) is reported as affecting **all** clients. If only shared
-infra changed, the comment says there's nothing to release.
+Every PR gets a **Changed packages** comment listing which client directories changed and which
+package(s) to release after merge. A change under `fixtures/**` (shared vectors) affects **all** clients.

--- a/dotnet/src/OpenBankingIO.Client/OpenBankingIO.Client.csproj
+++ b/dotnet/src/OpenBankingIO.Client/OpenBankingIO.Client.csproj
@@ -17,7 +17,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
     <PackageId>OpenBankingIO.Client</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>open-banking.io</Authors>
     <Description>Server-to-server client for open-banking.io: API-key auth + client-side decryption of the zero-knowledge data envelopes with your exported private key.</Description>
     <PackageTags>open-banking;psd2;zero-knowledge;encryption;fintech</PackageTags>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.open-banking</groupId>
   <artifactId>open-banking-io-client</artifactId>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <packaging>jar</packaging>
 
   <name>open-banking.io client</name>

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-banking-io/client",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-banking-io/client",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-banking-io/client",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Server-to-server client for open-banking.io: API-key auth + client-side decryption of the zero-knowledge data envelopes with your exported private key.",
   "type": "module",
   "license": "MIT",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-banking-io"
-version = "0.1.0"
+version = "0.2.0"
 description = "Server-to-server client for open-banking.io with local zero-knowledge envelope decryption."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    open-banking-io (0.1.0)
+    open-banking-io (0.2.0)
       base64 (>= 0.1)
       bigdecimal (>= 3.0)
 
@@ -105,7 +105,7 @@ CHECKSUMS
   json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
-  open-banking-io (0.1.0)
+  open-banking-io (0.2.0)
   parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85

--- a/ruby/lib/open_banking_io/version.rb
+++ b/ruby/lib/open_banking_io/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenBankingIO
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -501,7 +501,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open-banking-io"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-banking-io"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.74"
 description = "Server-to-server client for open-banking.io with local zero-knowledge envelope decryption."

--- a/tools/bump-version.mjs
+++ b/tools/bump-version.mjs
@@ -90,6 +90,14 @@ const bumpers = {
 
   ruby(version) {
     setRubyGemVersion(version);
+    // Keep the gem's own pin in Gemfile.lock in sync (two occurrences) so
+    // bundler's frozen install in CI doesn't reject the bump.
+    const rel = "ruby/Gemfile.lock";
+    if (existsSync(join(ROOT, rel))) {
+      const src = read(rel);
+      const out = src.replace(/(open-banking-io \()[0-9][^)]*(\))/g, `$1${version}$2`);
+      if (out !== src) write(rel, out);
+    }
   },
 
   go() {


### PR DESCRIPTION
Bumps all manifests to **0.2.0** (the Phase-3 resilience + crypto work) and adapts the release flow to the now-protected `main`:

- 6 manifest packages → 0.2.0; go/php cosmetic `VERSION` consts already 0.2.0.
- `release.yml` no longer pushes to `main` (branch protection); it verifies the manifest is at the version, then creates the tag + GitHub Release.
- `RELEASING.md` updated to the two-step flow (bump in a PR → tag).

After merge I'll tag `<pkg>/v0.2.0` for all 8 → the publish workflows ship 0.2.0 to every registry.