### PR TITLE
CLI: one-step login via browser-relay (zero-knowledge)

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -38,6 +38,17 @@ These SDKs implement the client: they hold the private key and decrypt envelopes
 from the bank **without ever holding the uid in plaintext**. Sessions are time-limited (see
 `Connection.validUntil` / `needsReconnect`).
 
+## CLI onboarding (browser-relay)
+
+`openbanking login` sets the CLI up in one step without the private key ever reaching the server. The CLI
+starts a localhost loopback and opens the browser to the app's authorize page; you sign in and enter your
+passphrase **in the browser**, which unlocks the locally-held private key and POSTs the full credentials
+**directly to `http://127.0.0.1:<port>`** — browser → localhost only. The server never sees the private key
+(not even encrypted) or the passphrase. The relay is bound by three things: the random loopback port, the
+PKCE `verifier` (held only by the CLI, required to redeem the one-time code for the API key), and a `state`
+nonce echoed by the authenticated browser. CORS on the loopback is scoped to the app origin. The CLI writes
+`credentials.json` at `0600` and never logs the key or passphrase.
+
 ## Assumptions & limitations
 
 - The private key staying private is load-bearing — if it leaks, future envelopes encrypted to its public

--- a/cli/README.md
+++ b/cli/README.md
@@ -28,8 +28,8 @@ go install github.com/open-banking-io/clients/cli@latest
 ## Usage
 
 ```sh
-openbanking login                       # sign in via the browser, saves an API key
-openbanking key import ./credentials.json   # import your encryption key (exported from the app)
+openbanking login                       # sign in + unlock in the browser — sets up everything
+openbanking key import ./credentials.json   # (fallback) import a key file on a headless machine
 openbanking accounts                    # list accounts with balances
 openbanking transactions <account-id>   # an account's statement (--from --to --limit)
 openbanking sync --all                  # pull fresh transactions
@@ -43,7 +43,10 @@ Credentials live in `$OPENBANKING_CONFIG` or
 
 ## How it works
 
-`login` runs a localhost loopback + PKCE flow against the API to mint an API key
-without a browser cookie. `key import` adds your P-256 encryption key (exported
-from the web app) so accounts and transactions can be decrypted locally. Money
-amounts are kept as exact decimal strings; debits render negative at display time.
+`login` runs a localhost loopback + PKCE flow against the API. In the browser you
+sign in and enter your passphrase; the web app unlocks your P-256 encryption key
+and hands the full credentials straight to the CLI's loopback. **The private key
+travels browser → localhost only — it never touches the server, not even encrypted**
+(the server is zero-knowledge and only ever holds your public key). `key import`
+remains as a manual fallback for headless machines without a browser. Money amounts
+are kept as exact decimal strings; debits render negative at display time.

--- a/cli/internal/app/login.go
+++ b/cli/internal/app/login.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -25,6 +26,25 @@ type cliTokenResponse struct {
 	APIBaseURL string `json:"apiBaseUrl"`
 	User       string `json:"user"`
 	Prefix     string `json:"prefix"`
+}
+
+// relayPayload is what the browser POSTs to the loopback after the user unlocks their key in the UI.
+// The encryption private key travels browser -> localhost only; it never touches the server.
+type relayPayload struct {
+	Code          string `json:"code"`
+	State         string `json:"state"`
+	EncryptionKey *struct {
+		PrivateKey string `json:"privateKey"`
+		PublicKey  string `json:"publicKey"`
+	} `json:"encryptionKey"`
+}
+
+// callbackResult is delivered from the loopback to login(): the one-time code, and (when the browser
+// relayed it) the unlocked encryption key material.
+type callbackResult struct {
+	code       string
+	privKeyB64 string // empty if the browser didn't relay a key (key-less fallback)
+	pubKeyB64  string
 }
 
 // openBrowser is a package var so tests can stub it. It best-effort opens a URL in the user's browser.
@@ -53,8 +73,10 @@ func (a *App) login(args []string) error {
 	// (the challenge) goes to the server, and only the verifier can later redeem the code.
 	verifier := pkceVerifier()
 	challenge := pkceChallenge(verifier)
+	// state binds the browser's relay POST to this exact CLI session.
+	state := pkceVerifier()
 
-	// A loopback listener the server will redirect the browser back to with the one-time code.
+	// A loopback listener the browser (or the server redirect) reaches with the code + relayed key.
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return fmt.Errorf("could not start local login listener: %w", err)
@@ -62,13 +84,13 @@ func (a *App) login(args []string) error {
 	defer listener.Close()
 	port := listener.Addr().(*net.TCPAddr).Port
 
-	codeCh := make(chan string, 1)
-	server := &http.Server{Handler: callbackHandler(codeCh)}
+	resultCh := make(chan callbackResult, 1)
+	server := &http.Server{Handler: callbackHandler(resultCh, state, base)}
 	go server.Serve(listener)
 	defer server.Close()
 
-	startURL := fmt.Sprintf("%s/auth/cli/start?port=%d&code_challenge=%s",
-		base, port, url.QueryEscape(challenge))
+	startURL := fmt.Sprintf("%s/auth/cli/start?port=%d&code_challenge=%s&state=%s",
+		base, port, url.QueryEscape(challenge), url.QueryEscape(state))
 	fmt.Fprintf(a.Stderr, "Opening your browser to sign in...\nIf it doesn't open, visit:\n  %s\n\n", startURL)
 	if err := openBrowser(startURL); err != nil {
 		fmt.Fprintf(a.Stderr, "(could not open a browser automatically: %v)\n", err)
@@ -77,19 +99,19 @@ func (a *App) login(args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
 	defer cancel()
 
-	var code string
+	var result callbackResult
 	select {
-	case code = <-codeCh:
+	case result = <-resultCh:
 	case <-ctx.Done():
 		return fmt.Errorf("timed out waiting for the browser login after %s", *timeout)
 	}
 
-	token, err := a.exchangeToken(ctx, base, code, verifier)
+	token, err := a.exchangeToken(ctx, base, result.code, verifier)
 	if err != nil {
 		return err
 	}
 
-	// Preserve any encryption key already imported; login only owns the API credential.
+	// Preserve any encryption key already imported; we overwrite it only if the browser relayed one.
 	bundle, err := config.Load(a.ConfigPath)
 	if err != nil {
 		bundle = config.Bundle{} // first login: start fresh
@@ -102,12 +124,23 @@ func (a *App) login(args []string) error {
 	}
 	bundle.User = token.User
 	bundle.APIKey = token.APIKey
+
+	if result.privKeyB64 != "" {
+		if err := validateP256Pkcs8(result.privKeyB64); err != nil {
+			return fmt.Errorf("the browser relayed an invalid encryption key: %w", err)
+		}
+		bundle.EncryptionKey = encryptionKeyFor(result.privKeyB64)
+		bundle.EncryptionKey.PublicKey = result.pubKeyB64
+	}
+
 	if err := config.Save(a.ConfigPath, bundle); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(a.Stdout, "Logged in as %s. Credentials saved to %s\n", token.User, a.ConfigPath)
-	if bundle.EncryptionKey.PrivateKey == "" {
+	if bundle.EncryptionKey.PrivateKey != "" {
+		fmt.Fprintf(a.Stdout, "Logged in as %s — encryption key set up. You're ready to go.\nCredentials saved to %s\n", token.User, a.ConfigPath)
+	} else {
+		fmt.Fprintf(a.Stdout, "Logged in as %s. Credentials saved to %s\n", token.User, a.ConfigPath)
 		fmt.Fprintln(a.Stdout, "Next: run `openbanking key import` to add your encryption key so accounts can be decrypted.")
 	}
 	return nil
@@ -145,25 +178,63 @@ func (a *App) exchangeToken(ctx context.Context, apiBaseURL, code, verifier stri
 	return token, nil
 }
 
-// callbackHandler serves the loopback /callback the server redirects to, capturing the one-time code.
-func callbackHandler(codeCh chan<- string) http.Handler {
+// callbackHandler serves the loopback /callback. The browser authorize page POSTs {code,state,
+// encryptionKey} after unlocking the key (CORS-scoped to the app origin); the legacy GET ?code= path
+// remains as a key-less fallback.
+func callbackHandler(resultCh chan<- callbackResult, state, allowOrigin string) http.Handler {
+	deliver := func(res callbackResult) {
+		select {
+		case resultCh <- res:
+		default:
+		}
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-		code := r.URL.Query().Get("code")
-		if code == "" {
-			http.Error(w, "missing code", http.StatusBadRequest)
-			return
-		}
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = io.WriteString(w, `<!doctype html><meta charset=utf-8>
-<title>open-banking.io CLI</title><body style="font-family:system-ui;padding:3rem">
-<h2>Login complete</h2><p>You can close this tab and return to your terminal.</p></body>`)
-		select {
-		case codeCh <- code:
+		w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+		w.Header().Set("Vary", "Origin")
+		switch r.Method {
+		case http.MethodOptions:
+			w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "content-type")
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodGet:
+			code := r.URL.Query().Get("code")
+			if code == "" {
+				http.Error(w, "missing code", http.StatusBadRequest)
+				return
+			}
+			writeDoneHTML(w)
+			deliver(callbackResult{code: code})
+		case http.MethodPost:
+			var p relayPayload
+			if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&p); err != nil || p.Code == "" {
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			if subtle.ConstantTimeCompare([]byte(p.State), []byte(state)) != 1 {
+				http.Error(w, "state mismatch", http.StatusForbidden)
+				return
+			}
+			res := callbackResult{code: p.Code}
+			if p.EncryptionKey != nil {
+				res.privKeyB64 = p.EncryptionKey.PrivateKey
+				res.pubKeyB64 = p.EncryptionKey.PublicKey
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"ok":true}`)
+			deliver(res)
 		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
 	})
 	return mux
