### PR TITLE
n8n: add author email

### DIFF
--- a/n8n/package.json
+++ b/n8n/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "author": {
     "name": "open-banking.io",
+    "email": "info@open-banking.io",
     "url": "https://open-banking.io"
   },
   "homepage": "https://open-banking.io",


### PR DESCRIPTION
Adds `info@open-banking.io` to the package `author` field. Metadata-only; takes effect on the next publish.