### PR TITLE
docs: refocus root README on getting started, split detail per language

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,24 @@
 [![codecov](https://codecov.io/gh/open-banking-io/clients/branch/main/graph/badge.svg)](https://codecov.io/gh/open-banking-io/clients)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-Server-to-server clients for [open-banking.io](https://open-banking.io) in **.NET, Node, Python,
-Rust, Go, Java, Ruby, and PHP**.
+Official server-to-server SDKs for **[open-banking.io](https://open-banking.io)** in .NET, Node,
+Python, Rust, Go, Java, Ruby, and PHP.
 
 open-banking.io is **zero-knowledge**: the service stores and returns only ciphertext it cannot read.
-These SDKs do the two things an integrator needs — **authenticate** with your API key and **decrypt**
-the data locally with your exported private key — and hand you clean, typed models.
+Each SDK does the two things an integrator needs — **authenticate** with your API key and **decrypt**
+your data locally with your private key — and hands you clean, typed models.
 
-| Language | Package | Path |
+> **New here?** Create an account and export your credentials bundle at
+> **[open-banking.io](https://open-banking.io)**, then pick your language below.
+
+## Pick your language
+
+Each package has its own README with install instructions, a runnable example, and language-specific
+notes (money types, async, dependencies).
+
+| Language | Package | Guide |
 |---|---|---|
-| .NET | `OpenBankingIO.Client` (NuGet) | [`dotnet/`](dotnet/) |
+| .NET | `OpenBankingIO.Client` (NuGet) | [`dotnet/`](dotnet/src/OpenBankingIO.Client/README.md) |
 | Node / TypeScript | `@open-banking-io/client` (npm) | [`node/`](node/) |
 | Python | `open-banking-io` (PyPI) | [`python/`](python/) |
 | Rust | `open-banking-io` (crates.io) | [`rust/`](rust/) |
@@ -31,23 +39,35 @@ the data locally with your exported private key — and hand you clean, typed mo
 | Ruby | `open-banking-io` (RubyGems) | [`ruby/`](ruby/) |
 | PHP | `open-banking-io/client` (Packagist) | [`php/`](php/) |
 
-## How it works
+Prefer the terminal? There's also a [command-line client](cli/) (`openbanking`).
 
-1. In the app, export your **credentials bundle** (`.json`) — it contains your `apiBaseUrl`, an
-   **API key**, and your **encryption private key** (PKCS#8).
-2. Point an SDK at the bundle. Every request sends `X-Api-Key`; every response is decrypted in-process.
+## Getting started
+
+1. **Get your credentials.** In the [open-banking.io](https://open-banking.io) app, export your
+   **credentials bundle** (`credentials.json`) — it contains your `apiBaseUrl`, an **API key**, and
+   your **encryption private key** (PKCS#8).
+2. **Point an SDK at the bundle.** Every request sends `X-Api-Key`; every response is decrypted
+   in-process with your private key. The service never sees your plaintext data.
+
+```ts
+// Node / TypeScript — the same shape exists in all eight languages (see each guide above).
+import { OpenBankingClient } from "@open-banking-io/client";
+
+const client = OpenBankingClient.fromCredentials("credentials.json");
+for (const a of await client.getAccounts()) {
+  const booked = a.balances.find((b) => b.type === "ITBD");
+  console.log(`${a.iban}: ${booked?.amount} ${a.currency}`);
+}
+```
+
+<details>
+<summary>The same example in .NET, Python, Rust, Go, Java, Ruby, and PHP</summary>
 
 ```csharp
 // .NET
 using var client = OpenBankingClient.FromCredentials("credentials.json");
 foreach (var a in await client.GetAccountsAsync())
     Console.WriteLine($"{a.Iban}: {a.Balances.First(b => b.Type == "ITBD").Amount} {a.Currency}");
-```
-```ts
-// Node
-const client = OpenBankingClient.fromCredentials("credentials.json");
-for (const a of await client.getAccounts())
-  console.log(a.iban, a.balances.find(b => b.type === "ITBD")?.amount, a.currency);
 ```
 ```python
 # Python
@@ -98,18 +118,22 @@ foreach ($client->getAccounts() as $a) {
     }
 }
 ```
+</details>
 
-All eight expose the same surface: `getAccounts`, `getTransactions(accountId, …)`, `getConnections`,
-`sync(accountId)`, `syncAll()`. Sync decrypts the account's session uid locally and posts it, so the
+All eight expose the same surface — `getAccounts`, `getTransactions(accountId, …)`, `getConnections`,
+`sync(accountId)`, `syncAll()`. `sync` decrypts the account's session uid locally and posts it, so the
 service can refresh from the bank without ever holding it in plaintext.
 
-## The encryption scheme
+## How it works
 
-Each sensitive value is an **envelope**: `version(1) | ephemeralPublicKey(65) | nonce(12) | tag(16) |
-ciphertext`, produced with **ephemeral ECDH on P-256 → HKDF-SHA256 (salt = 32 zero bytes, info =
-`bank.core.ci/zk/v1`) → AES-256-GCM**. Only your private key can open it. All eight SDKs are verified
-against the **same fixtures** (`fixtures/`) so they decrypt identically and interoperate with the live
-service's wire format.
+1. Your bank credentials are never sent to open-banking.io.
+2. Your account data (IBAN, balances, transactions) is stored **encrypted** by the service.
+3. Only your **local private key** can decrypt it — the service holds ciphertext it cannot read.
+
+Each sensitive value is an **envelope** sealed with **ephemeral ECDH (P-256) → HKDF-SHA256 →
+AES-256-GCM**; only your private key can open it, and all eight SDKs are verified against the same
+`fixtures/` so they decrypt identically. The full wire format, trust boundaries, and assumptions are
+in **[`THREAT_MODEL.md`](THREAT_MODEL.md)**.
 
 ## Development
 
@@ -128,11 +152,9 @@ cd ruby   && bundle install && bundle exec rspec
 cd php    && composer install && vendor/bin/phpunit
 ```
 
-CI (`.github/workflows/ci.yml`) builds and tests all eight on every push. **Releases are per-package**:
-each package publishes from its own `<dir>/vX.Y.Z` tag (e.g. `node/v0.2.0`), so tagging one package never
-republishes the others. Cut a release from **Actions → Release** (pick a package + version) — see
-[`RELEASING.md`](RELEASING.md). Targets: NuGet, npm, PyPI, crates.io, Maven Central, RubyGems, Packagist,
-and the Go module proxy.
+CI builds and tests all eight on every push. **Releases are per-package** — each publishes from its own
+`<dir>/vX.Y.Z` tag (e.g. `node/v0.2.0`), so tagging one package never republishes the others. Cut a
+release from **Actions → Release** (pick a package + version); see [`RELEASING.md`](RELEASING.md).
 
 ## Security & contributing
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -11,6 +11,20 @@ SDKs protect against and what they assume.
 
 These SDKs implement the client: they hold the private key and decrypt envelopes in-process.
 
+## Encryption scheme
+
+Each sensitive value is an **envelope**:
+
+```
+version(1)=0x01 | ephemeralPublicKey(65) | nonce(12) | tag(16) | ciphertext
+```
+
+It is produced with **ephemeral ECDH on P-256 → HKDF-SHA256** (salt = 32 zero bytes, info =
+`bank.core.ci/zk/v1`) **→ AES-256-GCM**. Only your private key can open it. Every SDK validates that
+the ephemeral public key is a valid point on P-256, and AES-GCM tag verification rejects tampered
+ciphertext. All eight SDKs are verified against the **same fixtures** (`fixtures/`) so they decrypt
+identically and interoperate with the live service's wire format.
+
 ## Trust boundaries
 
 **The SDK trusts:**

--- a/dotnet/src/OpenBankingIO.Client/README.md
+++ b/dotnet/src/OpenBankingIO.Client/README.md
@@ -45,8 +45,9 @@ using var client = new OpenBankingClient(apiBaseUrl, apiKey, privateKeyPkcs8Base
 ## Encryption
 
 Envelopes use **ECDH P-256 → HKDF-SHA256 → AES-256-GCM**. Decryption requires the private key from
-your credentials bundle and happens entirely in-process; amounts are exposed as `decimal`. See the
-[repo README](https://github.com/open-banking-io/clients) for the full scheme and the other language
-clients (Node, Python).
+your credentials bundle and happens entirely in-process; amounts are exposed as `decimal`. Full wire
+format and the other language clients:
+[repo README](https://github.com/open-banking-io/clients) ·
+[`THREAT_MODEL.md`](https://github.com/open-banking-io/clients/blob/main/THREAT_MODEL.md).
 
 MIT licensed.

--- a/go/README.md
+++ b/go/README.md
@@ -38,6 +38,20 @@ func main() {
 				fmt.Println(a.Iban, b.Amount, a.Currency)
 			}
 		}
+
+		limit := 50
+		page, err := client.GetTransactions(a.ID, openbanking.TransactionQuery{Limit: &limit})
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, t := range page.Items {
+			fmt.Println(" ", t.BookingDate, t.CreditorName, t.Amount, t.Currency)
+		}
+
+		// Trigger an online sync (decrypts the account uid locally and posts it):
+		if _, err := client.Sync(a.ID); err != nil {
+			log.Fatal(err)
+		}
 	}
 }
 ```
@@ -55,12 +69,14 @@ The client has **no third-party dependencies** — it uses only the standard lib
 When you pass a `nil` httpClient the client builds one with a 30s timeout; every request sends
 `User-Agent: open-banking-io/go/<version>` (see the exported `Version` const).
 
-## Encryption scheme
+## Encryption
 
-Each sensitive value is an envelope: `version(1) | ephemeralPublicKey(65) | nonce(12) | tag(16) |
-ciphertext`, produced with ephemeral ECDH on P-256 → HKDF-SHA256 (salt = 32 zero bytes, info =
-`bank.core.ci/zk/v1`) → AES-256-GCM. Only your private key can open it. The package is verified
-against the shared `fixtures/` so it decrypts identically to the other SDKs.
+Envelopes use **ECDH P-256 → HKDF-SHA256 → AES-256-GCM**, implemented with only the standard library
+(`crypto/ecdh`, `crypto/hkdf`, `crypto/aes`). Decryption requires the private key from your
+credentials bundle and happens entirely in-process. The package is verified against the shared
+`fixtures/` so it decrypts identically to the other SDKs. Full wire format and the other language
+clients: [repo README](https://github.com/open-banking-io/clients) ·
+[`THREAT_MODEL.md`](https://github.com/open-banking-io/clients/blob/main/THREAT_MODEL.md).
 
 ## Development
 

--- a/java/README.md
+++ b/java/README.md
@@ -11,21 +11,29 @@ client-side decryption of the zero-knowledge data envelopes with your exported p
 
 ```xml
 <dependency>
-  <groupId>io.openbanking</groupId>
+  <groupId>io.open-banking</groupId>
   <artifactId>open-banking-io-client</artifactId>
-  <version>0.1.0</version>
+  <version>0.2.1</version>
 </dependency>
 ```
 
 ```java
 import io.openbanking.*;
 
+// Load the credentials .json you exported from the app (API key + private key).
 var client = OpenBankingClient.fromCredentials("credentials.json");
 for (Account a : client.getAccounts()) {
     a.balances().stream()
         .filter(b -> b.type().equals("ITBD"))
         .findFirst()
         .ifPresent(b -> System.out.println(a.iban() + " " + b.amount() + " " + a.currency()));
+
+    TransactionPage page = client.getTransactions(a.id(), TransactionQuery.none().withLimit(50));
+    for (Transaction t : page.items())
+        System.out.println("  " + t.bookingDate() + "  " + t.creditorName() + "  " + t.amount() + " " + t.currency());
+
+    // Trigger an online sync (decrypts the account uid locally and posts it):
+    client.sync(a.id());
 }
 ```
 
@@ -42,12 +50,14 @@ The default client uses a 10s connect timeout and a 30s per-request timeout, and
 `User-Agent: open-banking-io/java/<version>` header on every request; an injected `HttpClient` is
 used as-is.
 
-## Encryption scheme
+## Encryption
 
-Each sensitive value is an envelope: `version(1) | ephemeralPublicKey(65) | nonce(12) | tag(16) |
-ciphertext`, produced with ephemeral ECDH on P-256 → HKDF-SHA256 (salt = 32 zero bytes, info =
-`bank.core.ci/zk/v1`) → AES-256-GCM. Only your private key can open it. The library is verified
-against the shared `fixtures/` so it decrypts identically to the other SDKs.
+Envelopes use **ECDH P-256 → HKDF-SHA256 → AES-256-GCM**, implemented with `javax.crypto` (JCA).
+Decryption requires the private key from your credentials bundle and happens entirely in-process. The
+library is verified against the shared `fixtures/` so it decrypts identically to the other SDKs. Full
+wire format and the other language clients:
+[repo README](https://github.com/open-banking-io/clients) ·
+[`THREAT_MODEL.md`](https://github.com/open-banking-io/clients/blob/main/THREAT_MODEL.md).
 
 ## Development
 

--- a/node/README.md
+++ b/node/README.md
@@ -55,9 +55,10 @@ library to avoid precision loss.
 
 ## Encryption
 
-Envelopes use **ECDH P-256 → HKDF-SHA256 → AES-256-GCM**. Decryption requires the private key from
-your credentials bundle and happens entirely in-process. See the
-[repo README](https://github.com/open-banking-io/clients) for the full scheme and the other language
-clients (.NET, Python).
+Envelopes use **ECDH P-256 → HKDF-SHA256 → AES-256-GCM**, implemented with the built-in `node:crypto`
+WebCrypto. Decryption requires the private key from your credentials bundle and happens entirely
+in-process. Full wire format and the other language clients:
+[repo README](https://github.com/open-banking-io/clients) ·
+[`THREAT_MODEL.md`](https://github.com/open-banking-io/clients/blob/main/THREAT_MODEL.md).
 
 MIT licensed.

--- a/php/README.md
+++ b/php/README.md
@@ -64,11 +64,9 @@ Money/amount fields are exposed as **decimal `string`s** (exact; never a float).
 ## Encryption
 
 Envelopes use **ECDH P-256 → HKDF-SHA256 → AES-256-GCM** and are decrypted entirely in-process with
-`ext-openssl`. The wire format is
-`version(1)=0x01 | ephemeralPublicKeyRaw(65) | nonce(12) | tag(16) | ciphertext`; HKDF uses info
-`bank.core.ci/zk/v1` and a 32-byte zero salt. See the
-[repo README](https://github.com/open-banking-io/clients) for the full scheme and the other language
-clients (.NET, Go, Python, Node).
+`ext-openssl`. Full wire format and the other language clients:
+[repo README](https://github.com/open-banking-io/clients) ·
+[`THREAT_MODEL.md`](https://github.com/open-banking-io/clients/blob/main/THREAT_MODEL.md).
 
 ## Development
 

--- a/python/README.md
+++ b/python/README.md
@@ -53,9 +53,9 @@ When the client constructs its own `httpx.Client` it applies a default 30s timeo
 ## Encryption
 
 Envelopes use **ECDH P-256 → HKDF-SHA256 → AES-256-GCM**. Decryption requires the private key from
-your credentials bundle and happens entirely in-process. See the
-[repo README](https://github.com/open-banking-io/clients) for the full scheme and the other language
-clients (.NET, Node).
+your credentials bundle and happens entirely in-process. Full wire format and the other language
+clients: [repo README](https://github.com/open-banking-io/clients) ·
+[`THREAT_MODEL.md`](https://github.com/open-banking-io/clients/blob/main/THREAT_MODEL.md).
 
 ## Development
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -61,8 +61,9 @@ Every request sets connect/read timeouts (15s/60s) and a `User-Agent: open-banki
 
 Envelopes use **ECDH P-256 → HKDF-SHA256 → AES-256-GCM**, implemented entirely with Ruby's OpenSSL
 standard library. Decryption requires the private key from your credentials bundle and happens fully
-in-process. See the [repo README](https://github.com/open-banking-io/clients) for the full scheme and
-the other language clients (.NET, Node, Python, Rust, Go, Java).
+in-process. Full wire format and the other language clients:
+[repo README](https://github.com/open-banking-io/clients) ·
+[`THREAT_MODEL.md`](https://github.com/open-banking-io/clients/blob/main/THREAT_MODEL.md).
 
 ## Development
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -11,17 +11,27 @@ client-side decryption of the zero-knowledge data envelopes with your exported p
 
 ```toml
 [dependencies]
-open-banking-io = "0.1"
+open-banking-io = "0.2"
 ```
 
 ```rust
-use open_banking_io::OpenBankingClient;
+use open_banking_io::{OpenBankingClient, TransactionQuery};
 
 fn main() -> open_banking_io::Result<()> {
+    // Load the credentials .json you exported from the app (API key + private key).
     let client = OpenBankingClient::from_credentials("credentials.json")?;
+
     for a in client.get_accounts()? {
         let booked = a.balances.iter().find(|b| b.type_ == "ITBD");
         println!("{:?}: {:?} {}", a.iban, booked.map(|b| &b.amount), a.currency);
+
+        let page = client.get_transactions(&a.id, &TransactionQuery { limit: Some(50), ..Default::default() })?;
+        for t in &page.items {
+            println!("  {:?}  {:?}  {} {}", t.booking_date, t.creditor_name, t.amount, t.currency);
+        }
+
+        // Trigger an online sync (decrypts the account uid locally and posts it):
+        client.sync(&a.id)?;
     }
     Ok(())
 }
@@ -38,13 +48,14 @@ Requests carry sensible HTTP timeouts (10s connect / 30s overall) and a
 Monetary amounts are returned as `String` exactly as the service emits them — parse them into your
 decimal type of choice to avoid any float round-trip.
 
-## Encryption scheme
+## Encryption
 
-Each sensitive value is an envelope: `version(1) | ephemeralPublicKey(65) | nonce(12) | tag(16) |
-ciphertext`, produced with ephemeral ECDH on P-256 → HKDF-SHA256 (salt = 32 zero bytes, info =
-`bank.core.ci/zk/v1`) → AES-256-GCM. Only your private key can open it. The crate is verified
-against the shared `fixtures/` so it decrypts identically to the .NET, Node, Python, Go, and Java
-SDKs.
+Envelopes use **ECDH P-256 → HKDF-SHA256 → AES-256-GCM**; decryption requires the private key from
+your credentials bundle and happens entirely in-process (the derived key material is zeroized after
+use). The crate is verified against the shared `fixtures/` so it decrypts identically to the other
+SDKs. Full wire format and the other language clients:
+[repo README](https://github.com/open-banking-io/clients) ·
+[`THREAT_MODEL.md`](https://github.com/open-banking-io/clients/blob/main/THREAT_MODEL.md).
 
 ## Development
 


### PR DESCRIPTION
## Why

The root README mixed too much language-specific implementation detail. It inlined code in **all eight languages** and repeated the full encryption-envelope **byte layout** — which was *also* duplicated across every per-language README and the security docs. A newcomer hit a 60-line wall of near-identical snippets before reaching "how it works," and any change to the wire format meant editing ~11 files.

## What changed

**Root `README.md`**
- Leads with the open-banking.io value prop + a clear **"get your credentials"** getting-started flow.
- Keeps **one** inline example (TypeScript) and tucks the other seven in a `<details>` block — no language dropped, but the page is scannable again.
- Replaces the inline byte layout with a one-line crypto summary → link to `THREAT_MODEL.md`.
- Adds a pointer to the CLI (was absent from the landing page).
- **Fixes the broken .NET table link** — `dotnet/` has no README; now deep-links to the real one.

**`THREAT_MODEL.md`** — now the single source of truth for the encryption scheme (added an **Encryption scheme** section with the full envelope byte layout). Everything else links here.

**Per-language READMEs** — each owns its own implementation detail; crypto sections trimmed to one sentence + a link, dropping the duplicated byte layouts and the inconsistent partial "other clients" lists.

**Backfilled Go / Java / Rust examples** with `getTransactions` + `sync` (they only showed `getAccounts`), so nothing the root used to imply is lost. Written against the actual method signatures in source, not guessed.

## Bugs fixed along the way
- `java/README.md` had the wrong Maven groupId (`io.openbanking`) — corrected to **`io.open-banking`** to match `pom.xml`.
- Bumped stale version snippets: **Java `0.1.0` → `0.2.1`**, **Rust `"0.1"` → `"0.2"`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)