### PR TITLE
dotnet: bump coverlet.collector to 10.0.1

### DIFF
--- a/dotnet/tests/OpenBankingIO.Client.Tests/OpenBankingIO.Client.Tests.csproj
+++ b/dotnet/tests/OpenBankingIO.Client.Tests/OpenBankingIO.Client.Tests.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary

Bumps the test project's coverage collector dependency (major version upgrade).

| Package | Old | New |
| --- | --- | --- |
| `coverlet.collector` | 6.0.4 | 10.0.1 |

Other test deps (`Microsoft.NET.Test.Sdk` 18.6.0, `xunit` 2.9.3, `xunit.runner.visualstudio` 3.1.5) are already latest and left unchanged. The production `OpenBankingIO.Client.csproj` has no PackageReferences. The published package version is unchanged.

## Verification

- `dotnet restore` — succeeded
- `dotnet build` — succeeded, 0 warnings, 0 errors
- `dotnet test --collect:"XPlat Code Coverage"` — Passed! 41/41 tests, 0 failed/skipped; coverage collection works with coverlet 10 (cobertura report emitted successfully)