### PR TITLE
n8n(mirror): publish in Production environment

### DIFF
--- a/n8n/.github/workflows/publish.yml
+++ b/n8n/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: Production
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
The npm trusted publisher for open-banking-io/n8n is scoped to environment Production, so the mirror's publish.yml must run in that environment for the OIDC claim to match.