### PR TITLE
Fix red main: java toolchain + coverage go; block major dep bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     directory: /dotnet
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: npm
     directory: /node
@@ -25,6 +28,9 @@ updates:
     directory: /python
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: cargo
     directory: /rust
@@ -38,18 +44,30 @@ updates:
     directory: /go
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: maven
     directory: /java
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: bundler
     directory: /ruby
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: composer
     directory: /php
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - run: go test -coverprofile=coverage.out -covermode=atomic ./...
         working-directory: go
       - run: |

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -37,8 +37,8 @@
     <jackson.version>2.22.0</jackson.version>
     <junit.version>6.1.0</junit.version>
     <jacoco.version>0.8.15</jacoco.version>
-    <spotless.version>3.6.0</spotless.version>
-    <google-java-format.version>1.35.0</google-java-format.version>
+    <spotless.version>2.44.0</spotless.version>
+    <google-java-format.version>1.27.0</google-java-format.version>
     <spotbugs.version>4.10.2.0</spotbugs.version>
   </properties>
 


### PR DESCRIPTION
`main` went red after auto-merged Dependabot bumps:
- **java (17)** failed — `spotless` 3.6 / `google-java-format` 1.35 format differently under JDK 17. Reverted both to the JDK-17-safe versions (2.44.0 / 1.27.0); `mvn verify` green on JDK 17 locally.
- **coverage go** would fail — `gocover-cobertura` v1.5 needs Go ≥1.25; bumped that job to 1.25.
- **Root cause**: Dependabot was auto-bumping breaking majors (cargo, npm, now maven) — now **semver-major ignored across all language ecosystems** (github-actions still updates; they're SHA-pinned).
🤖 Generated with [Claude Code](https://claude.com/claude-code)