+}
+
+func writeDoneHTML(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = io.WriteString(w, `<!doctype html><meta charset=utf-8>
+<title>open-banking.io CLI</title><body style="font-family:system-ui;padding:3rem">
+<h2>Login complete</h2><p>You can close this tab and return to your terminal.</p></body>`)
 }
 
 func trimTrailingSlash(s string) string {

--- a/cli/internal/app/login_logic_test.go
+++ b/cli/internal/app/login_logic_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -24,8 +25,8 @@ func TestTrimTrailingSlash(t *testing.T) {
 }
 
 func TestCallbackHandlerRejectsMissingCode(t *testing.T) {
-	codeCh := make(chan string, 1)
-	srv := httptest.NewServer(callbackHandler(codeCh))
+	ch := make(chan callbackResult, 1)
+	srv := httptest.NewServer(callbackHandler(ch, "st", "https://app.example"))
 	defer srv.Close()
 
 	resp, err := srv.Client().Get(srv.URL + "/callback") // no ?code
@@ -39,8 +40,8 @@ func TestCallbackHandlerRejectsMissingCode(t *testing.T) {
 }
 
 func TestCallbackHandlerCapturesCode(t *testing.T) {
-	codeCh := make(chan string, 1)
-	srv := httptest.NewServer(callbackHandler(codeCh))
+	ch := make(chan callbackResult, 1)
+	srv := httptest.NewServer(callbackHandler(ch, "st", "https://app.example"))
 	defer srv.Close()
 
 	resp, err := srv.Client().Get(srv.URL + "/callback?code=abc123")
@@ -51,8 +52,66 @@ func TestCallbackHandlerCapturesCode(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("status = %d, want 200", resp.StatusCode)
 	}
-	if got := <-codeCh; got != "abc123" {
-		t.Errorf("captured code = %q, want abc123", got)
+	if got := <-ch; got.code != "abc123" || got.privKeyB64 != "" {
+		t.Errorf("captured = %+v, want code abc123 and no key", got)
+	}
+}
+
+func TestCallbackHandlerRelaysEncryptionKey(t *testing.T) {
+	ch := make(chan callbackResult, 1)
+	srv := httptest.NewServer(callbackHandler(ch, "secret-state", "https://app.example"))
+	defer srv.Close()
+
+	body := `{"code":"c1","state":"secret-state","encryptionKey":{"privateKey":"PK","publicKey":"PUB"}}`
+	resp, err := srv.Client().Post(srv.URL+"/callback", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /callback: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://app.example" {
+		t.Errorf("CORS origin = %q, want the app origin", got)
+	}
+	res := <-ch
+	if res.code != "c1" || res.privKeyB64 != "PK" || res.pubKeyB64 != "PUB" {
+		t.Errorf("relayed result = %+v, want code c1 + key PK/PUB", res)
+	}
+}
+
+func TestCallbackHandlerRejectsWrongState(t *testing.T) {
+	ch := make(chan callbackResult, 1)
+	srv := httptest.NewServer(callbackHandler(ch, "right-state", "https://app.example"))
+	defer srv.Close()
+
+	body := `{"code":"c1","state":"WRONG","encryptionKey":{"privateKey":"PK"}}`
+	resp, err := srv.Client().Post(srv.URL+"/callback", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /callback: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for a state mismatch", resp.StatusCode)
+	}
+}
+
+func TestCallbackHandlerCORSPreflight(t *testing.T) {
+	ch := make(chan callbackResult, 1)
+	srv := httptest.NewServer(callbackHandler(ch, "st", "https://app.example"))
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodOptions, srv.URL+"/callback", nil)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("OPTIONS /callback: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("preflight status = %d, want 204", resp.StatusCode)
+	}
+	if resp.Header.Get("Access-Control-Allow-Methods") == "" {
+		t.Error("preflight is missing Access-Control-Allow-Methods")
 	}
 }
 

--- a/cli/internal/app/login_test.go
+++ b/cli/internal/app/login_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/open-banking-io/clients/cli/internal/config"
@@ -127,5 +129,67 @@ func TestLoginPreservesEncryptionKey(t *testing.T) {
 	}
 	if got.APIBaseURL != srv.URL {
 		t.Errorf("apiBaseUrl = %q, want %q (empty server value falls back to --api)", got.APIBaseURL, srv.URL)
+	}
+}
+
+// TestLoginRelaysEncryptionKeyFromBrowser drives the one-step flow: the stubbed browser plays the
+// authorize page — it reads the loopback port + state from the start URL and POSTs the unlocked key
+// to the loopback. login() must end up with BOTH the API key and the relayed encryption key, with no
+// manual `key import`.
+func TestLoginRelaysEncryptionKeyFromBrowser(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "credentials.json")
+	fb := fixtureBundle(t)
+	validKey, validPub := fb.EncryptionKey.PrivateKey, fb.EncryptionKey.PublicKey
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth/cli/token" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"apiKey":"ebk_minted","user":"me@example.com","prefix":"ebk_minted12"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	prev := openBrowser
+	openBrowser = func(target string) error {
+		u, err := url.Parse(target)
+		if err != nil {
+			return err
+		}
+		port, state := u.Query().Get("port"), u.Query().Get("state")
+		body, _ := json.Marshal(map[string]any{
+			"code":          "relay-code",
+			"state":         state,
+			"encryptionKey": map[string]string{"privateKey": validKey, "publicKey": validPub},
+		})
+		go func() {
+			_, _ = http.Post("http://127.0.0.1:"+port+"/callback", "application/json", bytes.NewReader(body))
+		}()
+		return nil
+	}
+	defer func() { openBrowser = prev }()
+
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfgPath, HTTPClient: srv.Client()}
+	if err := app.login([]string{"--api", srv.URL, "--timeout", "10s"}); err != nil {
+		t.Fatalf("login: %v\nstderr: %s", err, errOut.String())
+	}
+
+	got, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if got.APIKey != "ebk_minted" {
+		t.Errorf("apiKey = %q, want ebk_minted", got.APIKey)
+	}
+	if got.EncryptionKey.PrivateKey != validKey {
+		t.Error("the relayed encryption private key was not saved")
+	}
+	if got.EncryptionKey.PublicKey != validPub {
+		t.Error("the relayed public key was not saved")
+	}
+	if !strings.Contains(out.String(), "encryption key set up") {
+		t.Errorf("expected the one-step success message, got: %q", out.String())
 	}
 }


### PR DESCRIPTION
Phase 1 of the one-step onboarding (CLI side; defines the wire contract).

`openbanking login` becomes one step: after the PKCE browser login, the web authorize page POSTs the passphrase-unlocked encryption key **directly to the CLI's localhost loopback** — browser → `127.0.0.1` only. The server never sees the private key (not even encrypted) or the passphrase.

- Loopback now serves the relay **POST** `{code,state,encryptionKey}` (CORS scoped to the app origin, OPTIONS preflight, bound by a `state` nonce + PKCE `verifier`), validates the P-256 key, and saves the full bundle.
- The legacy GET `?code=` path and `key import` stay as a **headless fallback**.
- Backward-compatible: until the backend redirects to the authorize page (Phase 2-3), the current GET flow still works (key-less → `key import`).

Tests cover the relay POST, wrong-`state` rejection, CORS preflight, and the full `login` flow saving both API key + relayed key. THREAT_MODEL.md documents the relay.
🤖 Generated with [Claude Code](https://claude.com/claude-code)