### PR TITLE
CLI release: publish-cli owns the GitHub Release (avoid collision)

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -68,15 +68,20 @@ jobs:
           ( cd dist && sha256sum * > checksums.txt )
           echo "Built:"; ls -1 dist
 
-      - name: Create GitHub Release
+      - name: Publish GitHub Release with binaries
         if: steps.ver.outputs.is_tag == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" cli/dist/* \
-            --title "obank ${VERSION}" \
-            --notes "Binaries for linux/macOS/windows (amd64 + arm64). Verify with checksums.txt. Install via Homebrew: \`brew install open-banking-io/tap/obank\`."
+          notes="Binaries for linux/macOS/windows (amd64 + arm64). Verify with checksums.txt. Install via Homebrew: \`brew install open-banking-io/tap/obank\`."
+          # Idempotent: create the release if it doesn't exist yet, otherwise attach the assets to it
+          # (handles re-runs and any pre-created release).
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" cli/dist/* --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" cli/dist/* --title "obank ${VERSION}" --notes "$notes"
+          fi
 
       - name: Update Homebrew tap
         if: steps.ver.outputs.is_tag == 'true' && env.HAS_TAP == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,9 @@ jobs:
           echo "::notice::pushed ${TAG} — publish-${PACKAGE}.yml will pick it up"
 
       - name: Create GitHub Release
+        # The cli package's publish-cli.yml owns its release (it attaches the built binaries), so
+        # don't create an empty one here that would collide with it.
+        if: ${{ env.PACKAGE != 'cli' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release create "${TAG}" --title "${PACKAGE} v${VERSION}" --generate-notes --verify-tag


### PR DESCRIPTION
Follow-up to #31. `release.yml` creates a GitHub Release for every package, and `publish-cli.yml` also creates one (to attach the cross-platform binaries) — for `cli` that would collide. This skips `release.yml`'s release-creation for `cli` and makes `publish-cli`'s step idempotent (create-if-absent, else `upload --clobber`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)