### PR TITLE
cli: UX overhaul — colors, output formats, current account, completion

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,1 +1,4 @@
 dist/
+
+# Locally built binary (produced by `go build` in this directory)
+/openbanking

--- a/cli/README.md
+++ b/cli/README.md
@@ -36,11 +36,45 @@ go install github.com/open-banking-io/clients/cli@latest
 ```sh
 openbanking login                       # sign in + unlock in the browser — sets up everything
 openbanking key import ./credentials.json   # (fallback) import a key file on a headless machine
-openbanking accounts                    # list accounts with balances
-openbanking transactions <account-id>   # an account's statement (--from --to --limit)
-openbanking sync --all                  # pull fresh transactions
+openbanking accounts                    # list accounts with balances        (alias: acc, ls)
+openbanking use                         # pick a current account (arrow keys) — or: use <account-id>
+openbanking transactions                # the current account's statement     (alias: tx)
+openbanking transactions <account-id>   # a specific account (--from --to --limit --offset)
+openbanking sync                        # pull fresh transactions for the current account
+openbanking sync --all                  # …or for every connected account
+openbanking connections                 # list bank connections               (alias: conn)
 openbanking banks                       # list available banks (connect them in the web app)
+openbanking                             # no args, in a terminal → interactive menu
 openbanking version
+```
+
+Run `openbanking` with no command in a terminal for an interactive menu, or
+`openbanking help` for the full command list.
+
+### Current account
+
+`use` remembers a default account so `transactions` and `sync` need no id. Run
+`openbanking use` to pick one interactively, or `openbanking use <account-id>` to set it
+directly. An explicit id on `transactions`/`sync` always overrides it. The choice is stored
+in `state.json` beside your credentials (it is CLI-local — never sent anywhere).
+
+### Output formats
+
+Every listing command takes a global `-o`/`--output`:
+
+```sh
+openbanking accounts -o json | jq         # json (also the default when output is piped)
+openbanking transactions -o csv > tx.csv  # csv for spreadsheets
+openbanking accounts -o table             # the pretty, colored table (default in a terminal)
+```
+
+Color is on for terminals and off when piped; disable it with `--no-color` or the
+[`NO_COLOR`](https://no-color.org) environment variable.
+
+### Shell completion
+
+```sh
+source <(openbanking completion zsh)    # also: bash, fish
 ```
 
 > Connecting a new bank is done in the web app (it needs an interactive consent

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -2,4 +2,9 @@ module github.com/open-banking-io/clients/cli
 
 go 1.24
 
-require github.com/open-banking-io/clients/go v0.2.0
+require (
+	github.com/open-banking-io/clients/go v0.2.0
+	golang.org/x/term v0.34.0
+)
+
+require golang.org/x/sys v0.35.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,2 +1,6 @@
 github.com/open-banking-io/clients/go v0.2.0 h1:+56DPZalo35KfYv58P747QALOU/0y+x7YuXEE7Ld/u8=
 github.com/open-banking-io/clients/go v0.2.0/go.mod h1:DOqVT2pmX1aHGLXG5t4E0uqRYedPJ8nXvW9UiGCObZI=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.34.0 h1:O/2T7POpk0ZZ7MAzMeWFSg6S5IpWd/RXDlM9hgM3DR4=
+golang.org/x/term v0.34.0/go.mod h1:5jC53AEywhIVebHgPVeg0mj8OD3VO9OzclacVrqpaAw=

--- a/cli/internal/app/account_resolve.go
+++ b/cli/internal/app/account_resolve.go
@@ -1,0 +1,78 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/open-banking-io/clients/cli/internal/config"
+	"github.com/open-banking-io/clients/cli/internal/ui"
+	openbanking "github.com/open-banking-io/clients/go"
+)
+
+// resolveAccountID decides which account a command should act on when the user didn't name one on
+// the command line. An explicit, non-empty id always wins. Otherwise the saved current account is
+// used; if none is set, the picker opens on a terminal, or a clear error is returned in a
+// non-interactive context (so scripts fail loudly instead of hanging on a prompt).
+//
+// The saved id is trusted without a validating fetch — the common path stays a single API call. If
+// the saved account has since been removed, the command's own request returns a clear error and the
+// user can re-pick with `openbanking use`.
+func (a *App) resolveAccountID(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+
+	if state, _ := config.LoadState(a.ConfigPath); state.CurrentAccountID != "" {
+		return state.CurrentAccountID, nil
+	}
+
+	if !a.ui().Interactive() {
+		return "", fmt.Errorf("no account given and no current account set — pass an account id or run `openbanking use`")
+	}
+
+	client, err := a.client()
+	if err != nil {
+		return "", err
+	}
+	stop := a.ui().Spinner("Fetching accounts…")
+	accounts, err := client.GetAccounts()
+	stop()
+	if err != nil {
+		return "", fmt.Errorf("could not list accounts: %w", err)
+	}
+	if len(accounts) == 0 {
+		return "", fmt.Errorf("no accounts found — connect a bank in the web app, then run `openbanking sync`")
+	}
+
+	id, err := a.pickAccount(accounts)
+	if err != nil {
+		return "", err
+	}
+	// Remember the choice so the next call needs no prompt.
+	_ = config.SaveState(a.ConfigPath, config.State{CurrentAccountID: id})
+	return id, nil
+}
+
+func accountExists(accounts []openbanking.Account, id string) bool {
+	for _, acct := range accounts {
+		if acct.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// pickAccount opens the interactive selector over accounts and returns the chosen account id.
+func (a *App) pickAccount(accounts []openbanking.Account) (string, error) {
+	opts := make([]ui.Option, len(accounts))
+	for i, acct := range accounts {
+		opts[i] = ui.Option{
+			Label: fmt.Sprintf("%s  %s  %s", accountLabel(acct), accountNumber(acct), dash(acct.AspspName)),
+			Value: acct.ID,
+		}
+	}
+	choice, err := a.ui().Select("Select an account", opts)
+	if err != nil {
+		return "", err
+	}
+	return choice.Value, nil
+}

--- a/cli/internal/app/accounts.go
+++ b/cli/internal/app/accounts.go
@@ -3,15 +3,14 @@ package app
 import (
 	"flag"
 	"fmt"
-	"io"
-	"text/tabwriter"
 
+	"github.com/open-banking-io/clients/cli/internal/ui"
 	openbanking "github.com/open-banking-io/clients/go"
 )
 
 func (a *App) accounts(args []string) error {
 	fs := flag.NewFlagSet("accounts", flag.ContinueOnError)
-	fs.SetOutput(a.Stderr)
+	fs.SetOutput(a.stderr())
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -20,23 +19,66 @@ func (a *App) accounts(args []string) error {
 	if err != nil {
 		return err
 	}
+	stop := a.ui().Spinner("Fetching accounts…")
 	accounts, err := client.GetAccounts()
+	stop()
 	if err != nil {
 		return fmt.Errorf("could not list accounts: %w", err)
 	}
-	return renderAccounts(a.Stdout, accounts)
+	return a.ui().Render(accountsTable(accounts), accountsView(accounts))
 }
 
-func renderAccounts(w io.Writer, accounts []openbanking.Account) error {
-	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "NAME\tIBAN\tTYPE\tBALANCE\tCUR\tBANK\tID")
+func accountsTable(accounts []openbanking.Account) ui.Table {
+	t := ui.Table{Headers: []string{"NAME", "IBAN", "TYPE", "BALANCE", "CUR", "BANK", "ID"}}
 	for _, acct := range accounts {
 		bal := bookedBalance(acct.Balances)
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			accountLabel(acct), accountNumber(acct), dash(acct.AccountType),
-			dash(bal.Amount), dash(acct.Currency), dash(acct.AspspName), acct.ID)
+		balCell := ui.Cell{Text: dash(bal.Amount)}
+		if bal.Amount != "" {
+			balCell.Style = ui.AmountStyle(bal.Amount)
+		}
+		t.Rows = append(t.Rows, []ui.Cell{
+			{Text: accountLabel(acct)},
+			{Text: accountNumber(acct)},
+			{Text: dash(acct.AccountType)},
+			balCell,
+			{Text: dash(acct.Currency)},
+			{Text: dash(acct.AspspName)},
+			{Text: acct.ID, Style: ui.StyleMuted},
+		})
 	}
-	return tw.Flush()
+	return t
+}
+
+// accountView is the stable, CLI-shaped JSON representation of an account (lowerCamel keys, only the
+// fields the CLI surfaces) — deliberately decoupled from the untagged SDK struct.
+type accountView struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Number   string `json:"accountNumber,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Balance  string `json:"balance,omitempty"`
+	Currency string `json:"currency,omitempty"`
+	Bank     string `json:"bank,omitempty"`
+}
+
+func accountsView(accounts []openbanking.Account) []accountView {
+	views := make([]accountView, 0, len(accounts))
+	for _, acct := range accounts {
+		number := acct.Iban
+		if number == "" {
+			number = acct.Bban
+		}
+		views = append(views, accountView{
+			ID:       acct.ID,
+			Name:     accountLabel(acct),
+			Number:   number,
+			Type:     acct.AccountType,
+			Balance:  bookedBalance(acct.Balances).Amount,
+			Currency: acct.Currency,
+			Bank:     acct.AspspName,
+		})
+	}
+	return views
 }
 
 // accountLabel is the most human-friendly name available for an account.

--- a/cli/internal/app/app.go
+++ b/cli/internal/app/app.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/open-banking-io/clients/cli/internal/config"
+	"github.com/open-banking-io/clients/cli/internal/ui"
 	openbanking "github.com/open-banking-io/clients/go"
 )
 
@@ -21,6 +22,8 @@ type App struct {
 	ConfigPath string
 	Version    string       // set by main from the build-time version
 	HTTPClient *http.Client // nil uses the SDK default
+
+	env *ui.Env // resolved per run; tests may pre-set it to force color/format/interactivity
 }
 
 // stdin returns the configured input, defaulting to an empty reader when unset.
@@ -31,37 +34,67 @@ func (a *App) stdin() io.Reader {
 	return a.Stdin
 }
 
-// Run dispatches a single command invocation. args is everything after the program name.
+// stdout/stderr return the configured streams, defaulting to io.Discard so a partly-built App (or a
+// command reached before Run resolves the environment) never nil-panics.
+func (a *App) stdout() io.Writer {
+	if a.Stdout == nil {
+		return io.Discard
+	}
+	return a.Stdout
+}
+
+func (a *App) stderr() io.Writer {
+	if a.Stderr == nil {
+		return io.Discard
+	}
+	return a.Stderr
+}
+
+// ui returns the resolved output environment, lazily building a default one. Run sets a.env up front
+// (honoring the global flags), but commands invoked directly in tests get a sensible default here so
+// they never nil-panic on a.env.
+func (a *App) ui() *ui.Env {
+	if a.env == nil {
+		a.env, _ = ui.Resolve(a.stdout(), a.stderr(), a.stdin(), "", false)
+	}
+	return a.env
+}
+
+// Run dispatches a single command invocation. args is everything after the program name. It first
+// strips the global flags (--output, --no-color, --config), resolves the output environment once,
+// then dispatches through the command table so names, aliases, help and completion share one source.
 func (a *App) Run(args []string) error {
-	if len(args) == 0 {
+	rest, opt, err := parseGlobals(args)
+	if err != nil {
+		return err
+	}
+	if opt.config != "" {
+		a.ConfigPath = opt.config
+	}
+	if a.env == nil {
+		env, err := ui.Resolve(a.stdout(), a.stderr(), a.stdin(), opt.output, opt.noColor)
+		if err != nil {
+			return err
+		}
+		a.env = env
+	}
+
+	if len(rest) == 0 {
+		// On a terminal, an empty invocation opens the interactive menu; otherwise (piped, scripts)
+		// it prints usage and errors, exactly as before.
+		if a.env.Interactive() {
+			return a.interactiveMenu()
+		}
 		a.usage()
 		return fmt.Errorf("no command given")
 	}
-	cmd, rest := args[0], args[1:]
-	switch cmd {
-	case "login":
-		return a.login(rest)
-	case "accounts":
-		return a.accounts(rest)
-	case "transactions":
-		return a.transactions(rest)
-	case "connections":
-		return a.connections(rest)
-	case "key":
-		return a.key(rest)
-	case "sync":
-		return a.sync(rest)
-	case "banks":
-		return a.banks(rest)
-	case "version", "--version", "-v":
-		fmt.Fprintf(a.Stdout, "openbanking %s\n", a.versionString())
-		return nil
-	case "help", "-h", "--help":
-		a.usage()
-		return nil
-	default:
+
+	cmd, cargs := rest[0], rest[1:]
+	c, ok := a.lookup(cmd)
+	if !ok {
 		return fmt.Errorf("unknown command %q (run `openbanking help`)", cmd)
 	}
+	return c.run(a, cargs)
 }
 
 // client builds a decrypting SDK client from the saved credentials bundle (needs the encryption key).
@@ -93,21 +126,30 @@ func (a *App) versionString() string {
 	return a.Version
 }
 
+// usage prints the help text, generated from the command table so it can never drift from the
+// commands that actually exist.
 func (a *App) usage() {
-	fmt.Fprint(a.Stderr, `openbanking — open-banking.io command line
-
-Usage:
-  openbanking <command> [flags]
-
-Commands:
-  login                          Sign in via the browser and save an API key (--api --timeout)
-  accounts                       List your accounts with balances
-  transactions <account-id>      Show an account's statement (--from --to --limit --offset)
-  connections                    List your bank connections
-  key import [<file>]            Import your encryption key (SPA bundle or PKCS#8; stdin if no file)
-  sync <account-id> | --all      Pull fresh transactions for one account or all
-  banks                          List available banks (--country); connect them in the web app
-  version                        Print the openbanking version
-  help                           Show this help
-`)
+	var b strings.Builder
+	b.WriteString("openbanking — open-banking.io command line\n\n")
+	b.WriteString("Usage:\n")
+	b.WriteString("  openbanking <command> [flags]\n")
+	b.WriteString("  openbanking [--output table|json|csv] [--no-color] [--config <path>] <command>\n\n")
+	b.WriteString("Commands:\n")
+	for _, c := range a.commands() {
+		if c.hidden {
+			continue
+		}
+		name := c.name
+		if len(c.aliases) > 0 {
+			name += " (" + strings.Join(c.aliases, ", ") + ")"
+		}
+		fmt.Fprintf(&b, "  %-22s %s\n", name, c.short)
+	}
+	b.WriteString("\nGlobal flags:\n")
+	b.WriteString("  -o, --output   Output format: table (default on a terminal), json (default when piped), csv\n")
+	b.WriteString("      --no-color Disable colored output (also respects NO_COLOR)\n")
+	b.WriteString("      --config   Path to the credentials file\n")
+	b.WriteString("\nRun `openbanking <command> --help` for a command's own flags, or `openbanking` with no\n")
+	b.WriteString("arguments for an interactive menu.\n")
+	fmt.Fprint(a.stderr(), b.String())
 }

--- a/cli/internal/app/app_test.go
+++ b/cli/internal/app/app_test.go
@@ -91,7 +91,8 @@ func TestAccountsCommandRendersDecryptedTable(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
-	if err := app.Run([]string{"accounts"}); err != nil {
+	// Pin the table format: a captured buffer is not a terminal, so the default would be json.
+	if err := app.Run([]string{"-o", "table", "accounts"}); err != nil {
 		t.Fatalf("Run accounts: %v\nstderr: %s", err, errOut.String())
 	}
 
@@ -110,7 +111,7 @@ func TestTransactionsCommandRendersSignedAmountAndCounterparty(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
-	if err := app.Run([]string{"transactions", "11111111-1111-4111-8111-111111111111"}); err != nil {
+	if err := app.Run([]string{"-o", "table", "transactions", "11111111-1111-4111-8111-111111111111"}); err != nil {
 		t.Fatalf("Run transactions: %v\nstderr: %s", err, errOut.String())
 	}
 
@@ -147,7 +148,7 @@ func TestConnectionsCommandRendersTable(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
-	if err := app.Run([]string{"connections"}); err != nil {
+	if err := app.Run([]string{"-o", "table", "connections"}); err != nil {
 		t.Fatalf("Run connections: %v\nstderr: %s", err, errOut.String())
 	}
 

--- a/cli/internal/app/banks.go
+++ b/cli/internal/app/banks.go
@@ -3,16 +3,15 @@ package app
 import (
 	"flag"
 	"fmt"
-	"io"
 	"strings"
-	"text/tabwriter"
 
+	"github.com/open-banking-io/clients/cli/internal/ui"
 	openbanking "github.com/open-banking-io/clients/go"
 )
 
 func (a *App) banks(args []string) error {
 	fs := flag.NewFlagSet("banks", flag.ContinueOnError)
-	fs.SetOutput(a.Stderr)
+	fs.SetOutput(a.stderr())
 	country := fs.String("country", "DK", "country to list banks for")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -22,23 +21,51 @@ func (a *App) banks(args []string) error {
 	if err != nil {
 		return err
 	}
+	stop := a.ui().Spinner("Fetching banks…")
 	banks, err := client.ListBanks(*country)
+	stop()
 	if err != nil {
 		return fmt.Errorf("could not list banks: %w", err)
 	}
-	return renderBanks(a.Stdout, banks)
+	return a.ui().Render(banksTable(banks), banksView(banks))
 }
 
-func renderBanks(w io.Writer, banks []openbanking.Bank) error {
-	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "NAME\tCOUNTRY\tBIC\tPSU TYPES\tBETA")
+func banksTable(banks []openbanking.Bank) ui.Table {
+	t := ui.Table{Headers: []string{"NAME", "COUNTRY", "BIC", "PSU TYPES", "BETA"}}
 	for _, b := range banks {
-		beta := ""
+		beta := ui.Cell{}
 		if b.Beta {
-			beta = "beta"
+			beta = ui.Cell{Text: "beta", Style: ui.StyleStatusWarn}
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
-			dash(b.Name), dash(b.Country), dash(b.Bic), dash(strings.Join(b.PsuTypes, ",")), beta)
+		t.Rows = append(t.Rows, []ui.Cell{
+			{Text: dash(b.Name)},
+			{Text: dash(b.Country)},
+			{Text: dash(b.Bic)},
+			{Text: dash(strings.Join(b.PsuTypes, ","))},
+			beta,
+		})
 	}
-	return tw.Flush()
+	return t
+}
+
+type bankView struct {
+	Name     string   `json:"name"`
+	Country  string   `json:"country,omitempty"`
+	Bic      string   `json:"bic,omitempty"`
+	PsuTypes []string `json:"psuTypes,omitempty"`
+	Beta     bool     `json:"beta"`
+}
+
+func banksView(banks []openbanking.Bank) []bankView {
+	views := make([]bankView, 0, len(banks))
+	for _, b := range banks {
+		views = append(views, bankView{
+			Name:     b.Name,
+			Country:  b.Country,
+			Bic:      b.Bic,
+			PsuTypes: b.PsuTypes,
+			Beta:     b.Beta,
+		})
+	}
+	return views
 }

--- a/cli/internal/app/commands.go
+++ b/cli/internal/app/commands.go
@@ -1,0 +1,56 @@
+package app
+
+import "fmt"
+
+// command is one CLI verb. Keeping name, aliases, help and handler in a single table gives one
+// source of truth that dispatch, the help text, and shell completion all read from. The handler
+// signature matches the existing command methods exactly, so they slot in as method expressions
+// (e.g. (*App).accounts) with no change to their bodies.
+type command struct {
+	name    string
+	aliases []string
+	short   string
+	run     func(*App, []string) error
+	hidden  bool // kept out of help/completion (version, help)
+}
+
+func (a *App) commands() []command {
+	return []command{
+		{name: "login", short: "Sign in via the browser and save an API key", run: (*App).login},
+		{name: "accounts", aliases: []string{"acc", "ls"}, short: "List your accounts with balances", run: (*App).accounts},
+		{name: "transactions", aliases: []string{"tx"}, short: "Show an account's statement (current account if none given)", run: (*App).transactions},
+		{name: "use", short: "Set or pick the current account", run: (*App).use},
+		{name: "sync", short: "Pull fresh transactions for one account or --all", run: (*App).sync},
+		{name: "connections", aliases: []string{"conn"}, short: "List your bank connections", run: (*App).connections},
+		{name: "banks", short: "List banks available to connect (--country)", run: (*App).banks},
+		{name: "key", short: "Import your encryption key (key import [<file>])", run: (*App).key},
+		{name: "completion", short: "Output a shell completion script (bash|zsh|fish)", run: (*App).completion},
+		{name: "version", aliases: []string{"--version", "-v"}, short: "Print the openbanking version", run: (*App).versionCmd, hidden: true},
+		{name: "help", aliases: []string{"-h", "--help"}, short: "Show this help", run: (*App).helpCmd, hidden: true},
+	}
+}
+
+// lookup finds a command by its name or any of its aliases.
+func (a *App) lookup(name string) (command, bool) {
+	for _, c := range a.commands() {
+		if c.name == name {
+			return c, true
+		}
+		for _, al := range c.aliases {
+			if al == name {
+				return c, true
+			}
+		}
+	}
+	return command{}, false
+}
+
+func (a *App) versionCmd([]string) error {
+	fmt.Fprintf(a.stdout(), "openbanking %s\n", a.versionString())
+	return nil
+}
+
+func (a *App) helpCmd([]string) error {
+	a.usage()
+	return nil
+}

--- a/cli/internal/app/completion.go
+++ b/cli/internal/app/completion.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+// completion prints a shell completion script to stdout. The command and alias list is taken from
+// the command table, so completions stay in sync with the real commands automatically.
+func (a *App) completion(args []string) error {
+	shell := ""
+	if len(args) > 0 {
+		shell = args[0]
+	}
+	names := a.visibleCommandNames()
+	switch shell {
+	case "bash":
+		fmt.Fprint(a.stdout(), bashCompletion(names))
+	case "zsh":
+		fmt.Fprint(a.stdout(), zshCompletion(names))
+	case "fish":
+		fmt.Fprint(a.stdout(), fishCompletion(names))
+	default:
+		return fmt.Errorf("usage: openbanking completion [bash|zsh|fish]")
+	}
+	return nil
+}
+
+// visibleCommandNames returns the user-facing command names plus aliases, for completion.
+func (a *App) visibleCommandNames() []string {
+	var names []string
+	for _, c := range a.commands() {
+		if c.hidden {
+			continue
+		}
+		names = append(names, c.name)
+		names = append(names, c.aliases...)
+	}
+	return names
+}
+
+func bashCompletion(names []string) string {
+	return fmt.Sprintf(`# openbanking bash completion
+# Enable with:  source <(openbanking completion bash)
+_openbanking() {
+    local cur cmds opts
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    cmds="%s"
+    opts="-o --output --no-color --config -h --help"
+    if [ "$COMP_CWORD" -eq 1 ]; then
+        COMPREPLY=( $(compgen -W "${cmds}" -- "${cur}") )
+    else
+        COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+    fi
+}
+complete -F _openbanking openbanking
+`, strings.Join(names, " "))
+}
+
+func zshCompletion(names []string) string {
+	return fmt.Sprintf(`#compdef openbanking
+# Enable with:  source <(openbanking completion zsh)
+_openbanking() {
+    local -a cmds
+    cmds=(%s)
+    _arguments \
+        '(-o --output)'{-o,--output}'[output format]:format:(table json csv)' \
+        '--no-color[disable colored output]' \
+        '--config[path to credentials file]:file:_files' \
+        '1: :->cmd' \
+        '*:: :->args'
+    if [[ $state == cmd ]]; then
+        _describe 'command' cmds
+    fi
+}
+_openbanking "$@"
+`, strings.Join(names, " "))
+}
+
+func fishCompletion(names []string) string {
+	var b strings.Builder
+	b.WriteString("# openbanking fish completion\n")
+	b.WriteString("# Save to ~/.config/fish/completions/openbanking.fish\n")
+	for _, n := range names {
+		fmt.Fprintf(&b, "complete -c openbanking -n '__fish_use_subcommand' -a '%s'\n", n)
+	}
+	b.WriteString("complete -c openbanking -s o -l output -d 'output format' -x -a 'table json csv'\n")
+	b.WriteString("complete -c openbanking -l no-color -d 'disable colored output'\n")
+	b.WriteString("complete -c openbanking -l config -d 'path to credentials file' -r\n")
+	return b.String()
+}

--- a/cli/internal/app/connections.go
+++ b/cli/internal/app/connections.go
@@ -3,15 +3,14 @@ package app
 import (
 	"flag"
 	"fmt"
-	"io"
-	"text/tabwriter"
 
+	"github.com/open-banking-io/clients/cli/internal/ui"
 	openbanking "github.com/open-banking-io/clients/go"
 )
 
 func (a *App) connections(args []string) error {
 	fs := flag.NewFlagSet("connections", flag.ContinueOnError)
-	fs.SetOutput(a.Stderr)
+	fs.SetOutput(a.stderr())
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -20,20 +19,56 @@ func (a *App) connections(args []string) error {
 	if err != nil {
 		return err
 	}
+	stop := a.ui().Spinner("Fetching connections…")
 	conns, err := client.GetConnections()
+	stop()
 	if err != nil {
 		return fmt.Errorf("could not list connections: %w", err)
 	}
-	return renderConnections(a.Stdout, conns)
+	return a.ui().Render(connectionsTable(conns), connectionsView(conns))
 }
 
-func renderConnections(w io.Writer, conns []openbanking.Connection) error {
-	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "BANK\tCOUNTRY\tSTATUS\tACCOUNTS\tPSU\tVALID UNTIL\tLAST SYNCED\tSESSION")
+func connectionsTable(conns []openbanking.Connection) ui.Table {
+	t := ui.Table{Headers: []string{"BANK", "COUNTRY", "STATUS", "ACCOUNTS", "PSU", "VALID UNTIL", "LAST SYNCED", "SESSION"}}
 	for _, c := range conns {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\n",
-			dash(c.AspspName), dash(c.AspspCountry), dash(c.Status), c.AccountCount,
-			dash(c.PsuType), dash(c.ValidUntil), dash(c.LastSyncedAt), dash(c.SessionID))
+		t.Rows = append(t.Rows, []ui.Cell{
+			{Text: dash(c.AspspName)},
+			{Text: dash(c.AspspCountry)},
+			{Text: dash(c.Status), Style: ui.StatusStyle(c.Status)},
+			{Text: fmt.Sprintf("%d", c.AccountCount)},
+			{Text: dash(c.PsuType)},
+			{Text: dash(c.ValidUntil)},
+			{Text: dash(c.LastSyncedAt)},
+			{Text: dash(c.SessionID), Style: ui.StyleMuted},
+		})
 	}
-	return tw.Flush()
+	return t
+}
+
+type connectionView struct {
+	Bank         string `json:"bank,omitempty"`
+	Country      string `json:"country,omitempty"`
+	Status       string `json:"status,omitempty"`
+	AccountCount int64  `json:"accountCount"`
+	PsuType      string `json:"psuType,omitempty"`
+	ValidUntil   string `json:"validUntil,omitempty"`
+	LastSyncedAt string `json:"lastSyncedAt,omitempty"`
+	SessionID    string `json:"sessionId,omitempty"`
+}
+
+func connectionsView(conns []openbanking.Connection) []connectionView {
+	views := make([]connectionView, 0, len(conns))
+	for _, c := range conns {
+		views = append(views, connectionView{
+			Bank:         c.AspspName,
+			Country:      c.AspspCountry,
+			Status:       c.Status,
+			AccountCount: c.AccountCount,
+			PsuType:      c.PsuType,
+			ValidUntil:   c.ValidUntil,
+			LastSyncedAt: c.LastSyncedAt,
+			SessionID:    c.SessionID,
+		})
+	}
+	return views
 }

--- a/cli/internal/app/dispatch_test.go
+++ b/cli/internal/app/dispatch_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/open-banking-io/clients/cli/internal/config"
+	"github.com/open-banking-io/clients/cli/internal/ui"
 	openbanking "github.com/open-banking-io/clients/go"
 )
 
@@ -144,8 +145,9 @@ func TestRenderBanksShowsBetaFlag(t *testing.T) {
 		{Name: "Lunar", Country: "DK", Bic: "LUNADK22", PsuTypes: []string{"business"}, Beta: false},
 		{Name: "NewBank", Country: "DK", Beta: true},
 	}
-	if err := renderBanks(&out, banks); err != nil {
-		t.Fatalf("renderBanks: %v", err)
+	e := ui.Custom(nil, &out, &out, ui.FormatTable, false, false)
+	if err := e.Render(banksTable(banks), banksView(banks)); err != nil {
+		t.Fatalf("render banks: %v", err)
 	}
 	if !strings.Contains(out.String(), "beta") {
 		t.Errorf("expected a beta marker in output\n%s", out.String())

--- a/cli/internal/app/globals.go
+++ b/cli/internal/app/globals.go
@@ -1,0 +1,49 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+// globalOpts holds the flags that apply to every command, parsed out of the argument list before
+// dispatch.
+type globalOpts struct {
+	output  string // raw --output/-o value ("" = auto)
+	noColor bool
+	config  string // overrides the credentials path when non-empty
+}
+
+// parseGlobals pulls the global flags (-o/--output, --no-color, --config) out of args wherever they
+// appear and returns the remaining args (command name plus command-specific flags) untouched. Only
+// these specific flags are recognized, so per-command flags such as --from or --all pass straight
+// through to their own FlagSet — letting commands keep parsing exactly as they do today.
+func parseGlobals(args []string) (rest []string, opt globalOpts, err error) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-o" || arg == "--output":
+			if i+1 >= len(args) {
+				return nil, opt, fmt.Errorf("flag %s needs a value (table, json, or csv)", arg)
+			}
+			opt.output = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "-o="):
+			opt.output = strings.TrimPrefix(arg, "-o=")
+		case strings.HasPrefix(arg, "--output="):
+			opt.output = strings.TrimPrefix(arg, "--output=")
+		case arg == "--no-color":
+			opt.noColor = true
+		case arg == "--config":
+			if i+1 >= len(args) {
+				return nil, opt, fmt.Errorf("flag --config needs a path")
+			}
+			opt.config = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "--config="):
+			opt.config = strings.TrimPrefix(arg, "--config=")
+		default:
+			rest = append(rest, arg)
+		}
+	}
+	return rest, opt, nil
+}

--- a/cli/internal/app/login.go
+++ b/cli/internal/app/login.go
@@ -100,12 +100,15 @@ func (a *App) login(args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
 	defer cancel()
 
+	stopSpinner := a.ui().Spinner("Waiting for you to finish signing in…")
 	var result callbackResult
 	select {
 	case result = <-resultCh:
 	case <-ctx.Done():
+		stopSpinner()
 		return fmt.Errorf("timed out waiting for the browser login after %s", *timeout)
 	}
+	stopSpinner()
 
 	token, err := a.exchangeToken(ctx, base, result.code, verifier)
 	if err != nil {

--- a/cli/internal/app/menu.go
+++ b/cli/internal/app/menu.go
@@ -1,0 +1,60 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/open-banking-io/clients/cli/internal/config"
+	"github.com/open-banking-io/clients/cli/internal/ui"
+)
+
+// interactiveMenu is shown when openbanking is run with no command on a terminal: a short status
+// header plus a selectable list of common actions. It is only reached interactively — non-terminal
+// empty invocations print usage and error (see Run).
+func (a *App) interactiveMenu() error {
+	a.printStatus()
+
+	actions := []ui.Option{
+		{Label: "Accounts — list balances", Value: "accounts"},
+		{Label: "Transactions — current account statement", Value: "transactions"},
+		{Label: "Sync — pull fresh transactions", Value: "sync"},
+		{Label: "Use — switch current account", Value: "use"},
+		{Label: "Connections — bank connections", Value: "connections"},
+		{Label: "Banks — available to connect", Value: "banks"},
+		{Label: "Login — sign in", Value: "login"},
+		{Label: "Quit", Value: ""},
+	}
+	choice, err := a.ui().Select("openbanking", actions)
+	if err == ui.ErrCancelled {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if choice.Value == "" { // Quit
+		return nil
+	}
+	c, ok := a.lookup(choice.Value)
+	if !ok {
+		return fmt.Errorf("unknown command %q", choice.Value)
+	}
+	return c.run(a, nil)
+}
+
+// printStatus writes a short who-am-I / current-account header to stderr.
+func (a *App) printStatus() {
+	bundle, err := config.Load(a.ConfigPath)
+	if err != nil || bundle.APIKey == "" {
+		a.ui().Infof("Not signed in — choose Login to get started.")
+		return
+	}
+	user := bundle.User
+	if user == "" {
+		user = "signed in"
+	}
+	a.ui().Infof("Signed in as %s", user)
+	if state, _ := config.LoadState(a.ConfigPath); state.CurrentAccountID != "" {
+		a.ui().Infof("Current account: %s", state.CurrentAccountID)
+	} else {
+		a.ui().Infof("No current account set (choose Use to pick one)")
+	}
+}

--- a/cli/internal/app/sync.go
+++ b/cli/internal/app/sync.go
@@ -3,11 +3,13 @@ package app
 import (
 	"flag"
 	"fmt"
+
+	"github.com/open-banking-io/clients/cli/internal/ui"
 )
 
 func (a *App) sync(args []string) error {
 	fs := flag.NewFlagSet("sync", flag.ContinueOnError)
-	fs.SetOutput(a.Stderr)
+	fs.SetOutput(a.stderr())
 	all := fs.Bool("all", false, "sync every account that has an active session")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -22,23 +24,32 @@ func (a *App) sync(args []string) error {
 		if fs.NArg() > 0 {
 			return fmt.Errorf("`sync --all` takes no account id")
 		}
+		stop := a.ui().Spinner("Syncing all accounts…")
 		result, err := client.SyncAll()
+		stop()
 		if err != nil {
 			return fmt.Errorf("sync failed: %w", err)
 		}
-		fmt.Fprintf(a.Stdout, "Synced %d account(s): %d new transaction(s)\n",
-			result.Accounts, result.NewTransactions)
+		fmt.Fprintln(a.stdout(), a.ui().Color(
+			fmt.Sprintf("Synced %d account(s): %d new transaction(s)", result.Accounts, result.NewTransactions),
+			ui.StyleSuccess))
 		return nil
 	}
 
-	if fs.NArg() == 0 {
-		return fmt.Errorf("usage: openbanking sync <account-id>   (or: openbanking sync --all)")
+	// No id and no --all: fall back to the current account (or the picker on a terminal), rather
+	// than erroring outright.
+	accountID, err := a.resolveAccountID(fs.Arg(0))
+	if err != nil {
+		return err
 	}
-	result, err := client.Sync(fs.Arg(0))
+	stop := a.ui().Spinner("Syncing…")
+	result, err := client.Sync(accountID)
+	stop()
 	if err != nil {
 		return fmt.Errorf("sync failed: %w", err)
 	}
-	fmt.Fprintf(a.Stdout, "Synced: %d new transaction(s) (%d fetched)\n",
-		result.NewTransactions, result.TotalFetched)
+	fmt.Fprintln(a.stdout(), a.ui().Color(
+		fmt.Sprintf("Synced: %d new transaction(s) (%d fetched)", result.NewTransactions, result.TotalFetched),
+		ui.StyleSuccess))
 	return nil
 }

--- a/cli/internal/app/transactions.go
+++ b/cli/internal/app/transactions.go
@@ -3,26 +3,34 @@ package app
 import (
 	"flag"
 	"fmt"
-	"io"
 	"strings"
-	"text/tabwriter"
 
+	"github.com/open-banking-io/clients/cli/internal/ui"
 	openbanking "github.com/open-banking-io/clients/go"
 )
 
 func (a *App) transactions(args []string) error {
-	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
-		return fmt.Errorf("usage: openbanking transactions <account-id> [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--limit N] [--offset N]")
+	// A leading non-flag token is an explicit account id; otherwise the current account is used (or
+	// the picker opens). Either way the remaining tokens are the command's own flags.
+	explicit := ""
+	flagArgs := args
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		explicit = args[0]
+		flagArgs = args[1:]
 	}
-	accountID := args[0]
 
 	fs := flag.NewFlagSet("transactions", flag.ContinueOnError)
-	fs.SetOutput(a.Stderr)
+	fs.SetOutput(a.stderr())
 	from := fs.String("from", "", "earliest booking date (YYYY-MM-DD)")
 	to := fs.String("to", "", "latest booking date (YYYY-MM-DD)")
 	limit := fs.Int("limit", 0, "max rows to return (0 = server default)")
 	offset := fs.Int("offset", 0, "rows to skip")
-	if err := fs.Parse(args[1:]); err != nil {
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+
+	accountID, err := a.resolveAccountID(explicit)
+	if err != nil {
 		return err
 	}
 
@@ -38,26 +46,66 @@ func (a *App) transactions(args []string) error {
 	if err != nil {
 		return err
 	}
+	stop := a.ui().Spinner("Fetching transactions…")
 	page, err := client.GetTransactions(accountID, query)
+	stop()
 	if err != nil {
 		return fmt.Errorf("could not list transactions: %w", err)
 	}
-	return renderTransactions(a.Stdout, page)
+	return a.ui().Render(transactionsTable(page), transactionsView(page))
 }
 
-func renderTransactions(w io.Writer, page openbanking.TransactionPage) error {
-	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "DATE\tAMOUNT\tCUR\tCOUNTERPARTY\tINFO\tSTATUS")
-	for _, t := range page.Items {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			dash(transactionDate(t)), signedAmount(t), dash(t.Currency),
-			dash(counterparty(t)), dash(transactionInfo(t)), dash(t.Status))
+func transactionsTable(page openbanking.TransactionPage) ui.Table {
+	t := ui.Table{Headers: []string{"DATE", "AMOUNT", "CUR", "COUNTERPARTY", "INFO", "STATUS"}}
+	for _, tx := range page.Items {
+		amt := signedAmount(tx)
+		t.Rows = append(t.Rows, []ui.Cell{
+			{Text: dash(transactionDate(tx))},
+			{Text: amt, Style: ui.AmountStyle(amt)},
+			{Text: dash(tx.Currency)},
+			{Text: dash(counterparty(tx))},
+			{Text: dash(transactionInfo(tx))},
+			{Text: dash(tx.Status), Style: ui.StatusStyle(tx.Status)},
+		})
 	}
-	if err := tw.Flush(); err != nil {
-		return err
+	t.Note = fmt.Sprintf("%d shown, %d total", len(page.Items), page.Total)
+	return t
+}
+
+type transactionView struct {
+	ID           string `json:"id"`
+	Date         string `json:"date,omitempty"`
+	Amount       string `json:"amount"`
+	Currency     string `json:"currency,omitempty"`
+	Counterparty string `json:"counterparty,omitempty"`
+	Info         string `json:"info,omitempty"`
+	Status       string `json:"status,omitempty"`
+}
+
+type transactionsPageView struct {
+	Items []transactionView `json:"items"`
+	Shown int               `json:"shown"`
+	Total int64             `json:"total"`
+}
+
+func transactionsView(page openbanking.TransactionPage) transactionsPageView {
+	view := transactionsPageView{
+		Items: make([]transactionView, 0, len(page.Items)),
+		Shown: len(page.Items),
+		Total: page.Total,
 	}
-	fmt.Fprintf(w, "\n%d shown, %d total\n", len(page.Items), page.Total)
-	return nil
+	for _, tx := range page.Items {
+		view.Items = append(view.Items, transactionView{
+			ID:           tx.ID,
+			Date:         transactionDate(tx),
+			Amount:       signedAmount(tx),
+			Currency:     tx.Currency,
+			Counterparty: counterparty(tx),
+			Info:         transactionInfo(tx),
+			Status:       tx.Status,
+		})
+	}
+	return view
 }
 
 // isDebit reports whether the indicator is a debit, tolerant of case and surrounding whitespace —

--- a/cli/internal/app/use.go
+++ b/cli/internal/app/use.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/open-banking-io/clients/cli/internal/config"
+)
+
+// use sets the current account that transactions and sync default to. With an account id it sets
+// it directly (after checking it exists); with no id it opens the interactive picker on a terminal.
+func (a *App) use(args []string) error {
+	fs := flag.NewFlagSet("use", flag.ContinueOnError)
+	fs.SetOutput(a.stderr())
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	client, err := a.client()
+	if err != nil {
+		return err
+	}
+	stop := a.ui().Spinner("Fetching accounts…")
+	accounts, err := client.GetAccounts()
+	stop()
+	if err != nil {
+		return fmt.Errorf("could not list accounts: %w", err)
+	}
+	if len(accounts) == 0 {
+		return fmt.Errorf("no accounts found — connect a bank in the web app, then run `openbanking sync`")
+	}
+
+	var chosenID string
+	if id := fs.Arg(0); id != "" {
+		if !accountExists(accounts, id) {
+			return fmt.Errorf("unknown account id %q (run `openbanking accounts` to list them)", id)
+		}
+		chosenID = id
+	} else {
+		if !a.ui().Interactive() {
+			return fmt.Errorf("no account id given and not a terminal — pass one, e.g. `openbanking use <account-id>`")
+		}
+		if chosenID, err = a.pickAccount(accounts); err != nil {
+			return err
+		}
+	}
+
+	if err := config.SaveState(a.ConfigPath, config.State{CurrentAccountID: chosenID}); err != nil {
+		return err
+	}
+	for _, acct := range accounts {
+		if acct.ID == chosenID {
+			a.ui().Successf("Current account set to %s (%s)", accountLabel(acct), acct.ID)
+			return nil
+		}
+	}
+	a.ui().Successf("Current account set to %s", chosenID)
+	return nil
+}

--- a/cli/internal/app/ux_test.go
+++ b/cli/internal/app/ux_test.go
@@ -1,0 +1,243 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/open-banking-io/clients/cli/internal/config"
+	"github.com/open-banking-io/clients/cli/internal/ui"
+)
+
+const fixtureAccountID = "11111111-1111-4111-8111-111111111111"
+
+// newApp wires an App against the mock API server with the fixture credentials.
+func newApp(t *testing.T, out, errOut *bytes.Buffer) *App {
+	t.Helper()
+	bundle := fixtureBundle(t)
+	srv := startAPIServer(t, bundle.APIKey)
+	cfg := writeConfig(t, bundle, srv.URL)
+	return &App{Stdout: out, Stderr: errOut, ConfigPath: cfg}
+}
+
+func TestCommandAliasesDispatch(t *testing.T) {
+	for _, alias := range []string{"acc", "ls"} {
+		var out, errOut bytes.Buffer
+		app := newApp(t, &out, &errOut)
+		if err := app.Run([]string{"-o", "json", alias}); err != nil {
+			t.Fatalf("alias %q: %v\nstderr: %s", alias, err, errOut.String())
+		}
+		if !strings.Contains(out.String(), fixtureAccountID) {
+			t.Errorf("alias %q did not behave like `accounts`:\n%s", alias, out.String())
+		}
+	}
+
+	// tx is the alias for transactions and takes the account id positionally.
+	var out, errOut bytes.Buffer
+	app := newApp(t, &out, &errOut)
+	if err := app.Run([]string{"-o", "json", "tx", fixtureAccountID}); err != nil {
+		t.Fatalf("alias tx: %v\nstderr: %s", err, errOut.String())
+	}
+	if !strings.Contains(out.String(), "-194.23") {
+		t.Errorf("alias tx did not behave like `transactions`:\n%s", out.String())
+	}
+}
+
+func TestAccountsJSONOutput(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := newApp(t, &out, &errOut)
+	if err := app.Run([]string{"-o", "json", "accounts"}); err != nil {
+		t.Fatalf("accounts -o json: %v\nstderr: %s", err, errOut.String())
+	}
+	var got []map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("output is not a json array: %v\n%s", err, out.String())
+	}
+	if len(got) != 1 || got[0]["id"] != fixtureAccountID {
+		t.Errorf("unexpected json: %+v", got)
+	}
+	if got[0]["bank"] != "Lunar" {
+		t.Errorf("expected lowerCamel CLI keys (bank=Lunar), got: %+v", got[0])
+	}
+}
+
+func TestAccountsCSVOutput(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := newApp(t, &out, &errOut)
+	if err := app.Run([]string{"-o", "csv", "accounts"}); err != nil {
+		t.Fatalf("accounts -o csv: %v\nstderr: %s", err, errOut.String())
+	}
+	if !strings.HasPrefix(out.String(), "NAME,IBAN,TYPE,BALANCE,CUR,BANK,ID") {
+		t.Errorf("csv header missing:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Drift") {
+		t.Errorf("csv data row missing:\n%s", out.String())
+	}
+}
+
+func TestPipedDefaultsToJSON(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := newApp(t, &out, &errOut)
+	// No -o flag and a captured (non-terminal) stdout -> json by default.
+	if err := app.Run([]string{"accounts"}); err != nil {
+		t.Fatalf("accounts: %v\nstderr: %s", err, errOut.String())
+	}
+	var got []map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("piped output should default to json, but did not parse: %v\n%s", err, out.String())
+	}
+}
+
+func TestUseSetsCurrentAccountExplicit(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := newApp(t, &out, &errOut)
+	if err := app.Run([]string{"use", fixtureAccountID}); err != nil {
+		t.Fatalf("use: %v\nstderr: %s", err, errOut.String())
+	}
+	state, err := config.LoadState(app.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.CurrentAccountID != fixtureAccountID {
+		t.Errorf("current account = %q, want %q", state.CurrentAccountID, fixtureAccountID)
+	}
+}
+
+func TestUseUnknownAccountErrors(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := newApp(t, &out, &errOut)
+	if err := app.Run([]string{"use", "does-not-exist"}); err == nil {
+		t.Fatal("expected an error for an unknown account id")
+	}
+}
+
+func TestUseNoIDNonInteractiveErrors(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := newApp(t, &out, &errOut)
+	// Non-terminal streams: there's no id and no way to prompt, so it must error clearly.
+	if err := app.Run([]string{"use"}); err == nil {
+		t.Fatal("expected an error: no id and not a terminal")
+	}
+}
+
+func TestUseInteractivePicker(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := newApp(t, &out, &errOut)
+	// Force an interactive env reading a choice from a buffer; the arrow-key path can't run on a
+	// buffer (no Fd), so Select falls back to the numbered prompt and reads "1".
+	app.env = ui.Custom(strings.NewReader("1\n"), &out, &errOut, ui.FormatTable, false, true)
+	if err := app.Run([]string{"use"}); err != nil {
+		t.Fatalf("use (picker): %v\nstderr: %s", err, errOut.String())
+	}
+	state, _ := config.LoadState(app.ConfigPath)
+	if state.CurrentAccountID != fixtureAccountID {
+		t.Errorf("picker did not save the chosen account, got %q", state.CurrentAccountID)
+	}
+}
+
+func TestTransactionsUsesCurrentAccount(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := newApp(t, &out, &errOut)
+	if err := config.SaveState(app.ConfigPath, config.State{CurrentAccountID: fixtureAccountID}); err != nil {
+		t.Fatal(err)
+	}
+	// No account id on the command line -> the current account is used.
+	if err := app.Run([]string{"-o", "table", "transactions"}); err != nil {
+		t.Fatalf("transactions (current account): %v\nstderr: %s", err, errOut.String())
+	}
+	if !strings.Contains(out.String(), "-194.23") {
+		t.Errorf("expected the current account's statement:\n%s", out.String())
+	}
+}
+
+func TestSyncUsesCurrentAccount(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := newApp(t, &out, &errOut)
+	if err := config.SaveState(app.ConfigPath, config.State{CurrentAccountID: fixtureAccountID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Run([]string{"sync"}); err != nil {
+		t.Fatalf("sync (current account): %v\nstderr: %s", err, errOut.String())
+	}
+	if !strings.Contains(out.String(), "fetched") {
+		t.Errorf("expected a sync summary:\n%s", out.String())
+	}
+}
+
+func TestCompletionScripts(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish"} {
+		var out, errOut bytes.Buffer
+		app := &App{Stdout: &out, Stderr: &errOut}
+		if err := app.Run([]string{"completion", shell}); err != nil {
+			t.Fatalf("completion %s: %v", shell, err)
+		}
+		for _, want := range []string{"openbanking", "accounts", "tx"} {
+			if !strings.Contains(out.String(), want) {
+				t.Errorf("completion %s missing %q:\n%s", shell, want, out.String())
+			}
+		}
+	}
+
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut}
+	if err := app.Run([]string{"completion", "powershell"}); err == nil {
+		t.Fatal("expected an error for an unsupported shell")
+	}
+}
+
+func TestGlobalOutputFlagNeedsValue(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut}
+	if err := app.Run([]string{"-o"}); err == nil {
+		t.Fatal("expected an error: -o needs a value")
+	}
+}
+
+func TestGlobalOutputFlagRejectsUnknownFormat(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut}
+	if err := app.Run([]string{"-o", "yaml", "accounts"}); err == nil {
+		t.Fatal("expected an error for an unknown output format")
+	}
+}
+
+func TestInteractiveMenuQuit(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := newApp(t, &out, &errOut)
+	// Option 8 is Quit; the numbered fallback reads it and the menu exits cleanly.
+	app.env = ui.Custom(strings.NewReader("8\n"), &out, &errOut, ui.FormatTable, false, true)
+	if err := app.Run(nil); err != nil {
+		t.Fatalf("interactive menu quit: %v\nstderr: %s", err, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "openbanking") {
+		t.Errorf("expected the menu header on stderr:\n%s", errOut.String())
+	}
+}
+
+func TestInteractiveMenuRunsChosenCommand(t *testing.T) {
+	var out, errOut bytes.Buffer
+	app := newApp(t, &out, &errOut)
+	// Option 1 is Accounts; selecting it dispatches the accounts command.
+	app.env = ui.Custom(strings.NewReader("1\n"), &out, &errOut, ui.FormatTable, false, true)
+	if err := app.Run(nil); err != nil {
+		t.Fatalf("interactive menu run: %v\nstderr: %s", err, errOut.String())
+	}
+	if !strings.Contains(out.String(), "Lunar") {
+		t.Errorf("expected accounts output after choosing it from the menu:\n%s", out.String())
+	}
+}
+
+func TestParseGlobals(t *testing.T) {
+	rest, opt, err := parseGlobals([]string{"-o", "json", "transactions", "acct-1", "--no-color", "--from", "2026-01-01"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opt.output != "json" || !opt.noColor {
+		t.Errorf("globals not parsed: %+v", opt)
+	}
+	want := []string{"transactions", "acct-1", "--from", "2026-01-01"}
+	if strings.Join(rest, " ") != strings.Join(want, " ") {
+		t.Errorf("rest = %v, want %v", rest, want)
+	}
+}

--- a/cli/internal/config/state.go
+++ b/cli/internal/config/state.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// State is CLI-local, non-secret UI state — chiefly the "current account" that transactions and
+// sync default to. It is deliberately kept out of the credentials Bundle: the Bundle is the SDK's
+// CredentialsBundle struct (consumed by the SDK too), so adding fields there would be fragile.
+type State struct {
+	CurrentAccountID string `json:"currentAccountId,omitempty"`
+}
+
+// StatePath returns the state file path: state.json beside the credentials file. Deriving it from
+// the credentials path (rather than re-resolving DefaultPath) means OPENBANKING_CONFIG overrides and
+// test temp directories are honored automatically.
+func StatePath(credentialsPath string) string {
+	return filepath.Join(filepath.Dir(credentialsPath), "state.json")
+}
+
+// LoadState reads CLI state stored beside the credentials file. A missing file is not an error — it
+// just means no current account has been chosen yet, so the zero State is returned.
+func LoadState(credentialsPath string) (State, error) {
+	path := StatePath(credentialsPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return State{}, nil
+		}
+		return State{}, fmt.Errorf("could not read state at %s: %w", path, err)
+	}
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		return State{}, fmt.Errorf("could not parse state at %s: %w", path, err)
+	}
+	return s, nil
+}
+
+// SaveState writes CLI state beside the credentials file. It sits next to secrets, so it is written
+// 0600 with its directory created 0700, matching Save.
+func SaveState(credentialsPath string, s State) error {
+	path := StatePath(credentialsPath)
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("could not create config directory: %w", err)
+		}
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("could not encode state: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("could not write state to %s: %w", path, err)
+	}
+	return nil
+}

--- a/cli/internal/config/state_test.go
+++ b/cli/internal/config/state_test.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestStatePathIsSiblingOfCredentials(t *testing.T) {
+	creds := filepath.Join("/tmp", "open-banking", "credentials.json")
+	want := filepath.Join("/tmp", "open-banking", "state.json")
+	if got := StatePath(creds); got != want {
+		t.Errorf("StatePath = %q, want %q", got, want)
+	}
+}
+
+func TestLoadStateMissingIsZero(t *testing.T) {
+	creds := filepath.Join(t.TempDir(), "credentials.json")
+	s, err := LoadState(creds)
+	if err != nil {
+		t.Fatalf("LoadState on missing file: %v", err)
+	}
+	if s.CurrentAccountID != "" {
+		t.Errorf("expected zero State, got %+v", s)
+	}
+}
+
+func TestSaveLoadStateRoundTrip(t *testing.T) {
+	creds := filepath.Join(t.TempDir(), "credentials.json")
+	if err := SaveState(creds, State{CurrentAccountID: "acct-123"}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	s, err := LoadState(creds)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if s.CurrentAccountID != "acct-123" {
+		t.Errorf("CurrentAccountID = %q, want acct-123", s.CurrentAccountID)
+	}
+}

--- a/cli/internal/ui/color.go
+++ b/cli/internal/ui/color.go
@@ -1,0 +1,113 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Style is a semantic role for a piece of text. The concrete ANSI code is chosen by the theme, so
+// commands describe meaning ("this is a negative amount") rather than a color.
+type Style int
+
+const (
+	StyleNone Style = iota
+	StyleHeader
+	StylePositive
+	StyleNegative
+	StyleStatusOK
+	StyleStatusWarn
+	StyleError
+	StyleSuccess
+	StyleMuted
+)
+
+const (
+	ansiReset  = "\x1b[0m"
+	ansiBold   = "\x1b[1m"
+	ansiDim    = "\x1b[2m"
+	ansiRed    = "\x1b[31m"
+	ansiGreen  = "\x1b[32m"
+	ansiYellow = "\x1b[33m"
+	ansiCyan   = "\x1b[36m"
+)
+
+func styleCode(s Style) string {
+	switch s {
+	case StyleHeader:
+		return ansiBold + ansiCyan
+	case StylePositive, StyleStatusOK, StyleSuccess:
+		return ansiGreen
+	case StyleNegative, StyleError:
+		return ansiRed
+	case StyleStatusWarn:
+		return ansiYellow
+	case StyleMuted:
+		return ansiDim
+	default:
+		return ""
+	}
+}
+
+// Color wraps s in the ANSI codes for style when color is enabled; otherwise it returns s unchanged
+// so the same call site works in both colored and plain (piped, NO_COLOR) output.
+func (e *Env) Color(s string, style Style) string {
+	if !e.color || style == StyleNone || s == "" {
+		return s
+	}
+	code := styleCode(style)
+	if code == "" {
+		return s
+	}
+	return code + s + ansiReset
+}
+
+// AmountStyle colors a monetary amount by direction: a leading minus (money out) is red, anything
+// else green. Matches the presentation-edge signing used by the transactions view.
+func AmountStyle(amount string) Style {
+	if strings.HasPrefix(strings.TrimSpace(amount), "-") {
+		return StyleNegative
+	}
+	return StylePositive
+}
+
+// StatusStyle colors a connection/transaction status: healthy states green, problem states red,
+// everything else neutral. The match is case-insensitive and tolerant of unknown values.
+func StatusStyle(status string) Style {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "ok", "active", "booked", "valid", "connected", "ready":
+		return StyleStatusOK
+	case "expired", "error", "failed", "revoked", "rejected", "suspended":
+		return StyleNegative
+	case "", "-":
+		return StyleNone
+	default:
+		return StyleStatusWarn
+	}
+}
+
+// Successf prints a success line to Stderr — green with a check mark when color is on, plain text
+// otherwise. Status chatter goes to Stderr so Stdout stays a clean data channel for piping.
+func (e *Env) Successf(format string, a ...any) {
+	msg := fmt.Sprintf(format, a...)
+	if e.color {
+		fmt.Fprintln(e.err(), e.Color("✓ "+msg, StyleSuccess))
+		return
+	}
+	fmt.Fprintln(e.err(), msg)
+}
+
+// Infof prints a neutral informational line to Stderr (dim when color is on).
+func (e *Env) Infof(format string, a ...any) {
+	msg := fmt.Sprintf(format, a...)
+	fmt.Fprintln(e.err(), e.Color(msg, StyleMuted))
+}
+
+// Errorf prints an error line to Stderr — red with a cross when color is on, plain text otherwise.
+func (e *Env) Errorf(format string, a ...any) {
+	msg := fmt.Sprintf(format, a...)
+	if e.color {
+		fmt.Fprintln(e.err(), e.Color("✗ "+msg, StyleError))
+		return
+	}
+	fmt.Fprintln(e.err(), msg)
+}

--- a/cli/internal/ui/env.go
+++ b/cli/internal/ui/env.go
@@ -1,0 +1,127 @@
+// Package ui holds the CLI's presentation primitives: terminal detection, color theming, loading
+// spinners, interactive selectors, and multi-format (table/json/csv) rendering. Everything degrades
+// gracefully when the streams are not terminals (pipes, tests), so output stays clean and scriptable.
+package ui
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// Format is an output rendering format chosen by the global --output/-o flag.
+type Format int
+
+const (
+	// FormatTable is the human-friendly aligned table (the default on a terminal).
+	FormatTable Format = iota
+	// FormatJSON emits a stable, CLI-shaped JSON document (the default when stdout is piped).
+	FormatJSON
+	// FormatCSV emits comma-separated rows for spreadsheets.
+	FormatCSV
+)
+
+// Env carries the resolved output environment for one CLI invocation: where to write, which format
+// to render, and whether color and interactivity are available. It is built once (by Resolve) and
+// threaded onto App, so commands never reach for process globals.
+type Env struct {
+	Stdout io.Writer
+	Stderr io.Writer
+	Stdin  io.Reader
+
+	Format Format
+	color  bool // styled output is both wanted and possible
+	outTTY bool // Stdout is a terminal
+	errTTY bool // Stderr is a terminal (gates spinners and interactive prompts)
+	inTTY  bool // Stdin is a terminal (gates the arrow-key selector)
+}
+
+// Resolve computes the output environment from the streams and the global flags. outFmt is the raw
+// --output value: "" means auto (table on a terminal, json when piped). An unknown value is an error.
+func Resolve(stdout, stderr io.Writer, stdin io.Reader, outFmt string, noColor bool) (*Env, error) {
+	e := &Env{
+		Stdout: stdout,
+		Stderr: stderr,
+		Stdin:  stdin,
+		outTTY: isTerminal(stdout),
+		errTTY: isTerminal(stderr),
+		inTTY:  isTerminal(stdin),
+	}
+
+	switch strings.ToLower(strings.TrimSpace(outFmt)) {
+	case "":
+		if e.outTTY {
+			e.Format = FormatTable
+		} else {
+			e.Format = FormatJSON
+		}
+	case "table":
+		e.Format = FormatTable
+	case "json":
+		e.Format = FormatJSON
+	case "csv":
+		e.Format = FormatCSV
+	default:
+		return nil, fmt.Errorf("unknown output format %q (use table, json, or csv)", outFmt)
+	}
+
+	e.color = !noColor && os.Getenv("NO_COLOR") == "" && e.outTTY
+	return e, nil
+}
+
+// Custom builds an Env with explicit settings, bypassing terminal detection. It exists for callers
+// that already know their environment — chiefly tests, which need deterministic color and an
+// interactive flag they can drive against in-memory buffers.
+func Custom(stdin io.Reader, stdout, stderr io.Writer, f Format, color, interactive bool) *Env {
+	return &Env{
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+		Format: f,
+		color:  color,
+		outTTY: interactive,
+		errTTY: interactive,
+		inTTY:  interactive,
+	}
+}
+
+// Interactive reports whether the user can be prompted for input (stdin is a terminal). Callers use
+// it to decide between opening a picker and returning a "pass the value explicitly" error.
+func (e *Env) Interactive() bool { return e.inTTY }
+
+// Colored reports whether styled output is enabled.
+func (e *Env) Colored() bool { return e.color }
+
+func (e *Env) out() io.Writer {
+	if e.Stdout == nil {
+		return io.Discard
+	}
+	return e.Stdout
+}
+
+func (e *Env) err() io.Writer {
+	if e.Stderr == nil {
+		return io.Discard
+	}
+	return e.Stderr
+}
+
+func (e *Env) in() io.Reader {
+	if e.Stdin == nil {
+		return strings.NewReader("")
+	}
+	return e.Stdin
+}
+
+// isTerminal reports whether v is backed by a terminal file descriptor. A *bytes.Buffer (tests) or
+// any non-file stream has no Fd, so it is reported non-interactive — keeping tests deterministic.
+func isTerminal(v any) bool {
+	f, ok := v.(interface{ Fd() uintptr })
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
+}

--- a/cli/internal/ui/render.go
+++ b/cli/internal/ui/render.go
@@ -1,0 +1,116 @@
+package ui
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Cell is one rendered table value plus an optional semantic style applied when color is enabled.
+type Cell struct {
+	Text  string
+	Style Style
+}
+
+// Table is a tabular view: column headers and rows of cells aligned to those headers. It drives the
+// table and csv formats; JSON is rendered from a separate, CLI-shaped view value.
+type Table struct {
+	Headers []string
+	Rows    [][]Cell
+	// Note is an optional human summary printed after the table (table format only, e.g. "12 shown").
+	Note string
+}
+
+// Row is a small helper to build a row from plain strings (no styling).
+func Row(values ...string) []Cell {
+	cells := make([]Cell, len(values))
+	for i, v := range values {
+		cells[i] = Cell{Text: v}
+	}
+	return cells
+}
+
+// Render writes data in the environment's selected format. table supplies headers/rows for the
+// table and csv formats; view is the value marshalled for json (a CLI-shaped struct, never the raw
+// SDK types, so the JSON contract stays stable and free of PascalCase noise).
+func (e *Env) Render(table Table, view any) error {
+	switch e.Format {
+	case FormatJSON:
+		enc := json.NewEncoder(e.out())
+		enc.SetIndent("", "  ")
+		return enc.Encode(view)
+	case FormatCSV:
+		return e.renderCSV(table)
+	default:
+		return e.renderTable(table)
+	}
+}
+
+// renderTable lays out columns by hand (rather than text/tabwriter) so ANSI color codes, which would
+// otherwise inflate the measured width, never break alignment: widths are computed from plain text
+// and color is applied only to the visible content, with padding added afterwards.
+func (e *Env) renderTable(t Table) error {
+	w := e.out()
+	cols := len(t.Headers)
+	widths := make([]int, cols)
+	for i, h := range t.Headers {
+		widths[i] = utf8.RuneCountInString(h)
+	}
+	for _, row := range t.Rows {
+		for i := 0; i < cols && i < len(row); i++ {
+			if n := utf8.RuneCountInString(row[i].Text); n > widths[i] {
+				widths[i] = n
+			}
+		}
+	}
+
+	const gap = 2
+	var sb strings.Builder
+	writeRow := func(cells func(i int) (string, Style)) {
+		sb.Reset()
+		for i := 0; i < cols; i++ {
+			text, style := cells(i)
+			sb.WriteString(e.Color(text, style))
+			if i < cols-1 {
+				sb.WriteString(strings.Repeat(" ", widths[i]-utf8.RuneCountInString(text)+gap))
+			}
+		}
+		fmt.Fprintln(w, strings.TrimRight(sb.String(), " "))
+	}
+
+	writeRow(func(i int) (string, Style) { return t.Headers[i], StyleHeader })
+	for _, row := range t.Rows {
+		writeRow(func(i int) (string, Style) {
+			if i < len(row) {
+				return row[i].Text, row[i].Style
+			}
+			return "", StyleNone
+		})
+	}
+	if t.Note != "" {
+		fmt.Fprintf(w, "\n%s\n", e.Color(t.Note, StyleMuted))
+	}
+	return nil
+}
+
+func (e *Env) renderCSV(t Table) error {
+	cw := csv.NewWriter(e.out())
+	if err := cw.Write(t.Headers); err != nil {
+		return err
+	}
+	for _, row := range t.Rows {
+		rec := make([]string, len(t.Headers))
+		for i := range rec {
+			if i < len(row) {
+				rec[i] = row[i].Text
+			}
+		}
+		if err := cw.Write(rec); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}

--- a/cli/internal/ui/select.go
+++ b/cli/internal/ui/select.go
@@ -1,0 +1,172 @@
+package ui
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/term"
+)
+
+// Option is one selectable entry. Label is shown to the user; Value is returned when it is chosen.
+type Option struct {
+	Label string
+	Value string
+}
+
+var (
+	// ErrCancelled is returned when the user aborts a selection (Ctrl-C, q, or empty input).
+	ErrCancelled = errors.New("selection cancelled")
+	// ErrNoInput is returned when there is no input available to read a selection from.
+	ErrNoInput = errors.New("no input available to make a selection")
+)
+
+// Select asks the user to choose one of opts. With a real terminal on Stdin and Stderr it draws an
+// interactive arrow-key list; otherwise (or if raw mode can't be enabled) it falls back to a
+// numbered prompt read from Stdin. All prompting and echo go to Stderr, so Stdout stays a clean
+// channel for piped data. Callers should gate the interactive path with Interactive() when they
+// want a hard error in non-terminal contexts instead of consuming stdin.
+func (e *Env) Select(title string, opts []Option) (Option, error) {
+	if len(opts) == 0 {
+		return Option{}, fmt.Errorf("nothing to choose from")
+	}
+	if e.inTTY && e.errTTY {
+		if opt, ok, err := e.selectArrow(title, opts); ok {
+			return opt, err
+		}
+		// Raw mode unavailable on these streams — fall through to the numbered prompt.
+	}
+	return e.selectNumbered(title, opts)
+}
+
+// selectArrow runs the raw-mode arrow-key picker. The bool result reports whether the picker ran;
+// false means raw mode could not be enabled (e.g. Stdin is not a real file) and the caller should
+// fall back. The terminal is always restored, including on SIGINT/SIGTERM.
+func (e *Env) selectArrow(title string, opts []Option) (Option, bool, error) {
+	f, ok := e.Stdin.(interface{ Fd() uintptr })
+	if !ok {
+		return Option{}, false, nil
+	}
+	fd := int(f.Fd())
+	oldState, err := term.MakeRaw(fd)
+	if err != nil {
+		return Option{}, false, nil
+	}
+	defer term.Restore(fd, oldState)
+
+	// Safety net: if a signal arrives while the terminal is raw, restore it and exit cleanly rather
+	// than leaving the user's shell in a broken state.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	guardDone := make(chan struct{})
+	defer close(guardDone)
+	go func() {
+		select {
+		case <-sigCh:
+			term.Restore(fd, oldState)
+			fmt.Fprint(e.err(), "\r\n")
+			os.Exit(130)
+		case <-guardDone:
+		}
+	}()
+
+	reader := bufio.NewReader(e.Stdin)
+	selected := 0
+	lines := len(opts) + 1 // title row + one row per option (the hint shares the final cursor line)
+	first := true
+	repaint := func() {
+		if !first {
+			fmt.Fprintf(e.err(), "\r\x1b[%dA", lines)
+		}
+		first = false
+		e.drawMenu(title, opts, selected)
+	}
+	clear := func() { fmt.Fprintf(e.err(), "\r\x1b[%dA\x1b[J", lines) }
+
+	repaint()
+	for {
+		b, err := reader.ReadByte()
+		if err != nil {
+			clear()
+			return Option{}, true, ErrCancelled
+		}
+		switch b {
+		case '\r', '\n':
+			clear()
+			return opts[selected], true, nil
+		case 3, 'q', 'Q': // Ctrl-C or quit
+			clear()
+			return Option{}, true, ErrCancelled
+		case 'k': // vim up
+			selected = (selected - 1 + len(opts)) % len(opts)
+			repaint()
+		case 'j': // vim down
+			selected = (selected + 1) % len(opts)
+			repaint()
+		case 27: // ESC — start of an arrow-key sequence
+			b2, err := reader.ReadByte()
+			if err != nil || b2 != '[' {
+				continue
+			}
+			b3, err := reader.ReadByte()
+			if err != nil {
+				continue
+			}
+			switch b3 {
+			case 'A': // up
+				selected = (selected - 1 + len(opts)) % len(opts)
+				repaint()
+			case 'B': // down
+				selected = (selected + 1) % len(opts)
+				repaint()
+			}
+		}
+	}
+}
+
+// drawMenu paints the title, the options with the current one highlighted, and a key hint. In raw
+// mode line breaks must be explicit \r\n, and each line is cleared to the right (\x1b[K) so a
+// shorter repaint can't leave stale characters behind.
+func (e *Env) drawMenu(title string, opts []Option, selected int) {
+	w := e.err()
+	fmt.Fprintf(w, "\r%s\x1b[K\r\n", e.Color(title, StyleHeader))
+	for i, opt := range opts {
+		if i == selected {
+			fmt.Fprintf(w, "%s%s\x1b[K\r\n", e.Color("❯ ", StyleStatusOK), e.Color(opt.Label, StyleStatusOK))
+		} else {
+			fmt.Fprintf(w, "  %s\x1b[K\r\n", opt.Label)
+		}
+	}
+	fmt.Fprintf(w, "%s\x1b[K", e.Color("  ↑/↓ move · enter select · q cancel", StyleMuted))
+}
+
+// selectNumbered prints a numbered list and reads a choice from Stdin. It is the non-terminal
+// fallback (and what tests drive), so it never needs raw mode.
+func (e *Env) selectNumbered(title string, opts []Option) (Option, error) {
+	w := e.err()
+	fmt.Fprintln(w, e.Color(title, StyleHeader))
+	for i, opt := range opts {
+		fmt.Fprintf(w, "  %s %s\n", e.Color(strconv.Itoa(i+1)+")", StyleMuted), opt.Label)
+	}
+	fmt.Fprint(w, "Enter a number: ")
+
+	line, err := bufio.NewReader(e.in()).ReadString('\n')
+	line = strings.TrimSpace(line)
+	if line == "" {
+		if err != nil {
+			return Option{}, ErrNoInput
+		}
+		return Option{}, ErrCancelled
+	}
+	n, convErr := strconv.Atoi(line)
+	if convErr != nil || n < 1 || n > len(opts) {
+		return Option{}, fmt.Errorf("invalid selection %q (choose 1-%d)", line, len(opts))
+	}
+	return opts[n-1], nil
+}

--- a/cli/internal/ui/spinner.go
+++ b/cli/internal/ui/spinner.go
@@ -1,0 +1,48 @@
+package ui
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// Spinner starts an animated spinner on Stderr with the given label and returns a stop function.
+// When Stderr is not a terminal (tests, pipes) the spinner is a no-op and stop does nothing, so
+// stdout stays clean and captured test output is undisturbed. stop is safe to call more than once;
+// it waits for the animation goroutine to exit before clearing the line, so no stray frame can be
+// written afterwards.
+func (e *Env) Spinner(label string) (stop func()) {
+	if !e.errTTY {
+		return func() {}
+	}
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		ticker := time.NewTicker(90 * time.Millisecond)
+		defer ticker.Stop()
+		paint := func(i int) {
+			frame := e.Color(spinnerFrames[i%len(spinnerFrames)], StyleStatusOK)
+			fmt.Fprintf(e.err(), "\r%s %s", frame, label)
+		}
+		paint(0)
+		for i := 1; ; i++ {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				paint(i)
+			}
+		}
+	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			close(done)
+			<-finished
+			fmt.Fprint(e.err(), "\r\x1b[K")
+		})
+	}
+}

--- a/cli/internal/ui/ui_test.go
+++ b/cli/internal/ui/ui_test.go
@@ -1,0 +1,213 @@
+package ui
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestResolveFormatPrecedence(t *testing.T) {
+	var buf bytes.Buffer // a buffer is never a terminal
+	cases := []struct {
+		outFmt string
+		want   Format
+	}{
+		{"", FormatJSON}, // non-TTY auto-defaults to json
+		{"table", FormatTable},
+		{"json", FormatJSON},
+		{"csv", FormatCSV},
+		{"TABLE", FormatTable}, // case-insensitive
+	}
+	for _, tc := range cases {
+		e, err := Resolve(&buf, &buf, &buf, tc.outFmt, false)
+		if err != nil {
+			t.Fatalf("Resolve(%q): %v", tc.outFmt, err)
+		}
+		if e.Format != tc.want {
+			t.Errorf("Resolve(%q).Format = %d, want %d", tc.outFmt, e.Format, tc.want)
+		}
+	}
+	if _, err := Resolve(&buf, &buf, &buf, "yaml", false); err == nil {
+		t.Error("expected an error for an unknown output format")
+	}
+}
+
+func TestResolveColorDisabledOnNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	e, _ := Resolve(&buf, &buf, &buf, "table", false)
+	if e.Colored() {
+		t.Error("color must be off when stdout is not a terminal")
+	}
+}
+
+func sampleTable() Table {
+	return Table{
+		Headers: []string{"NAME", "AMOUNT"},
+		Rows: [][]Cell{
+			{{Text: "Drift"}, {Text: "-50.00", Style: StyleNegative}},
+			{{Text: "Salary"}, {Text: "1250.00", Style: StylePositive}},
+		},
+		Note: "2 shown",
+	}
+}
+
+type rowView struct {
+	Name   string `json:"name"`
+	Amount string `json:"amount"`
+}
+
+func TestRenderTableAligns(t *testing.T) {
+	var out bytes.Buffer
+	e := Custom(nil, &out, &out, FormatTable, false, false)
+	if err := e.Render(sampleTable(), nil); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{"NAME", "AMOUNT", "Drift", "-50.00", "2 shown"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("table output missing %q\n%s", want, got)
+		}
+	}
+	// No ANSI escapes when color is off.
+	if strings.Contains(got, "\x1b[") {
+		t.Errorf("unexpected ANSI escape in plain table output:\n%q", got)
+	}
+}
+
+func TestRenderTableColorized(t *testing.T) {
+	var out bytes.Buffer
+	e := Custom(nil, &out, &out, FormatTable, true, true)
+	if err := e.Render(sampleTable(), nil); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, ansiRed) || !strings.Contains(got, ansiGreen) {
+		t.Errorf("expected red/green ANSI codes in colorized output:\n%q", got)
+	}
+}
+
+func TestRenderCSV(t *testing.T) {
+	var out bytes.Buffer
+	e := Custom(nil, &out, &out, FormatCSV, false, false)
+	if err := e.Render(sampleTable(), nil); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "NAME,AMOUNT") {
+		t.Errorf("csv missing header row:\n%s", got)
+	}
+	if !strings.Contains(got, "Drift,-50.00") {
+		t.Errorf("csv missing data row:\n%s", got)
+	}
+	if strings.Contains(got, "2 shown") {
+		t.Errorf("csv must not include the table Note:\n%s", got)
+	}
+}
+
+func TestRenderJSONUsesView(t *testing.T) {
+	var out bytes.Buffer
+	e := Custom(nil, &out, &out, FormatJSON, false, false)
+	view := []rowView{{Name: "Drift", Amount: "-50.00"}}
+	if err := e.Render(sampleTable(), view); err != nil {
+		t.Fatal(err)
+	}
+	var back []rowView
+	if err := json.Unmarshal(out.Bytes(), &back); err != nil {
+		t.Fatalf("output is not valid json: %v\n%s", err, out.String())
+	}
+	if len(back) != 1 || back[0].Name != "Drift" || back[0].Amount != "-50.00" {
+		t.Errorf("json round-trip mismatch: %+v", back)
+	}
+	// JSON must come from the view (lowerCamel keys), not the table headers.
+	if strings.Contains(out.String(), "NAME") {
+		t.Errorf("json should use view keys, not table headers:\n%s", out.String())
+	}
+}
+
+func TestSelectNumberedFallback(t *testing.T) {
+	var errOut bytes.Buffer
+	in := strings.NewReader("2\n")
+	e := Custom(in, &bytes.Buffer{}, &errOut, FormatTable, false, false)
+	opts := []Option{{Label: "Checking", Value: "acct-1"}, {Label: "Savings", Value: "acct-2"}}
+	got, err := e.Select("Pick an account", opts)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if got.Value != "acct-2" {
+		t.Errorf("selected %q, want acct-2", got.Value)
+	}
+	if !strings.Contains(errOut.String(), "Pick an account") {
+		t.Errorf("prompt should go to stderr:\n%s", errOut.String())
+	}
+}
+
+func TestSelectNumberedInvalid(t *testing.T) {
+	in := strings.NewReader("9\n")
+	e := Custom(in, &bytes.Buffer{}, &bytes.Buffer{}, FormatTable, false, false)
+	_, err := e.Select("Pick", []Option{{Label: "a", Value: "1"}})
+	if err == nil {
+		t.Fatal("expected an error for an out-of-range selection")
+	}
+}
+
+func TestSelectNumberedEmptyIsNoInput(t *testing.T) {
+	e := Custom(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, FormatTable, false, false)
+	_, err := e.Select("Pick", []Option{{Label: "a", Value: "1"}})
+	if err != ErrNoInput {
+		t.Errorf("got %v, want ErrNoInput", err)
+	}
+}
+
+func TestColorOnlyWhenEnabled(t *testing.T) {
+	off := Custom(nil, &bytes.Buffer{}, &bytes.Buffer{}, FormatTable, false, false)
+	if got := off.Color("x", StyleNegative); got != "x" {
+		t.Errorf("color off should pass text through, got %q", got)
+	}
+	on := Custom(nil, &bytes.Buffer{}, &bytes.Buffer{}, FormatTable, true, true)
+	if got := on.Color("x", StyleNegative); !strings.Contains(got, ansiRed) {
+		t.Errorf("color on should wrap with red, got %q", got)
+	}
+	if got := on.Color("", StyleNegative); got != "" {
+		t.Errorf("empty string should not be colored, got %q", got)
+	}
+}
+
+func TestAmountAndStatusStyle(t *testing.T) {
+	if AmountStyle("-5") != StyleNegative || AmountStyle("5") != StylePositive {
+		t.Error("AmountStyle direction wrong")
+	}
+	if StatusStyle("Active") != StyleStatusOK || StatusStyle("expired") != StyleNegative {
+		t.Error("StatusStyle mapping wrong")
+	}
+	if StatusStyle("pending") != StyleStatusWarn || StatusStyle("") != StyleNone {
+		t.Error("StatusStyle fallback wrong")
+	}
+}
+
+func TestMessageHelpersWriteToStderr(t *testing.T) {
+	var out, errOut bytes.Buffer
+	e := Custom(nil, &out, &errOut, FormatTable, false, false)
+	e.Successf("done %d", 1)
+	e.Errorf("oops")
+	e.Infof("note")
+	if out.Len() != 0 {
+		t.Errorf("messages must not touch stdout, got %q", out.String())
+	}
+	for _, want := range []string{"done 1", "oops", "note"} {
+		if !strings.Contains(errOut.String(), want) {
+			t.Errorf("stderr missing %q:\n%s", want, errOut.String())
+		}
+	}
+}
+
+func TestSpinnerNoopOnNonTTY(t *testing.T) {
+	var errOut bytes.Buffer
+	e := Custom(nil, &bytes.Buffer{}, &errOut, FormatTable, false, false)
+	stop := e.Spinner("working")
+	stop()
+	stop() // safe to call twice
+	if errOut.Len() != 0 {
+		t.Errorf("spinner must be silent on a non-terminal stderr, wrote: %q", errOut.String())
+	}
+}


### PR DESCRIPTION
## What

A full UX overhaul of the `openbanking` CLI — colorized output, loading spinners, interactive pickers, multiple output formats, a remembered current account, short aliases, an interactive menu, and shell completion. **One new dependency** (`golang.org/x/term`); everything else is pure stdlib.

## Highlights

- **Output formats** — global `-o/--output`: `table` (default in a terminal), `json` (default when piped, jq-ready), `csv`. JSON is a stable, CLI-shaped contract with lowerCamel keys — deliberately decoupled from the untagged SDK structs.
- **Color + spinners** — aligned colored tables (green/red amounts, status-aware), animated spinner on every network call. Respects `NO_COLOR` and `--no-color`; auto-off when piped.
- **Current account** — `openbanking use [<id>]` sets or interactively picks a default account; `transactions`/`sync` then need no id (an explicit id always overrides). Stored in a CLI-local `state.json` beside the credentials — never in the SDK bundle, never sent anywhere.
- **Short aliases** — `tx`, `acc`, `ls`, `conn` — plus a no-arg interactive menu in a terminal.
- **Shell completion** — `openbanking completion {bash,zsh,fish}`, generated from a single command table that also drives dispatch and help.

## Design notes

- New `internal/ui` package isolates all presentation: terminal detection, color theme, spinner, interactive selector (arrow-key raw mode with a numbered fallback off-TTY), and the renderer. A `*bytes.Buffer` reports as non-TTY, so tests are fully deterministic with no terminal emulation.
- Dispatch refactored to one `command` table (name, aliases, help, handler) — one source of truth for routing, `help`, and completion. Existing command methods slot in unchanged as method expressions.
- Raw-mode selector restores the terminal on Ctrl-C (defer + signal handler); table color is applied after column widths are computed so ANSI codes never break alignment.

## Behavior changes (intentional)

- **Piped output now defaults to JSON** (better for scripting). The three golden render tests that capture stdout are pinned to `-o table`.
- Bare `openbanking` in a terminal opens the interactive menu; non-interactively it still prints usage and exits non-zero.

## Dependency note

Latest `x/term`/`x/sys` require go 1.25, but CI builds the CLI under **go 1.24 and 1.25** (`ci.yml` matrix). Pinned `x/term` v0.34.0 / `x/sys` v0.35.0 (need only go 1.23) so `cli/go.mod` stays at `go 1.24`.

## Testing

- New tests: globals parsing, table/json/csv rendering, selector numbered fallback, `config.State` round-trip, current-account resolution (explicit / saved / none, TTY vs not), interactive menu, completion scripts.
- Full suite green under `-race`; coverage app 85.8% / config 81.2% / ui 50.9% (the ui gap is the raw-mode arrow path that needs a real PTY). `go vet` + `gofmt` clean.
- Manually smoke-tested end-to-end through a PTY: colored table, spinner, `NO_COLOR`/`--no-color`, `-o json | jq`, `-o csv`, aliases, completion.

## Docs

`cli/README.md` updated with the current-account workflow, output formats, completion, aliases, and the interactive menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)