### PR TITLE
python: bump dependencies

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,17 +12,17 @@ license = { text = "MIT" }
 authors = [{ name = "open-banking.io" }]
 keywords = ["open-banking", "psd2", "banking", "zero-knowledge", "ecdh"]
 dependencies = [
-    "cryptography>=42.0",
-    "httpx>=0.27",
+    "cryptography>=49.0",
+    "httpx>=0.28",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0",
-    "pytest-httpserver>=1.0",
-    "pytest-cov>=5.0",
-    "ruff>=0.6",
-    "mypy>=1.11",
+    "pytest>=9.0",
+    "pytest-httpserver>=1.1",
+    "pytest-cov>=7.0",
+    "ruff>=0.15",
+    "mypy>=2.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Bumps the dependency floors for the `open-banking-io` Python package. Only `python/pyproject.toml` is touched. The package's own published `version` is unchanged.

## Version changes

| Dependency | Old floor | New floor | Scope |
|---|---|---|---|
| cryptography | >=42.0 | >=49.0 | runtime |
| httpx | >=0.27 | >=0.28 | runtime |
| pytest | >=8.0 | >=9.0 | dev |
| pytest-cov | >=5.0 | >=7.0 | dev |
| pytest-httpserver | >=1.0 | >=1.1 | dev |
| ruff | >=0.6 | >=0.15 | dev |
| mypy | >=1.11 | >=2.0 | dev |

## Heads-up: cryptography minimum-version trade-off

The runtime floor for **cryptography** jumps a major version range (42.0 -> **49.0**). This narrows the documented minimum supported version considerably: consumers pinned to older `cryptography` (anything <49.0) will no longer satisfy this package's requirement. If that's too aggressive for the supported install base, the floor can be dialed back (e.g. to >=44 or wherever the actual API needs land) without affecting the rest of this PR — the package code does not rely on any 49-specific API.

## Config changes for the dev-tool majors

None required. pytest 9, pytest-cov 7, and mypy 2 are all majors, but no changes to `[tool.pytest.*]`, `[tool.coverage.*]`, `[tool.mypy]`, or any source/test code were needed — existing config and code are clean under the new versions.

## Verification

Installed with `pip install -e ".[dev]"` in a fresh venv (Python 3.11), resolving: cryptography 49.0.0, httpx 0.28.1, pytest 9.1.0, pytest-cov 7.1.0, pytest-httpserver 1.1.5, ruff 0.15.17, mypy 2.1.0.

- `pytest`: **50 passed**
- `ruff check .`: **All checks passed**
- `mypy` (strict, src): **Success: no issues found in 4 source files**
