### PR TITLE
Auto-release obank when the CLI or its SDK changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,14 @@ updates:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
 
+  - package-ecosystem: gomod
+    directory: /cli
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+
   - package-ecosystem: maven
     directory: /java
     schedule:

--- a/.github/workflows/auto-release-cli.yml
+++ b/.github/workflows/auto-release-cli.yml
@@ -1,0 +1,47 @@
+name: Auto-release CLI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cli/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-release-cli
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Compute next obank patch version
+        id: ver
+        run: |
+          latest="$(git tag --list 'cli/v*' --sort=-v:refname | head -1)"
+          if [ -z "$latest" ]; then
+            next="0.1.0"
+          else
+            v="${latest#cli/v}"
+            IFS='.' read -r MAJ MIN PAT <<< "$v"
+            next="${MAJ}.${MIN}.$((PAT + 1))"
+          fi
+          echo "tag=cli/v${next}" >> "$GITHUB_OUTPUT"
+          echo "next=${next}" >> "$GITHUB_OUTPUT"
+          echo "::notice::cli/** changed on main — auto-releasing obank ${next}"
+
+      - name: Tag the release (triggers publish-cli.yml)
+        env:
+          TOKEN: ${{ secrets.MIRROR_PUSH_TOKEN }}
+        run: |
+          git config user.name  "open-banking-io-bot"
+          git config user.email "bot@open-banking.io"
+          git tag -a "${{ steps.ver.outputs.tag }}" -m "auto-release obank ${{ steps.ver.outputs.next }}"
+          git push "https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${{ steps.ver.outputs.tag }}"


### PR DESCRIPTION
Makes obank releases automatic — no manual Actions → Release step.

- **`auto-release-cli.yml`**: any push to `main` touching `cli/**` → bump the obank patch (from the latest `cli/v*` tag) → push the tag via `MIRROR_PUSH_TOKEN` → `publish-cli.yml` builds the binaries, creates the GitHub Release, and updates `brew install open-banking-io/tap/obank`.
- **Dependabot `gomod /cli`**: when the Go SDK publishes a new version, Dependabot bumps the CLI's `go.mod` → that's a `cli/**` change → auto-release fires. So *SDK updated → CLI auto-releases* falls out for free.

Patch auto-bump (next would be obank 0.2.1); cut a minor/major manually via Actions → Release when intended. Merging this PR doesn't trigger a release (it only touches `.github/`).
🤖 Generated with [Claude Code](https://claude.com/claude-code)