### PR TITLE
cli: accept the browser relay as a form POST (fix CORS)

### DIFF
--- a/cli/internal/app/login.go
+++ b/cli/internal/app/login.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/open-banking-io/clients/cli/internal/config"
@@ -206,28 +207,42 @@ func callbackHandler(resultCh chan<- callbackResult, state, allowOrigin string) 
 			writeDoneHTML(w)
 			deliver(callbackResult{code: code})
 		case http.MethodPost:
-			var p relayPayload
-			if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&p); err != nil || p.Code == "" {
+			code, gotState, privKey, pubKey := parseRelayPost(r)
+			if code == "" {
 				http.Error(w, "bad request", http.StatusBadRequest)
 				return
 			}
-			if subtle.ConstantTimeCompare([]byte(p.State), []byte(state)) != 1 {
+			if subtle.ConstantTimeCompare([]byte(gotState), []byte(state)) != 1 {
 				http.Error(w, "state mismatch", http.StatusForbidden)
 				return
 			}
-			res := callbackResult{code: p.Code}
-			if p.EncryptionKey != nil {
-				res.privKeyB64 = p.EncryptionKey.PrivateKey
-				res.pubKeyB64 = p.EncryptionKey.PublicKey
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(w, `{"ok":true}`)
-			deliver(res)
+			// The browser reaches us via a cross-origin form POST (no CORS preflight, not blocked by
+			// mixed-content rules) and navigates here, so reply with the closeable success page.
+			writeDoneHTML(w)
+			deliver(callbackResult{code: code, privKeyB64: privKey, pubKeyB64: pubKey})
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
 	})
 	return mux
+}
+
+// parseRelayPost reads the relayed credentials from either a browser form POST (the default — it needs
+// no CORS preflight and isn't blocked by mixed-content rules) or a JSON body.
+func parseRelayPost(r *http.Request) (code, state, privKey, pubKey string) {
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+		var p relayPayload
+		if json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&p) == nil {
+			code, state = p.Code, p.State
+			if p.EncryptionKey != nil {
+				privKey, pubKey = p.EncryptionKey.PrivateKey, p.EncryptionKey.PublicKey
+			}
+		}
+		return
+	}
+	_ = r.ParseForm()
+	return r.PostFormValue("code"), r.PostFormValue("state"),
+		r.PostFormValue("privateKey"), r.PostFormValue("publicKey")
 }
 
 func writeDoneHTML(w http.ResponseWriter) {

--- a/cli/internal/app/login_logic_test.go
+++ b/cli/internal/app/login_logic_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -77,6 +78,27 @@ func TestCallbackHandlerRelaysEncryptionKey(t *testing.T) {
 	res := <-ch
 	if res.code != "c1" || res.privKeyB64 != "PK" || res.pubKeyB64 != "PUB" {
 		t.Errorf("relayed result = %+v, want code c1 + key PK/PUB", res)
+	}
+}
+
+func TestCallbackHandlerAcceptsFormPost(t *testing.T) {
+	ch := make(chan callbackResult, 1)
+	srv := httptest.NewServer(callbackHandler(ch, "st8", "https://app.example"))
+	defer srv.Close()
+
+	// A browser form POST (application/x-www-form-urlencoded) — the path that avoids CORS entirely.
+	form := url.Values{"code": {"c9"}, "state": {"st8"}, "privateKey": {"PK"}, "publicKey": {"PUB"}}
+	resp, err := srv.Client().PostForm(srv.URL+"/callback", form)
+	if err != nil {
+		t.Fatalf("form POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	res := <-ch
+	if res.code != "c9" || res.privKeyB64 != "PK" || res.pubKeyB64 != "PUB" {
+		t.Errorf("form relay result = %+v, want code c9 + PK/PUB", res)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #44. The browser authorize page can't `fetch()` the loopback (CORS preflight + mixed-content block it). It now submits a real `<form>` POST (OAuth `response_mode=form_post` style), which needs no preflight and isn't blocked.

The loopback parses `application/x-www-form-urlencoded` (`code,state,privateKey,publicKey`); JSON stays as a fallback. The POST replies with the success page since the browser navigates to it. Tests cover the form path + JSON path + wrong-state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)