### PR TITLE
CLI: default to open-banking.io

### DIFF
--- a/cli/internal/app/key_test.go
+++ b/cli/internal/app/key_test.go
@@ -35,7 +35,7 @@ func TestKeyImportFromBundleFilePreservesApiKey(t *testing.T) {
 
 	// A login already saved an API key into the local config.
 	cfg := filepath.Join(t.TempDir(), "credentials.json")
-	existing := config.Bundle{APIKey: "ebk_from_login", APIBaseURL: "https://bank.core.ci"}
+	existing := config.Bundle{APIKey: "ebk_from_login", APIBaseURL: "https://open-banking.io"}
 	if err := config.Save(cfg, existing); err != nil {
 		t.Fatal(err)
 	}

--- a/cli/internal/app/login.go
+++ b/cli/internal/app/login.go
@@ -17,7 +17,7 @@ import (
 	"github.com/open-banking-io/clients/cli/internal/config"
 )
 
-const defaultAPIBaseURL = "https://bank.core.ci"
+const defaultAPIBaseURL = "https://open-banking.io"
 
 // cliTokenResponse is the credential returned by POST /auth/cli/token.
 type cliTokenResponse struct {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -14,7 +14,7 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 
 	want := openbanking.CredentialsBundle{
 		Service:    "open-banking.io",
-		APIBaseURL: "https://bank.core.ci",
+		APIBaseURL: "https://open-banking.io",
 		User:       "demo@open-banking.io",
 		APIKey:     "ebk_secret",
 		EncryptionKey: openbanking.EncryptionKey{


### PR DESCRIPTION
Points the obank CLI default API base URL at `open-banking.io` (was `bank.core.ci`) + test fixtures.

The `bank.core.ci/zk/v1` HKDF `info` constant in the envelope spec is **not** a URL — it's a crypto domain-separation tag shared byte-for-byte across the backend, SPA and all 8 SDKs, so it's deliberately left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)