### PR TITLE
n8n: release 0.1.1 with npm provenance (CI publish)

### DIFF
--- a/.github/workflows/publish-n8n.yml
+++ b/.github/workflows/publish-n8n.yml
@@ -38,5 +38,9 @@ jobs:
       - run: npm ci --ignore-scripts
       - run: npm run build
       - run: npm install -g npm@latest
-      # Provenance via OIDC — required for n8n verified-community-node submission.
+      # Provenance via OIDC (id-token: write) — required for n8n verified-community-node
+      # submission. Auth uses NODE_AUTH_TOKEN; replace with npm trusted publishing once the
+      # package has a trusted publisher configured on npmjs.
       - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/n8n/nodes/OpenBankingIo/OpenBankingIo.node.ts
+++ b/n8n/nodes/OpenBankingIo/OpenBankingIo.node.ts
@@ -64,7 +64,6 @@ export class OpenBankingIo implements INodeType {
 				default: 'transaction',
 			},
 
-			// ---- Account ----
 			{
 				displayName: 'Operation',
 				name: 'operation',
@@ -82,7 +81,6 @@ export class OpenBankingIo implements INodeType {
 				default: 'getMany',
 			},
 
-			// ---- Transaction ----
 			{
 				displayName: 'Operation',
 				name: 'operation',
@@ -154,7 +152,6 @@ export class OpenBankingIo implements INodeType {
 				],
 			},
 
-			// ---- Connection ----
 			{
 				displayName: 'Operation',
 				name: 'operation',
@@ -172,7 +169,6 @@ export class OpenBankingIo implements INodeType {
 				default: 'getMany',
 			},
 
-			// ---- Bank ----
 			{
 				displayName: 'Operation',
 				name: 'operation',
@@ -199,7 +195,6 @@ export class OpenBankingIo implements INodeType {
 				description: 'Optional ISO 3166 country code to filter banks by',
 			},
 
-			// ---- Sync ----
 			{
 				displayName: 'Operation',
 				name: 'operation',

--- a/n8n/nodes/OpenBankingIo/shared/client.ts
+++ b/n8n/nodes/OpenBankingIo/shared/client.ts
@@ -93,8 +93,6 @@ export function importBundleKey(bundle: Bundle): Promise<PrivateKey> {
 	return importPrivateKey(bundle.privateKey);
 }
 
-// ---- Decryption mappers (ports of the SDK client's private mappers) -----------------------------
-
 export async function mapAccount(key: PrivateKey, a: AccountWire): Promise<Account> {
 	const acc = await decryptTo<AccountEnc>(key, a.enc);
 	const name = await decryptTo<DisplayNameEnc>(key, a.displayNameEnc);
@@ -177,8 +175,6 @@ export async function decryptUid(key: PrivateKey, a: AccountWire): Promise<strin
 	const dec = await decryptTo<UidEnc>(key, a.uidEnc);
 	return dec?.uid ?? null;
 }
-
-// ---- Pagination ---------------------------------------------------------------------------------
 
 /**
  * Collects transaction wires by looping the offset/limit window until the server's reported total

--- a/n8n/nodes/OpenBankingIo/shared/models.ts
+++ b/n8n/nodes/OpenBankingIo/shared/models.ts
@@ -4,8 +4,6 @@
 //
 // Monetary amounts are decimal STRINGS throughout — never parse them to floats.
 
-// ---- Public, decrypted models -------------------------------------------------------------------
-
 export interface Account {
 	id: string;
 	aspspName: string;
@@ -28,7 +26,6 @@ export interface Account {
 export interface Balance {
 	type: string;
 	name: string | null;
-	/** Decimal as a string — never parsed to float. */
 	amount: string;
 	currency: string;
 	referenceDate: string | null;
@@ -44,7 +41,6 @@ export interface Transaction {
 	transactionDate: string | null;
 	bankTransactionCode: string | null;
 
-	/** Decimal as a string — never parsed to float. */
 	amount: string;
 	creditorName: string | null;
 	creditorIban: string | null;
@@ -88,8 +84,6 @@ export interface SyncAllResult {
 	accounts: number;
 	newTransactions: number;
 }
-
-// ---- Wire DTOs (what the API returns; sensitive fields are ciphertext) ---------------------------
 
 export interface AccountWire {
 	id: string;
@@ -155,8 +149,6 @@ export interface Bank {
 	country: string;
 	[key: string]: unknown;
 }
-
-// ---- Decrypted envelope payloads (the camelCase contract with the backend) -----------------------
 
 export interface AccountEnc {
 	ownerName?: string | null;

--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-banking-io/n8n-nodes-open-banking-io",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-banking-io/n8n-nodes-open-banking-io",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-banking-io/n8n-nodes-open-banking-io",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "n8n community node for open-banking.io: API-key auth with client-side, zero-knowledge decryption of your bank accounts, balances and transactions.",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Bumps the n8n node to 0.1.1 and wires `NODE_AUTH_TOKEN` into the publish step so the GitHub Actions `npm publish --provenance` authenticates. 0.1.0 was published locally (no provenance), which n8n verification rejects; 0.1.1 will be published via CI with a provenance statement. After merge, releasing `n8n/v0.1.1` triggers the provenance publish.