### PR TITLE
Rename CLI obank → openbanking (open-banking.io CLI)

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -58,10 +58,10 @@ jobs:
           targets="linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64"
           for t in $targets; do
             os="${t%/*}"; arch="${t#*/}"
-            bin=obank; [ "$os" = windows ] && bin=obank.exe
+            bin=openbanking; [ "$os" = windows ] && bin=openbanking.exe
             CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
               go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" -o "$bin" .
-            name="obank_${VERSION}_${os}_${arch}"
+            name="openbanking_${VERSION}_${os}_${arch}"
             if [ "$os" = windows ]; then zip -j "dist/${name}.zip" "$bin"; else tar -czf "dist/${name}.tar.gz" "$bin"; fi
             rm -f "$bin"
           done
@@ -74,13 +74,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          notes="Binaries for linux/macOS/windows (amd64 + arm64). Verify with checksums.txt. Install via Homebrew: \`brew install open-banking-io/tap/obank\`."
+          notes="Binaries for linux/macOS/windows (amd64 + arm64). Verify with checksums.txt. Install via Homebrew: \`brew install open-banking-io/tap/openbanking\`."
           # Idempotent: create the release if it doesn't exist yet, otherwise attach the assets to it
           # (handles re-runs and any pre-created release).
           if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
             gh release upload "${GITHUB_REF_NAME}" cli/dist/* --clobber
           else
-            gh release create "${GITHUB_REF_NAME}" cli/dist/* --title "obank ${VERSION}" --notes "$notes"
+            gh release create "${GITHUB_REF_NAME}" cli/dist/* --title "open-banking.io CLI ${VERSION}" --notes "$notes"
           fi
 
       - name: Update Homebrew tap
@@ -91,12 +91,12 @@ jobs:
         run: |
           set -euo pipefail
           cd cli/dist
-          sha() { grep "  obank_${VERSION}_$1\$" checksums.txt | awk '{print $1}'; }
+          sha() { grep "  openbanking_${VERSION}_$1\$" checksums.txt | awk '{print $1}'; }
           dl="https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}"
-          cat > obank.rb <<EOF
+          cat > openbanking.rb <<EOF
           # typed: false
           # frozen_string_literal: true
-          class Obank < Formula
+          class Openbanking < Formula
             desc "open-banking.io command line — read, sync and connect your bank data locally"
             homepage "https://open-banking.io"
             version "${VERSION}"
@@ -104,41 +104,42 @@ jobs:
 
             on_macos do
               on_arm do
-                url "${dl}/obank_${VERSION}_darwin_arm64.tar.gz"
+                url "${dl}/openbanking_${VERSION}_darwin_arm64.tar.gz"
                 sha256 "$(sha darwin_arm64.tar.gz)"
               end
               on_intel do
-                url "${dl}/obank_${VERSION}_darwin_amd64.tar.gz"
+                url "${dl}/openbanking_${VERSION}_darwin_amd64.tar.gz"
                 sha256 "$(sha darwin_amd64.tar.gz)"
               end
             end
 
             on_linux do
               on_arm do
-                url "${dl}/obank_${VERSION}_linux_arm64.tar.gz"
+                url "${dl}/openbanking_${VERSION}_linux_arm64.tar.gz"
                 sha256 "$(sha linux_arm64.tar.gz)"
               end
               on_intel do
-                url "${dl}/obank_${VERSION}_linux_amd64.tar.gz"
+                url "${dl}/openbanking_${VERSION}_linux_amd64.tar.gz"
                 sha256 "$(sha linux_amd64.tar.gz)"
               end
             end
 
             def install
-              bin.install "obank"
+              bin.install "openbanking"
             end
 
             test do
-              system "#{bin}/obank", "version"
+              system "#{bin}/openbanking", "version"
             end
           end
           EOF
           git clone --depth 1 "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/open-banking-io/homebrew-tap.git" tap
           mkdir -p tap/Formula
-          cp obank.rb tap/Formula/obank.rb
+          rm -f tap/Formula/*.rb
+          cp openbanking.rb tap/Formula/openbanking.rb
           cd tap
           git config user.name  "open-banking-io-bot"
           git config user.email "bot@open-banking.io"
-          git add Formula/obank.rb
-          git commit -m "obank ${VERSION}"
+          git add -A Formula/
+          git commit -m "open-banking.io CLI ${VERSION}"
           git push

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,4 +1,4 @@
-# obank
+# open-banking.io CLI (`openbanking`)
 
 The **open-banking.io** command line. Authenticate once, then read, sync, and
 connect your bank data locally — the zero-knowledge envelopes are decrypted
@@ -9,14 +9,14 @@ in-process with your own key, never on a server.
 ### Homebrew (macOS / Linux)
 
 ```sh
-brew install open-banking-io/tap/obank
+brew install open-banking-io/tap/openbanking
 ```
 
 ### Binaries (Windows / macOS / Linux)
 
 Download the archive for your platform from the
-[latest release](https://github.com/open-banking-io/clients/releases?q=obank),
-unpack it, and put `obank` on your `PATH`. Windows ships a `.zip`; macOS/Linux a
+[latest release](https://github.com/open-banking-io/clients/releases?q=openbanking),
+unpack it, and put `openbanking` on your `PATH`. Windows ships a `.zip`; macOS/Linux a
 `.tar.gz`. Checksums are published alongside as `checksums.txt`.
 
 ### From source
@@ -28,14 +28,14 @@ go install github.com/open-banking-io/clients/cli@latest
 ## Usage
 
 ```sh
-obank login                       # sign in via the browser, saves an API key
-obank key import ./credentials.json   # import your encryption key (exported from the app)
-obank accounts                    # list accounts with balances
-obank transactions <account-id>   # an account's statement (--from --to --limit)
-obank sync --all                  # pull fresh transactions
-obank banks                       # banks available to connect
-obank connect <bank-name>         # connect a bank via the consent flow
-obank version
+openbanking login                       # sign in via the browser, saves an API key
+openbanking key import ./credentials.json   # import your encryption key (exported from the app)
+openbanking accounts                    # list accounts with balances
+openbanking transactions <account-id>   # an account's statement (--from --to --limit)
+openbanking sync --all                  # pull fresh transactions
+openbanking banks                       # banks available to connect
+openbanking connect <bank-name>         # connect a bank via the consent flow
+openbanking version
 ```
 
 Credentials live in `$OPENBANKING_CONFIG` or

--- a/cli/internal/app/app.go
+++ b/cli/internal/app/app.go
@@ -1,4 +1,4 @@
-// Package app implements the obank CLI command dispatch. Commands are methods on App so tests can
+// Package app implements the openbanking CLI command dispatch. Commands are methods on App so tests can
 // drive them with injected writers, an explicit config path, and a custom HTTP client.
 package app
 
@@ -56,13 +56,13 @@ func (a *App) Run(args []string) error {
 	case "connect":
 		return a.connect(rest)
 	case "version", "--version", "-v":
-		fmt.Fprintf(a.Stdout, "obank %s\n", a.versionString())
+		fmt.Fprintf(a.Stdout, "openbanking %s\n", a.versionString())
 		return nil
 	case "help", "-h", "--help":
 		a.usage()
 		return nil
 	default:
-		return fmt.Errorf("unknown command %q (run `obank help`)", cmd)
+		return fmt.Errorf("unknown command %q (run `openbanking help`)", cmd)
 	}
 }
 
@@ -83,7 +83,7 @@ func (a *App) publicClient() (*openbanking.Client, error) {
 		return nil, err
 	}
 	if bundle.APIKey == "" {
-		return nil, fmt.Errorf("no API key — run `obank login` first")
+		return nil, fmt.Errorf("no API key — run `openbanking login` first")
 	}
 	return openbanking.NewPublic(bundle.APIBaseURL, bundle.APIKey, a.HTTPClient)
 }
@@ -96,10 +96,10 @@ func (a *App) versionString() string {
 }
 
 func (a *App) usage() {
-	fmt.Fprint(a.Stderr, `obank — open-banking.io command line
+	fmt.Fprint(a.Stderr, `openbanking — open-banking.io command line
 
 Usage:
-  obank <command> [flags]
+  openbanking <command> [flags]
 
 Commands:
   login                          Sign in via the browser and save an API key (--api --timeout)
@@ -110,7 +110,7 @@ Commands:
   sync <account-id> | --all      Pull fresh transactions for one account or all
   banks                          List banks available for connection (--country)
   connect <bank-name>            Connect a bank via the browser consent flow
-  version                        Print the obank version
+  version                        Print the openbanking version
   help                           Show this help
 `)
 }

--- a/cli/internal/app/connect.go
+++ b/cli/internal/app/connect.go
@@ -15,7 +15,7 @@ var connectPollInterval = 2 * time.Second
 
 func (a *App) connect(args []string) error {
 	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
-		return fmt.Errorf("usage: obank connect <bank-name> [--country DK] [--psu-type personal|business]")
+		return fmt.Errorf("usage: openbanking connect <bank-name> [--country DK] [--psu-type personal|business]")
 	}
 	bankName := args[0]
 

--- a/cli/internal/app/dispatch_test.go
+++ b/cli/internal/app/dispatch_test.go
@@ -1,0 +1,153 @@
+package app
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-banking-io/clients/cli/internal/config"
+	openbanking "github.com/open-banking-io/clients/go"
+)
+
+// deadURL returns the URL of a server that has already been closed: connecting to it fails.
+func deadURL(t *testing.T) string {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := s.URL
+	s.Close()
+	return url
+}
+
+func TestRunVersion(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, Version: "1.2.3"}
+	if err := app.Run([]string{"version"}); err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if !strings.Contains(out.String(), "openbanking 1.2.3") {
+		t.Errorf("version output = %q", out.String())
+	}
+}
+
+func TestRunVersionDefaultsToDev(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut} // no Version set
+	if err := app.Run([]string{"--version"}); err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if !strings.Contains(out.String(), "openbanking dev") {
+		t.Errorf("version output = %q, want 'openbanking dev'", out.String())
+	}
+}
+
+func TestRunHelpPrintsUsage(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut}
+	if err := app.Run([]string{"help"}); err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "openbanking <command>") {
+		t.Errorf("usage not printed; stderr = %q", errOut.String())
+	}
+}
+
+func TestRunNoCommandErrorsAndPrintsUsage(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut}
+	if err := app.Run(nil); err == nil {
+		t.Fatal("expected an error when no command is given")
+	}
+	if !strings.Contains(errOut.String(), "Usage:") {
+		t.Errorf("usage not printed on empty args; stderr = %q", errOut.String())
+	}
+}
+
+// TestKeyImportDefaultStdin exercises the nil-Stdin path (stdin() returns an empty reader): the
+// command reads no key and fails cleanly rather than panicking.
+func TestKeyImportDefaultStdin(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "credentials.json")
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfg} // Stdin nil
+	if err := app.Run([]string{"key", "import"}); err == nil {
+		t.Fatal("expected an error when no key is provided on stdin")
+	}
+}
+
+func TestPublicClientCommandsRequireAPIKey(t *testing.T) {
+	// A config that exists but carries no API key.
+	cfg := filepath.Join(t.TempDir(), "credentials.json")
+	if err := config.Save(cfg, config.Bundle{APIBaseURL: "https://x"}); err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
+	if err := app.Run([]string{"banks"}); err == nil {
+		t.Fatal("expected an error when the config has no API key")
+	}
+}
+
+func TestPublicClientCommandsRequireConfig(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: filepath.Join(t.TempDir(), "missing.json")}
+	if err := app.Run([]string{"banks"}); err == nil {
+		t.Fatal("expected an error when the config is missing")
+	}
+}
+
+func TestBanksReportsListError(t *testing.T) {
+	bundle := fixtureBundle(t)
+	cfg := writeConfig(t, bundle, deadURL(t))
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
+	if err := app.Run([]string{"banks"}); err == nil {
+		t.Fatal("expected an error when the banks request fails")
+	}
+}
+
+func TestConnectionsReportsListError(t *testing.T) {
+	bundle := fixtureBundle(t)
+	cfg := writeConfig(t, bundle, deadURL(t))
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
+	if err := app.Run([]string{"connections"}); err == nil {
+		t.Fatal("expected an error when the connections request fails")
+	}
+}
+
+func TestSyncReportsError(t *testing.T) {
+	bundle := fixtureBundle(t)
+	cfg := writeConfig(t, bundle, deadURL(t))
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
+	if err := app.Run([]string{"sync", "--all"}); err == nil {
+		t.Fatal("expected an error when the sync request fails")
+	}
+}
+
+func TestSyncAllRejectsAccountID(t *testing.T) {
+	bundle := fixtureBundle(t)
+	srv := startAPIServer(t, bundle.APIKey)
+	cfg := writeConfig(t, bundle, srv.URL)
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
+	if err := app.Run([]string{"sync", "--all", "some-account"}); err == nil {
+		t.Fatal("expected an error: `sync --all` takes no account id")
+	}
+}
+
+func TestRenderBanksShowsBetaFlag(t *testing.T) {
+	var out bytes.Buffer
+	banks := []openbanking.Bank{
+		{Name: "Lunar", Country: "DK", Bic: "LUNADK22", PsuTypes: []string{"business"}, Beta: false},
+		{Name: "NewBank", Country: "DK", Beta: true},
+	}
+	if err := renderBanks(&out, banks); err != nil {
+		t.Fatalf("renderBanks: %v", err)
+	}
+	if !strings.Contains(out.String(), "beta") {
+		t.Errorf("expected a beta marker in output\n%s", out.String())
+	}
+}

--- a/cli/internal/app/helpers_logic_test.go
+++ b/cli/internal/app/helpers_logic_test.go
@@ -1,0 +1,105 @@
+package app
+
+import (
+	"testing"
+
+	openbanking "github.com/open-banking-io/clients/go"
+)
+
+func TestBookedBalance(t *testing.T) {
+	itbd := openbanking.Balance{Type: "ITBD", Amount: "100"}
+	itav := openbanking.Balance{Type: "ITAV", Amount: "90"}
+	othr := openbanking.Balance{Type: "OTHR", Amount: "5"}
+
+	cases := []struct {
+		name     string
+		balances []openbanking.Balance
+		want     string // expected Amount
+	}{
+		{"prefers ITBD", []openbanking.Balance{othr, itav, itbd}, "100"},
+		{"falls back to ITAV", []openbanking.Balance{othr, itav}, "90"},
+		{"falls back to first", []openbanking.Balance{othr}, "5"},
+		{"empty yields zero balance", nil, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := bookedBalance(c.balances).Amount; got != c.want {
+				t.Errorf("bookedBalance amount = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestAccountNumber(t *testing.T) {
+	if got := accountNumber(openbanking.Account{Iban: "DK123", Bban: "999"}); got != "DK123" {
+		t.Errorf("with IBAN = %q, want DK123", got)
+	}
+	if got := accountNumber(openbanking.Account{Bban: "999"}); got != "999" {
+		t.Errorf("without IBAN = %q, want BBAN 999", got)
+	}
+	if got := accountNumber(openbanking.Account{}); got != "-" {
+		t.Errorf("with neither = %q, want dash", got)
+	}
+}
+
+func TestAccountLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		acct openbanking.Account
+		want string
+	}{
+		{"display name wins", openbanking.Account{DisplayName: "Drift", AccountName: "x", ID: "id"}, "Drift"},
+		{"account name next", openbanking.Account{AccountName: "Acct", OwnerName: "x", ID: "id"}, "Acct"},
+		{"owner name next", openbanking.Account{OwnerName: "Tatic", Product: "x", ID: "id"}, "Tatic"},
+		{"product next", openbanking.Account{Product: "Current", ID: "id"}, "Current"},
+		{"id is last resort", openbanking.Account{ID: "acc-1"}, "acc-1"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := accountLabel(c.acct); got != c.want {
+				t.Errorf("accountLabel = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestDash(t *testing.T) {
+	if got := dash(""); got != "-" {
+		t.Errorf("dash(\"\") = %q, want -", got)
+	}
+	if got := dash("x"); got != "x" {
+		t.Errorf("dash(\"x\") = %q, want x", got)
+	}
+}
+
+func TestTransactionDate(t *testing.T) {
+	cases := []struct {
+		name string
+		tx   openbanking.Transaction
+		want string
+	}{
+		{"prefers booking date", openbanking.Transaction{BookingDate: "2026-01-01", ValueDate: "2026-01-02"}, "2026-01-01"},
+		{"falls back to value date", openbanking.Transaction{ValueDate: "2026-01-02", TransactionDate: "2026-01-03"}, "2026-01-02"},
+		{"falls back to transaction date", openbanking.Transaction{TransactionDate: "2026-01-03"}, "2026-01-03"},
+		{"empty when none", openbanking.Transaction{}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := transactionDate(c.tx); got != c.want {
+				t.Errorf("transactionDate = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestTransactionInfo(t *testing.T) {
+	if got := transactionInfo(openbanking.Transaction{RemittanceInformation: "Invoice 7", Note: "n"}); got != "Invoice 7" {
+		t.Errorf("with remittance = %q, want Invoice 7", got)
+	}
+	if got := transactionInfo(openbanking.Transaction{Note: "memo"}); got != "memo" {
+		t.Errorf("falls back to note = %q, want memo", got)
+	}
+	if got := transactionInfo(openbanking.Transaction{}); got != "" {
+		t.Errorf("empty = %q, want empty", got)
+	}
+}

--- a/cli/internal/app/key.go
+++ b/cli/internal/app/key.go
@@ -17,13 +17,13 @@ import (
 
 func (a *App) key(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: obank key import [<file>]")
+		return fmt.Errorf("usage: openbanking key import [<file>]")
 	}
 	switch args[0] {
 	case "import":
 		return a.keyImport(args[1:])
 	default:
-		return fmt.Errorf("unknown key subcommand %q (try `obank key import`)", args[0])
+		return fmt.Errorf("unknown key subcommand %q (try `openbanking key import`)", args[0])
 	}
 }
 
@@ -53,7 +53,7 @@ func (a *App) keyImport(args []string) error {
 		return fmt.Errorf("not a valid P-256 encryption key: %w", err)
 	}
 
-	// Preserve any API credential a prior `obank login` already wrote.
+	// Preserve any API credential a prior `openbanking login` already wrote.
 	bundle, err := config.Load(a.ConfigPath)
 	if err != nil {
 		bundle = config.Bundle{}
@@ -68,7 +68,7 @@ func (a *App) keyImport(args []string) error {
 
 	fmt.Fprintf(a.Stdout, "Encryption key imported to %s\n", a.ConfigPath)
 	if bundle.APIKey == "" {
-		fmt.Fprintln(a.Stdout, "Next: run `obank login` to add your API key.")
+		fmt.Fprintln(a.Stdout, "Next: run `openbanking login` to add your API key.")
 	}
 	return nil
 }

--- a/cli/internal/app/key_logic_test.go
+++ b/cli/internal/app/key_logic_test.go
@@ -1,0 +1,108 @@
+package app
+
+import (
+	"bytes"
+	"crypto/ecdh"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"path/filepath"
+	"testing"
+)
+
+func TestKeyRequiresSubcommand(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: filepath.Join(t.TempDir(), "c.json")}
+	if err := app.Run([]string{"key"}); err == nil {
+		t.Fatal("expected an error for `key` with no subcommand")
+	}
+}
+
+func TestKeyUnknownSubcommand(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: filepath.Join(t.TempDir(), "c.json")}
+	if err := app.Run([]string{"key", "frobnicate"}); err == nil {
+		t.Fatal("expected an error for an unknown key subcommand")
+	}
+}
+
+func TestParseEncryptionKeyEmptyInput(t *testing.T) {
+	if _, err := parseEncryptionKey([]byte("   \n")); err == nil {
+		t.Error("expected an error for empty key input")
+	}
+}
+
+func TestParseEncryptionKeyBundleWithoutPrivateKey(t *testing.T) {
+	if _, err := parseEncryptionKey([]byte(`{"encryptionKey":{}}`)); err == nil {
+		t.Error("expected an error for a bundle with no private key")
+	}
+}
+
+func TestParseEncryptionKeyMalformedBundle(t *testing.T) {
+	if _, err := parseEncryptionKey([]byte(`{ not json`)); err == nil {
+		t.Error("expected an error for a malformed bundle JSON")
+	}
+}
+
+func TestParseEncryptionKeyCollapsesWrappedBareKey(t *testing.T) {
+	// A bare key pasted with whitespace/newlines must be collapsed to a single base64 string.
+	enc, err := parseEncryptionKey([]byte("AAAA\n  BBBB \tCCCC\n"))
+	if err != nil {
+		t.Fatalf("parseEncryptionKey: %v", err)
+	}
+	if enc.PrivateKey != "AAAABBBBCCCC" {
+		t.Errorf("collapsed key = %q, want AAAABBBBCCCC", enc.PrivateKey)
+	}
+}
+
+func TestValidateP256Pkcs8(t *testing.T) {
+	// A real P-256 key passes.
+	p256, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p256DER, err := x509.MarshalPKCS8PrivateKey(p256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateP256Pkcs8(base64.StdEncoding.EncodeToString(p256DER)); err != nil {
+		t.Errorf("valid P-256 key rejected: %v", err)
+	}
+
+	// Invalid base64.
+	if err := validateP256Pkcs8("not!base64!!"); err == nil {
+		t.Error("expected error for invalid base64")
+	}
+
+	// Valid base64 but not a PKCS#8 structure.
+	if err := validateP256Pkcs8(base64.StdEncoding.EncodeToString([]byte("nope"))); err == nil {
+		t.Error("expected error for non-PKCS#8 DER")
+	}
+
+	// A non-EC key (Ed25519): parses, but has no ECDH.
+	_, edPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	edDER, err := x509.MarshalPKCS8PrivateKey(edPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateP256Pkcs8(base64.StdEncoding.EncodeToString(edDER)); err == nil {
+		t.Error("expected error for a non-EC key")
+	}
+
+	// A valid EC key on the wrong curve (P-384).
+	p384, err := ecdh.P384().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p384DER, err := x509.MarshalPKCS8PrivateKey(p384)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateP256Pkcs8(base64.StdEncoding.EncodeToString(p384DER)); err == nil {
+		t.Error("expected error for a P-384 key (wrong curve)")
+	}
+}

--- a/cli/internal/app/login.go
+++ b/cli/internal/app/login.go
@@ -108,7 +108,7 @@ func (a *App) login(args []string) error {
 
 	fmt.Fprintf(a.Stdout, "Logged in as %s. Credentials saved to %s\n", token.User, a.ConfigPath)
 	if bundle.EncryptionKey.PrivateKey == "" {
-		fmt.Fprintln(a.Stdout, "Next: run `obank key import` to add your encryption key so accounts can be decrypted.")
+		fmt.Fprintln(a.Stdout, "Next: run `openbanking key import` to add your encryption key so accounts can be decrypted.")
 	}
 	return nil
 }
@@ -156,7 +156,7 @@ func callbackHandler(codeCh chan<- string) http.Handler {
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = io.WriteString(w, `<!doctype html><meta charset=utf-8>
-<title>obank</title><body style="font-family:system-ui;padding:3rem">
+<title>open-banking.io CLI</title><body style="font-family:system-ui;padding:3rem">
 <h2>Login complete</h2><p>You can close this tab and return to your terminal.</p></body>`)
 		select {
 		case codeCh <- code:

--- a/cli/internal/app/login_logic_test.go
+++ b/cli/internal/app/login_logic_test.go
@@ -1,0 +1,81 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTrimTrailingSlash(t *testing.T) {
+	cases := map[string]string{
+		"https://x":     "https://x",
+		"https://x/":    "https://x",
+		"https://x///":  "https://x",
+		"":              "",
+		"/":             "",
+		"no-slash-here": "no-slash-here",
+	}
+	for in, want := range cases {
+		if got := trimTrailingSlash(in); got != want {
+			t.Errorf("trimTrailingSlash(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCallbackHandlerRejectsMissingCode(t *testing.T) {
+	codeCh := make(chan string, 1)
+	srv := httptest.NewServer(callbackHandler(codeCh))
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL + "/callback") // no ?code
+	if err != nil {
+		t.Fatalf("GET /callback: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for a missing code", resp.StatusCode)
+	}
+}
+
+func TestCallbackHandlerCapturesCode(t *testing.T) {
+	codeCh := make(chan string, 1)
+	srv := httptest.NewServer(callbackHandler(codeCh))
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL + "/callback?code=abc123")
+	if err != nil {
+		t.Fatalf("GET /callback: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := <-codeCh; got != "abc123" {
+		t.Errorf("captured code = %q, want abc123", got)
+	}
+}
+
+func TestExchangeTokenRejectsResponseWithoutAPIKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"user":"a@b.c"}`)) // no apiKey
+	}))
+	defer srv.Close()
+
+	app := &App{HTTPClient: srv.Client()}
+	if _, err := app.exchangeToken(context.Background(), srv.URL, "code", "verifier"); err == nil {
+		t.Fatal("expected an error when the token response has no apiKey")
+	}
+}
+
+func TestExchangeTokenTransportError(t *testing.T) {
+	app := &App{HTTPClient: http.DefaultClient}
+	// Closed server: the POST connection is refused.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	if _, err := app.exchangeToken(context.Background(), url, "code", "verifier"); err == nil {
+		t.Fatal("expected a transport error against a closed server")
+	}
+}

--- a/cli/internal/app/sync.go
+++ b/cli/internal/app/sync.go
@@ -32,7 +32,7 @@ func (a *App) sync(args []string) error {
 	}
 
 	if fs.NArg() == 0 {
-		return fmt.Errorf("usage: obank sync <account-id>   (or: obank sync --all)")
+		return fmt.Errorf("usage: openbanking sync <account-id>   (or: openbanking sync --all)")
 	}
 	result, err := client.Sync(fs.Arg(0))
 	if err != nil {

--- a/cli/internal/app/transactions.go
+++ b/cli/internal/app/transactions.go
@@ -12,7 +12,7 @@ import (
 
 func (a *App) transactions(args []string) error {
 	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
-		return fmt.Errorf("usage: obank transactions <account-id> [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--limit N] [--offset N]")
+		return fmt.Errorf("usage: openbanking transactions <account-id> [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--limit N] [--offset N]")
 	}
 	accountID := args[0]
 

--- a/cli/internal/app/version_test.go
+++ b/cli/internal/app/version_test.go
@@ -12,8 +12,8 @@ func TestVersionCommand(t *testing.T) {
 	if err := app.Run([]string{"version"}); err != nil {
 		t.Fatalf("version: %v", err)
 	}
-	if !strings.Contains(out.String(), "obank 1.2.3") {
-		t.Errorf("version output = %q, want to contain 'obank 1.2.3'", out.String())
+	if !strings.Contains(out.String(), "openbanking 1.2.3") {
+		t.Errorf("version output = %q, want to contain 'openbanking 1.2.3'", out.String())
 	}
 }
 
@@ -23,7 +23,7 @@ func TestVersionDefaultsToDev(t *testing.T) {
 	if err := app.Run([]string{"--version"}); err != nil {
 		t.Fatalf("--version: %v", err)
 	}
-	if !strings.Contains(out.String(), "obank dev") {
-		t.Errorf("version output = %q, want 'obank dev'", out.String())
+	if !strings.Contains(out.String(), "openbanking dev") {
+		t.Errorf("version output = %q, want 'openbanking dev'", out.String())
 	}
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -37,7 +37,7 @@ func Load(path string) (Bundle, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return Bundle{}, fmt.Errorf("no credentials at %s — run `obank login` first: %w", path, err)
+			return Bundle{}, fmt.Errorf("no credentials at %s — run `openbanking login` first: %w", path, err)
 		}
 		return Bundle{}, fmt.Errorf("could not read credentials at %s: %w", path, err)
 	}

--- a/cli/internal/config/config_more_test.go
+++ b/cli/internal/config/config_more_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	openbanking "github.com/open-banking-io/clients/go"
+)
+
+func TestDefaultPathFallsBackToHomeConfig(t *testing.T) {
+	t.Setenv("OPENBANKING_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	suffix := filepath.Join(".config", "open-banking", "credentials.json")
+	if !strings.HasSuffix(got, suffix) {
+		t.Errorf("DefaultPath = %q, want it to end with %q", got, suffix)
+	}
+}
+
+func TestLoadRejectsMalformedJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	if err := os.WriteFile(path, []byte("{ not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected an error parsing malformed credentials JSON")
+	}
+}
+
+func TestSaveFailsWhenParentIsAFile(t *testing.T) {
+	// Create a regular file, then try to save "underneath" it: MkdirAll cannot create a directory
+	// where a file already exists, so Save must surface that error.
+	file := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(file, "sub", "credentials.json")
+	if err := Save(target, openbanking.CredentialsBundle{APIKey: "k"}); err == nil {
+		t.Fatal("expected an error when the parent path is a file")
+	}
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,4 +1,4 @@
-// Command obank is the open-banking.io command line: authenticate once, then read and sync your
+// Command openbanking is the open-banking.io command line: authenticate once, then read and sync your
 // accounts and transactions locally, decrypting the zero-knowledge data with your own key.
 package main
 
@@ -16,7 +16,7 @@ var version = "dev"
 func main() {
 	path, err := config.DefaultPath()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "obank:", err)
+		fmt.Fprintln(os.Stderr, "openbanking:", err)
 		os.Exit(1)
 	}
 	a := &app.App{
@@ -27,7 +27,7 @@ func main() {
 		Version:    version,
 	}
 	if err := a.Run(os.Args[1:]); err != nil {
-		fmt.Fprintln(os.Stderr, "obank:", err)
+		fmt.Fprintln(os.Stderr, "openbanking:", err)
 		os.Exit(1)
 	}
 }

--- a/go/client_errors_test.go
+++ b/go/client_errors_test.go
@@ -1,0 +1,330 @@
+package openbanking
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeAPI is a configurable mock whose account/transaction responses each test can override to
+// exercise error and edge-case branches (bad ciphertext, missing sessions, empty pages, ...).
+type fakeAPI struct {
+	server       *httptest.Server
+	apiKey       string
+	privateKey   string
+	accounts     string // body for GET /api/accounts
+	transactions string // body for GET /api/accounts/{id}/transactions
+	postStatus   int    // when non-zero, POST routes reply with this status (to fail postJSON)
+	lastQuery    string
+	lastBody     map[string]any
+}
+
+func newFakeAPI(t *testing.T) *fakeAPI {
+	t.Helper()
+	f := &fakeAPI{
+		apiKey:       readJSON(t, "credentials.json")["apiKey"].(string),
+		privateKey:   testPrivateKey(t),
+		accounts:     string(readFixture(t, "api/accounts.json")),
+		transactions: string(readFixture(t, "api/transactions.json")),
+	}
+	capture := func(r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		f.lastBody = nil
+		_ = json.Unmarshal(raw, &f.lastBody)
+	}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.lastQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		if r.Header.Get("X-Api-Key") != f.apiKey {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/accounts":
+			_, _ = io.WriteString(w, f.accounts)
+		case r.Method == http.MethodGet && transactionsPath.MatchString(r.URL.Path):
+			_, _ = io.WriteString(w, f.transactions)
+		case r.Method == http.MethodPost && accountSyncPath.MatchString(r.URL.Path):
+			capture(r)
+			if f.postStatus != 0 {
+				w.WriteHeader(f.postStatus)
+				return
+			}
+			_, _ = io.WriteString(w, `{"newTransactions":0,"totalFetched":0}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/sync":
+			capture(r)
+			if f.postStatus != 0 {
+				w.WriteHeader(f.postStatus)
+				return
+			}
+			_, _ = io.WriteString(w, `{"accounts":0,"newTransactions":0}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *fakeAPI) client(t *testing.T) *Client {
+	t.Helper()
+	c, err := New(f.server.URL, f.apiKey, f.privateKey, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+// An account whose ciphertext fields are all empty: decrypts to zero values, never an error.
+const acctNoCiphertext = `[{"id":"acc-1","aspspName":"Lunar","aspspCountry":"DK","currency":"DKK",` +
+	`"accountType":"CACC","bic":"LUNADK22","needsReconnect":true,"balances":null,` +
+	`"enc":"","displayNameEnc":"","uidEnc":""}]`
+
+// ---- HTTP transport / status / decode failures (do, getJSON) ----
+
+func serve(t *testing.T, status int, body string) string {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(s.Close)
+	return s.URL
+}
+
+func clientAt(t *testing.T, url string) *Client {
+	t.Helper()
+	c, err := New(url, readJSON(t, "credentials.json")["apiKey"].(string), testPrivateKey(t), nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestNon2xxStatusErrors(t *testing.T) {
+	c := clientAt(t, serve(t, http.StatusInternalServerError, `{"error":"boom"}`))
+	if _, err := c.GetConnections(); err == nil {
+		t.Error("expected error for 500 response")
+	}
+}
+
+func TestUnparseableBodyErrors(t *testing.T) {
+	c := clientAt(t, serve(t, http.StatusOK, "this is not json"))
+	if _, err := c.GetConnections(); err == nil {
+		t.Error("expected error for unparseable body")
+	}
+}
+
+func TestTransportFailureErrors(t *testing.T) {
+	// Start a server only to obtain a guaranteed-dead URL, then close it: the connection is refused.
+	s := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := s.URL
+	s.Close()
+	c := clientAt(t, url)
+	if _, err := c.GetConnections(); err == nil {
+		t.Error("expected transport error against a closed server")
+	}
+}
+
+// ---- GetTransactions query building and edge cases ----
+
+func TestGetTransactionsEncodesAllQueryParams(t *testing.T) {
+	f := newFakeAPI(t)
+	f.transactions = `{"items":[],"total":0}`
+	limit, offset := 50, 10
+	_, err := f.client(t).GetTransactions("acc-1", TransactionQuery{
+		From: "2026-01-01", To: "2026-02-01", Limit: &limit, Offset: &offset,
+	})
+	if err != nil {
+		t.Fatalf("GetTransactions: %v", err)
+	}
+	for _, want := range []string{"from=2026-01-01", "to=2026-02-01", "limit=50", "offset=10"} {
+		if !strings.Contains(f.lastQuery, want) {
+			t.Errorf("query %q missing %q", f.lastQuery, want)
+		}
+	}
+}
+
+func TestGetTransactionsEmptyPage(t *testing.T) {
+	f := newFakeAPI(t)
+	f.transactions = `{"total":0}` // no items field
+	page, err := f.client(t).GetTransactions("acc-1", TransactionQuery{})
+	if err != nil {
+		t.Fatalf("GetTransactions: %v", err)
+	}
+	if len(page.Items) != 0 || page.Total != 0 {
+		t.Errorf("page = %+v, want empty", page)
+	}
+}
+
+func TestGetTransactionsDecryptErrorSurfaces(t *testing.T) {
+	f := newFakeAPI(t)
+	f.transactions = `{"items":[{"id":"tx-1","enc":"not!base64"}],"total":1}`
+	if _, err := f.client(t).GetTransactions("acc-1", TransactionQuery{}); err == nil {
+		t.Error("expected error from undecryptable transaction ciphertext")
+	}
+}
+
+// ---- GetAccounts decrypt edge cases (mapAccount) ----
+
+func TestGetAccountsWithEmptyCiphertextDecryptsToZeroValues(t *testing.T) {
+	f := newFakeAPI(t)
+	f.accounts = acctNoCiphertext
+	accounts, err := f.client(t).GetAccounts()
+	if err != nil {
+		t.Fatalf("GetAccounts: %v", err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("len = %d, want 1", len(accounts))
+	}
+	a := accounts[0]
+	if a.Iban != "" || a.OwnerName != "" || a.DisplayName != "" {
+		t.Errorf("expected empty decrypted fields, got %+v", a)
+	}
+	if len(a.Balances) != 0 {
+		t.Errorf("len(balances) = %d, want 0", len(a.Balances))
+	}
+}
+
+func TestGetAccountsDecryptErrorSurfaces(t *testing.T) {
+	f := newFakeAPI(t)
+	f.accounts = `[{"id":"acc-1","balances":null,"enc":"not!base64","displayNameEnc":"","uidEnc":""}]`
+	if _, err := f.client(t).GetAccounts(); err == nil {
+		t.Error("expected error from undecryptable account ciphertext")
+	}
+}
+
+func TestGetAccountsDisplayNameDecryptErrorSurfaces(t *testing.T) {
+	f := newFakeAPI(t)
+	// enc is empty (decrypts to nothing), but the display-name ciphertext is undecryptable.
+	f.accounts = `[{"id":"acc-1","balances":null,"enc":"","displayNameEnc":"not!base64","uidEnc":""}]`
+	if _, err := f.client(t).GetAccounts(); err == nil {
+		t.Error("expected error from undecryptable display-name ciphertext")
+	}
+}
+
+func TestGetAccountsBalanceDecryptErrorSurfaces(t *testing.T) {
+	f := newFakeAPI(t)
+	f.accounts = `[{"id":"acc-1","enc":"","displayNameEnc":"","uidEnc":"",` +
+		`"balances":[{"type":"ITBD","currency":"DKK","enc":"not!base64"}]}]`
+	if _, err := f.client(t).GetAccounts(); err == nil {
+		t.Error("expected error from undecryptable balance ciphertext")
+	}
+}
+
+// ---- Sync / SyncAll edge cases ----
+
+func TestSyncUnknownAccountErrors(t *testing.T) {
+	f := newFakeAPI(t)
+	f.accounts = `[]`
+	if _, err := f.client(t).Sync("missing"); err == nil {
+		t.Error("expected error for unknown account")
+	}
+}
+
+func TestSyncAccountWithoutSessionErrors(t *testing.T) {
+	f := newFakeAPI(t)
+	f.accounts = acctNoCiphertext // empty uidEnc => no active session
+	_, err := f.client(t).Sync("acc-1")
+	if err == nil || !strings.Contains(err.Error(), "no active session") {
+		t.Errorf("err = %v, want 'no active session'", err)
+	}
+}
+
+func TestSyncDecryptUidErrorSurfaces(t *testing.T) {
+	f := newFakeAPI(t)
+	f.accounts = `[{"id":"acc-1","balances":null,"enc":"","displayNameEnc":"","uidEnc":"not!base64"}]`
+	if _, err := f.client(t).Sync("acc-1"); err == nil {
+		t.Error("expected error from undecryptable uid ciphertext")
+	}
+}
+
+func TestSyncListAccountsErrorSurfaces(t *testing.T) {
+	c := clientAt(t, serve(t, http.StatusInternalServerError, `{}`))
+	if _, err := c.Sync("acc-1"); err == nil {
+		t.Error("expected error when listing accounts fails")
+	}
+	if _, err := c.SyncAll(); err == nil {
+		t.Error("expected error when listing accounts fails")
+	}
+}
+
+func TestSyncAllSkipsAccountsWithoutSession(t *testing.T) {
+	f := newFakeAPI(t)
+	f.accounts = acctNoCiphertext // no active session => skipped
+	if _, err := f.client(t).SyncAll(); err != nil {
+		t.Fatalf("SyncAll: %v", err)
+	}
+	items, ok := f.lastBody["items"].([]any)
+	if !ok || len(items) != 0 {
+		t.Errorf("posted items = %v, want empty list", f.lastBody["items"])
+	}
+}
+
+// ---- ListBanks / StartAuthorization branch coverage ----
+
+func TestListBanksWithoutCountry(t *testing.T) {
+	m := startMock(t)
+	banks, err := m.client(t).ListBanks("") // no country => path without query string
+	if err != nil {
+		t.Fatalf("ListBanks: %v", err)
+	}
+	if len(banks) != 1 {
+		t.Fatalf("len(banks) = %d, want 1", len(banks))
+	}
+}
+
+func TestListBanksHTTPErrorSurfaces(t *testing.T) {
+	c := clientAt(t, serve(t, http.StatusInternalServerError, `{}`))
+	if _, err := c.ListBanks("DK"); err == nil {
+		t.Error("expected error from ListBanks on 500")
+	}
+}
+
+func TestGetTransactionsHTTPErrorSurfaces(t *testing.T) {
+	c := clientAt(t, serve(t, http.StatusInternalServerError, `{}`))
+	if _, err := c.GetTransactions("acc-1", TransactionQuery{}); err == nil {
+		t.Error("expected error from GetTransactions on 500")
+	}
+}
+
+func TestStartAuthorizationHTTPErrorSurfaces(t *testing.T) {
+	c := clientAt(t, serve(t, http.StatusInternalServerError, `{}`))
+	if _, err := c.StartAuthorization(AuthorizationRequest{Country: "DK", AspspName: "Lunar"}); err == nil {
+		t.Error("expected error from StartAuthorization on 500")
+	}
+}
+
+func TestSyncPostErrorSurfaces(t *testing.T) {
+	f := newFakeAPI(t)
+	f.postStatus = http.StatusInternalServerError // account is found and has a session; the POST fails
+	if _, err := f.client(t).Sync("11111111-1111-4111-8111-111111111111"); err == nil {
+		t.Error("expected error when the sync POST fails")
+	}
+}
+
+func TestSyncAllPostErrorSurfaces(t *testing.T) {
+	f := newFakeAPI(t)
+	f.postStatus = http.StatusInternalServerError
+	if _, err := f.client(t).SyncAll(); err == nil {
+		t.Error("expected error when the sync-all POST fails")
+	}
+}
+
+func TestStartAuthorizationWithoutPsuType(t *testing.T) {
+	m := startMock(t)
+	url, err := m.client(t).StartAuthorization(AuthorizationRequest{Country: "DK", AspspName: "Lunar"})
+	if err != nil {
+		t.Fatalf("StartAuthorization: %v", err)
+	}
+	if url == "" {
+		t.Error("expected a consent url")
+	}
+	if _, present := m.lastSyncBody["psuType"]; present {
+		t.Error("psuType should be omitted when empty")
+	}
+}

--- a/go/factory_test.go
+++ b/go/factory_test.go
@@ -1,0 +1,121 @@
+package openbanking
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// bundleJSON builds a minimal credentials-bundle JSON document pointing at baseURL.
+func bundleJSON(baseURL, apiKey, privateKey string) string {
+	return `{"apiBaseUrl":"` + baseURL + `","apiKey":"` + apiKey +
+		`","encryptionKey":{"privateKey":"` + privateKey + `"}}`
+}
+
+func TestNewValidation(t *testing.T) {
+	cases := []struct {
+		name, base, key, priv string
+	}{
+		{"blank base url", "  ", "k", "p"},
+		{"blank api key", "https://x", "", "p"},
+		{"blank private key", "https://x", "k", "  "},
+		{"invalid private key", "https://x", "k", "not!base64!!"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := New(c.base, c.key, c.priv, nil); err == nil {
+				t.Errorf("expected error for %s", c.name)
+			}
+		})
+	}
+}
+
+func TestNewWithInjectedHTTPClient(t *testing.T) {
+	m := startMock(t)
+	// A non-nil client must be used as-is (rather than the 30s-timeout default).
+	hc := &http.Client{}
+	c, err := New(m.server.URL, m.apiKey, m.privateKey, hc)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if c.httpClient != hc {
+		t.Error("injected http client was not used")
+	}
+	if _, err := c.GetAccounts(); err != nil {
+		t.Errorf("GetAccounts: %v", err)
+	}
+}
+
+func TestNewPublicValidation(t *testing.T) {
+	if _, err := NewPublic("", "k", nil); err == nil {
+		t.Error("expected error for blank base url")
+	}
+	if _, err := NewPublic("https://x", "  ", nil); err == nil {
+		t.Error("expected error for blank api key")
+	}
+}
+
+func TestFromBundleValidation(t *testing.T) {
+	if _, err := FromBundle(CredentialsBundle{}, nil); err == nil {
+		t.Error("expected error for bundle without apiKey")
+	}
+	noKey := CredentialsBundle{APIBaseURL: "https://x", APIKey: "k"}
+	if _, err := FromBundle(noKey, nil); err == nil {
+		t.Error("expected error for bundle without encryption private key")
+	}
+}
+
+func TestFromBundleBuildsUsableClient(t *testing.T) {
+	m := startMock(t)
+	bundle := CredentialsBundle{
+		APIBaseURL: m.server.URL,
+		APIKey:     m.apiKey,
+	}
+	bundle.EncryptionKey.PrivateKey = m.privateKey
+	c, err := FromBundle(bundle, nil)
+	if err != nil {
+		t.Fatalf("FromBundle: %v", err)
+	}
+	if _, err := c.GetAccounts(); err != nil {
+		t.Errorf("GetAccounts: %v", err)
+	}
+}
+
+func TestFromCredentialsAcceptsJSONString(t *testing.T) {
+	m := startMock(t)
+	c, err := FromCredentials(bundleJSON(m.server.URL, m.apiKey, m.privateKey), nil)
+	if err != nil {
+		t.Fatalf("FromCredentials: %v", err)
+	}
+	if _, err := c.GetAccounts(); err != nil {
+		t.Errorf("GetAccounts: %v", err)
+	}
+}
+
+func TestFromCredentialsReadsFromFile(t *testing.T) {
+	m := startMock(t)
+	path := filepath.Join(t.TempDir(), "bundle.json")
+	if err := os.WriteFile(path, []byte(bundleJSON(m.server.URL, m.apiKey, m.privateKey)), 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	c, err := FromCredentials(path, nil)
+	if err != nil {
+		t.Fatalf("FromCredentials: %v", err)
+	}
+	if _, err := c.GetAccounts(); err != nil {
+		t.Errorf("GetAccounts: %v", err)
+	}
+}
+
+func TestFromCredentialsMissingFile(t *testing.T) {
+	if _, err := FromCredentials(filepath.Join(t.TempDir(), "nope.json"), nil); err == nil {
+		t.Error("expected error for missing credentials file")
+	}
+}
+
+func TestFromCredentialsMalformedJSON(t *testing.T) {
+	if _, err := FromCredentials("{ not valid json", nil); err == nil {
+		t.Error("expected error for malformed bundle JSON")
+	}
+}


### PR DESCRIPTION
Renames the CLI for clarity:
- **Terminal command / binary**: `obank` → **`openbanking`**
- **Product / display name**: **open-banking.io CLI** (README title, browser title, GitHub Release title)
- Homebrew: `brew install open-banking-io/tap/openbanking`; formula is now `openbanking.rb` (class `Openbanking`), and the tap step clears old `.rb` files so the stale `obank.rb` is removed.

Build/vet/test green. **Merging this is a `cli/**` change, so it auto-releases `openbanking 0.2.1`** (the live proof of the new auto-release pipeline).
🤖 Generated with [Claude Code](https://claude.com/claude-code)