### PR TITLE
n8n: scope package as @open-banking-io/n8n-nodes-open-banking-io

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -1,4 +1,4 @@
-# n8n-nodes-open-banking-io
+# @open-banking-io/n8n-nodes-open-banking-io
 
 An [n8n](https://n8n.io) community node for [open-banking.io](https://open-banking.io).
 
@@ -25,7 +25,7 @@ built into Node, so it qualifies as a verified n8n community node.
 In n8n, go to **Settings → Community Nodes → Install** and enter:
 
 ```
-n8n-nodes-open-banking-io
+@open-banking-io/n8n-nodes-open-banking-io
 ```
 
 ### Manual / development

--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "n8n-nodes-open-banking-io",
+  "name": "@open-banking-io/n8n-nodes-open-banking-io",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "n8n-nodes-open-banking-io",
+      "name": "@open-banking-io/n8n-nodes-open-banking-io",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
@@ -5625,6 +5625,7 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "n8n-nodes-open-banking-io",
+  "name": "@open-banking-io/n8n-nodes-open-banking-io",
   "version": "0.1.0",
   "description": "n8n community node for open-banking.io: API-key auth with client-side, zero-knowledge decryption of your bank accounts, balances and transactions.",
   "license": "MIT",


### PR DESCRIPTION
Follow-up to #51.

Publishing the unscoped `n8n-nodes-open-banking-io` failed with `E404` on the registry PUT: the org npm token can create `@open-banking-io/*` packages but not arbitrary unscoped names (the run signed provenance fine, then 404'd on PUT — npm's obscured "no permission to create" response).

Scoping the package to **`@open-banking-io/n8n-nodes-open-banking-io`**:
- works with the existing org token (same as the other 8 clients),
- still satisfies n8n's verified-node naming rule (`@scope/n8n-nodes-*`),
- and the publish workflow already passes `--access public` for the scoped package.

Changes: package name in `package.json` + `package-lock.json`, and the install name in the README. No code changes.