### PR TITLE
n8n: fix verified-scanner violations (0.1.4)

### DIFF
--- a/n8n/nodes/OpenBankingIo/shared/envelope.ts
+++ b/n8n/nodes/OpenBankingIo/shared/envelope.ts
@@ -3,10 +3,10 @@
 // This is a self-contained port of the @open-banking-io/client `envelope.ts`. It
 // deliberately uses ZERO runtime dependencies and avoids `node:crypto` and `Buffer`
 // so the package passes n8n's verified-community-node scan: it relies only on the
-// Web Crypto API exposed as the `globalThis.crypto.subtle` global (present in n8n's
-// Node 20+ runtime) and an `atob`-based base64 decoder.
+// Web Crypto API exposed as the `crypto.subtle` global (present in n8n's Node 20+
+// runtime) and an `atob`-based base64 decoder.
 
-const subtle = globalThis.crypto.subtle;
+const subtle = crypto.subtle;
 
 /** Web Crypto key handle, aliased so we don't import a DOM/node type. */
 export type PrivateKey = Awaited<ReturnType<typeof subtle.importKey>>;

--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-banking-io/n8n-nodes-open-banking-io",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-banking-io/n8n-nodes-open-banking-io",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-banking-io/n8n-nodes-open-banking-io",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "n8n community node for open-banking.io: API-key auth with client-side, zero-knowledge decryption of your bank accounts, balances and transactions.",
   "license": "MIT",
   "author": {
@@ -20,7 +20,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/open-banking-io/clients"
+    "url": "https://github.com/open-banking-io/clients",
+    "directory": "n8n"
   },
   "engines": {
     "node": ">=20.15"
@@ -50,6 +51,9 @@
   "files": [
     "dist"
   ],
+  "peerDependencies": {
+    "n8n-workflow": "*"
+  },
   "devDependencies": {
     "@types/node": "^22.10.0",
     "@typescript-eslint/parser": "^8.61.0",


### PR DESCRIPTION
Resolves the two `@n8n/scan-community-package` ESLint errors (globalThis→crypto, add peerDependencies) and adds `repository.directory: "n8n"` so n8n finds the credential/node source in this monorepo. Verified locally against the scanner's recommended config — clean.