### PR TITLE
ci: skip per-package builds when the package is unchanged

### DIFF
--- a/.github/actions/changed-packages/action.yml
+++ b/.github/actions/changed-packages/action.yml
@@ -1,0 +1,51 @@
+name: Detect changed packages
+description: >-
+  Path-filter which client packages are affected by a change. A package is
+  affected by its own dir, by shared test fixtures, or by any CI infra change
+  (workflows / composite actions) — so editing CI re-runs everything.
+
+outputs:
+  dotnet:
+    description: Whether the dotnet package is affected
+    value: ${{ steps.filter.outputs.dotnet }}
+  node:
+    description: Whether the node package is affected
+    value: ${{ steps.filter.outputs.node }}
+  n8n:
+    description: Whether the n8n package is affected
+    value: ${{ steps.filter.outputs.n8n }}
+  python:
+    description: Whether the python package is affected
+    value: ${{ steps.filter.outputs.python }}
+  rust:
+    description: Whether the rust package is affected
+    value: ${{ steps.filter.outputs.rust }}
+  java:
+    description: Whether the java package is affected
+    value: ${{ steps.filter.outputs.java }}
+  go:
+    description: Whether the go package is affected
+    value: ${{ steps.filter.outputs.go }}
+  ruby:
+    description: Whether the ruby package is affected
+    value: ${{ steps.filter.outputs.ruby }}
+  php:
+    description: Whether the php package is affected
+    value: ${{ steps.filter.outputs.php }}
+
+runs:
+  using: composite
+  steps:
+    - id: filter
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      with:
+        filters: |
+          dotnet: ['dotnet/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
+          node: ['node/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
+          n8n: ['n8n/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
+          python: ['python/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
+          rust: ['rust/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
+          java: ['java/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
+          go: ['go/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
+          ruby: ['ruby/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
+          php: ['php/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,54 +12,38 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      dotnet: ${{ steps.filter.outputs.dotnet }}
-      node: ${{ steps.filter.outputs.node }}
-      n8n: ${{ steps.filter.outputs.n8n }}
-      python: ${{ steps.filter.outputs.python }}
-      rust: ${{ steps.filter.outputs.rust }}
-      java: ${{ steps.filter.outputs.java }}
-      go: ${{ steps.filter.outputs.go }}
-      ruby: ${{ steps.filter.outputs.ruby }}
-      php: ${{ steps.filter.outputs.php }}
+      dotnet: ${{ steps.cp.outputs.dotnet }}
+      node: ${{ steps.cp.outputs.node }}
+      n8n: ${{ steps.cp.outputs.n8n }}
+      python: ${{ steps.cp.outputs.python }}
+      rust: ${{ steps.cp.outputs.rust }}
+      java: ${{ steps.cp.outputs.java }}
+      go: ${{ steps.cp.outputs.go }}
+      ruby: ${{ steps.cp.outputs.ruby }}
+      php: ${{ steps.cp.outputs.php }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      # A package's steps run when its own dir changes, OR when shared test
-      # fixtures change (they feed every client), OR when this workflow changes.
-      - id: filter
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        with:
-          filters: |
-            dotnet: ['dotnet/**', 'fixtures/**', '.github/workflows/ci.yml']
-            node: ['node/**', 'fixtures/**', '.github/workflows/ci.yml']
-            n8n: ['n8n/**', 'fixtures/**', '.github/workflows/ci.yml']
-            python: ['python/**', 'fixtures/**', '.github/workflows/ci.yml']
-            rust: ['rust/**', 'fixtures/**', '.github/workflows/ci.yml']
-            java: ['java/**', 'fixtures/**', '.github/workflows/ci.yml']
-            go: ['go/**', 'fixtures/**', '.github/workflows/ci.yml']
-            ruby: ['ruby/**', 'fixtures/**', '.github/workflows/ci.yml']
-            php: ['php/**', 'fixtures/**', '.github/workflows/ci.yml']
+      - id: cp
+        uses: ./.github/actions/changed-packages
 
   dotnet:
     needs: changes
+    if: needs.changes.outputs.dotnet == 'true'
     runs-on: ubuntu-latest
     steps:
-      - if: needs.changes.outputs.dotnet == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.dotnet == 'true'
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: |
             8.0.x
             10.0.x
-      - if: needs.changes.outputs.dotnet == 'true'
-        run: dotnet format dotnet/OpenBankingIO.slnx --verify-no-changes
-      - if: needs.changes.outputs.dotnet == 'true'
-        run: dotnet build dotnet/OpenBankingIO.slnx -c Release -warnaserror
-      - if: needs.changes.outputs.dotnet == 'true'
-        run: dotnet test dotnet/ -c Release
+      - run: dotnet format dotnet/OpenBankingIO.slnx --verify-no-changes
+      - run: dotnet build dotnet/OpenBankingIO.slnx -c Release -warnaserror
+      - run: dotnet test dotnet/ -c Release
 
   node:
     needs: changes
+    if: needs.changes.outputs.node == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -68,27 +52,20 @@ jobs:
       run:
         working-directory: node
     steps:
-      - if: needs.changes.outputs.node == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.node == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
-      - if: needs.changes.outputs.node == 'true'
-        run: npm ci
-      - if: needs.changes.outputs.node == 'true'
-        run: npm run lint
-      - if: needs.changes.outputs.node == 'true'
-        run: npm run format:check
-      - if: needs.changes.outputs.node == 'true'
-        run: npm run typecheck
-      - if: needs.changes.outputs.node == 'true'
-        run: npm run build
-      - if: needs.changes.outputs.node == 'true'
-        run: npm test
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format:check
+      - run: npm run typecheck
+      - run: npm run build
+      - run: npm test
 
   n8n:
     needs: changes
+    if: needs.changes.outputs.n8n == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -97,29 +74,22 @@ jobs:
       run:
         working-directory: n8n
     steps:
-      - if: needs.changes.outputs.n8n == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.n8n == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       # --ignore-scripts: the only native dep is isolated-vm (via n8n-workflow's expression
       # sandbox), which we never run and which fails to gyp-build on some Node versions.
-      - if: needs.changes.outputs.n8n == 'true'
-        run: npm ci --ignore-scripts
-      - if: needs.changes.outputs.n8n == 'true'
-        run: npm run lint
-      - if: needs.changes.outputs.n8n == 'true'
-        run: npm run format:check
-      - if: needs.changes.outputs.n8n == 'true'
-        run: npm run typecheck
-      - if: needs.changes.outputs.n8n == 'true'
-        run: npm run build
-      - if: needs.changes.outputs.n8n == 'true'
-        run: npm test
+      - run: npm ci --ignore-scripts
+      - run: npm run lint
+      - run: npm run format:check
+      - run: npm run typecheck
+      - run: npm run build
+      - run: npm test
 
   python:
     needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -128,50 +98,39 @@ jobs:
       run:
         working-directory: python
     steps:
-      - if: needs.changes.outputs.python == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.python == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-      - if: needs.changes.outputs.python == 'true'
-        run: pip install -e .[dev]
-      - if: needs.changes.outputs.python == 'true'
-        run: ruff check .
-      - if: needs.changes.outputs.python == 'true'
-        run: ruff format --check .
-      - if: needs.changes.outputs.python == 'true'
-        run: mypy src
-      - if: needs.changes.outputs.python == 'true'
-        run: pytest -q
+      - run: pip install -e .[dev]
+      - run: ruff check .
+      - run: ruff format --check .
+      - run: mypy src
+      - run: pytest -q
 
   rust:
     needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: rust
     steps:
-      - if: needs.changes.outputs.rust == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.rust == 'true'
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy, rustfmt
-      - if: needs.changes.outputs.rust == 'true'
-        run: cargo fmt --check
-      - if: needs.changes.outputs.rust == 'true'
-        run: cargo clippy --all-targets -- -D warnings
-      - if: needs.changes.outputs.rust == 'true'
-        run: cargo test
-      - if: needs.changes.outputs.rust == 'true'
-        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
+      - run: cargo fmt --check
+      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo test
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
         with:
           manifest-path: rust/Cargo.toml
           command: check advisories bans sources
 
   go:
     needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -180,24 +139,20 @@ jobs:
       run:
         working-directory: go
     steps:
-      - if: needs.changes.outputs.go == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.go == 'true'
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
-      - if: needs.changes.outputs.go == 'true'
-        run: go vet ./...
-      - if: needs.changes.outputs.go == 'true'
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+      - run: go vet ./...
+      - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.12.2
           working-directory: go
-      - if: needs.changes.outputs.go == 'true'
-        run: go test ./...
+      - run: go test ./...
 
   java:
     needs: changes
+    if: needs.changes.outputs.java == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -206,19 +161,17 @@ jobs:
       run:
         working-directory: java
     steps:
-      - if: needs.changes.outputs.java == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.java == 'true'
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: ${{ matrix.java-version }}
           cache: maven
-      - if: needs.changes.outputs.java == 'true'
-        run: mvn -B verify
+      - run: mvn -B verify
 
   ruby:
     needs: changes
+    if: needs.changes.outputs.ruby == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -227,21 +180,18 @@ jobs:
       run:
         working-directory: ruby
     steps:
-      - if: needs.changes.outputs.ruby == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.ruby == 'true'
-        uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
           working-directory: ruby
-      - if: needs.changes.outputs.ruby == 'true'
-        run: bundle exec standardrb
-      - if: needs.changes.outputs.ruby == 'true'
-        run: bundle exec rspec
+      - run: bundle exec standardrb
+      - run: bundle exec rspec
 
   php:
     needs: changes
+    if: needs.changes.outputs.php == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -250,19 +200,33 @@ jobs:
       run:
         working-directory: php
     steps:
-      - if: needs.changes.outputs.php == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.php == 'true'
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-version }}
           extensions: openssl, curl, json
           coverage: pcov
-      - if: needs.changes.outputs.php == 'true'
-        run: composer install --no-interaction --no-progress
-      - if: needs.changes.outputs.php == 'true'
-        run: vendor/bin/phpstan analyse --memory-limit=512M
-      - if: needs.changes.outputs.php == 'true'
-        run: vendor/bin/php-cs-fixer fix --dry-run --diff
-      - if: needs.changes.outputs.php == 'true'
-        run: vendor/bin/phpunit
+      - run: composer install --no-interaction --no-progress
+      - run: vendor/bin/phpstan analyse --memory-limit=512M
+      - run: vendor/bin/php-cs-fixer fix --dry-run --diff
+      - run: vendor/bin/phpunit
+
+  # Aggregate gate: the single required CI status check. Always runs so it
+  # reports even when language jobs are skipped; fails only if a needed job
+  # actually failed or was cancelled (skipped/success both pass).
+  ci-gate:
+    if: always()
+    needs: [changes, dotnet, node, n8n, python, rust, go, java, ruby, php]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job failed
+        run: |
+          results='${{ join(needs.*.result, ',') }}'
+          echo "job results: $results"
+          case ",$results," in
+            *,failure,* | *,cancelled,*)
+              echo "A required job did not succeed."
+              exit 1
+              ;;
+          esac
+          echo "All required jobs succeeded or were skipped."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,57 @@ permissions:
   contents: read
 
 jobs:
-  dotnet:
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      dotnet: ${{ steps.filter.outputs.dotnet }}
+      node: ${{ steps.filter.outputs.node }}
+      n8n: ${{ steps.filter.outputs.n8n }}
+      python: ${{ steps.filter.outputs.python }}
+      rust: ${{ steps.filter.outputs.rust }}
+      java: ${{ steps.filter.outputs.java }}
+      go: ${{ steps.filter.outputs.go }}
+      ruby: ${{ steps.filter.outputs.ruby }}
+      php: ${{ steps.filter.outputs.php }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+      # A package's steps run when its own dir changes, OR when shared test
+      # fixtures change (they feed every client), OR when this workflow changes.
+      - id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            dotnet: ['dotnet/**', 'fixtures/**', '.github/workflows/ci.yml']
+            node: ['node/**', 'fixtures/**', '.github/workflows/ci.yml']
+            n8n: ['n8n/**', 'fixtures/**', '.github/workflows/ci.yml']
+            python: ['python/**', 'fixtures/**', '.github/workflows/ci.yml']
+            rust: ['rust/**', 'fixtures/**', '.github/workflows/ci.yml']
+            java: ['java/**', 'fixtures/**', '.github/workflows/ci.yml']
+            go: ['go/**', 'fixtures/**', '.github/workflows/ci.yml']
+            ruby: ['ruby/**', 'fixtures/**', '.github/workflows/ci.yml']
+            php: ['php/**', 'fixtures/**', '.github/workflows/ci.yml']
+
+  dotnet:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.changes.outputs.dotnet == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.dotnet == 'true'
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: |
             8.0.x
             10.0.x
-      - run: dotnet format dotnet/OpenBankingIO.slnx --verify-no-changes
-      - run: dotnet build dotnet/OpenBankingIO.slnx -c Release -warnaserror
-      - run: dotnet test dotnet/ -c Release
+      - if: needs.changes.outputs.dotnet == 'true'
+        run: dotnet format dotnet/OpenBankingIO.slnx --verify-no-changes
+      - if: needs.changes.outputs.dotnet == 'true'
+        run: dotnet build dotnet/OpenBankingIO.slnx -c Release -warnaserror
+      - if: needs.changes.outputs.dotnet == 'true'
+        run: dotnet test dotnet/ -c Release
 
   node:
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -31,18 +68,27 @@ jobs:
       run:
         working-directory: node
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - if: needs.changes.outputs.node == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.node == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run format:check
-      - run: npm run typecheck
-      - run: npm run build
-      - run: npm test
+      - if: needs.changes.outputs.node == 'true'
+        run: npm ci
+      - if: needs.changes.outputs.node == 'true'
+        run: npm run lint
+      - if: needs.changes.outputs.node == 'true'
+        run: npm run format:check
+      - if: needs.changes.outputs.node == 'true'
+        run: npm run typecheck
+      - if: needs.changes.outputs.node == 'true'
+        run: npm run build
+      - if: needs.changes.outputs.node == 'true'
+        run: npm test
 
   n8n:
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -51,20 +97,29 @@ jobs:
       run:
         working-directory: n8n
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - if: needs.changes.outputs.n8n == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.n8n == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       # --ignore-scripts: the only native dep is isolated-vm (via n8n-workflow's expression
       # sandbox), which we never run and which fails to gyp-build on some Node versions.
-      - run: npm ci --ignore-scripts
-      - run: npm run lint
-      - run: npm run format:check
-      - run: npm run typecheck
-      - run: npm run build
-      - run: npm test
+      - if: needs.changes.outputs.n8n == 'true'
+        run: npm ci --ignore-scripts
+      - if: needs.changes.outputs.n8n == 'true'
+        run: npm run lint
+      - if: needs.changes.outputs.n8n == 'true'
+        run: npm run format:check
+      - if: needs.changes.outputs.n8n == 'true'
+        run: npm run typecheck
+      - if: needs.changes.outputs.n8n == 'true'
+        run: npm run build
+      - if: needs.changes.outputs.n8n == 'true'
+        run: npm test
 
   python:
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -73,35 +128,50 @@ jobs:
       run:
         working-directory: python
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - if: needs.changes.outputs.python == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.python == 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install -e .[dev]
-      - run: ruff check .
-      - run: ruff format --check .
-      - run: mypy src
-      - run: pytest -q
+      - if: needs.changes.outputs.python == 'true'
+        run: pip install -e .[dev]
+      - if: needs.changes.outputs.python == 'true'
+        run: ruff check .
+      - if: needs.changes.outputs.python == 'true'
+        run: ruff format --check .
+      - if: needs.changes.outputs.python == 'true'
+        run: mypy src
+      - if: needs.changes.outputs.python == 'true'
+        run: pytest -q
 
   rust:
+    needs: changes
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: rust
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - if: needs.changes.outputs.rust == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.rust == 'true'
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy, rustfmt
-      - run: cargo fmt --check
-      - run: cargo clippy --all-targets -- -D warnings
-      - run: cargo test
-      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
+      - if: needs.changes.outputs.rust == 'true'
+        run: cargo fmt --check
+      - if: needs.changes.outputs.rust == 'true'
+        run: cargo clippy --all-targets -- -D warnings
+      - if: needs.changes.outputs.rust == 'true'
+        run: cargo test
+      - if: needs.changes.outputs.rust == 'true'
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
         with:
           manifest-path: rust/Cargo.toml
           command: check advisories bans sources
 
   go:
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -110,18 +180,24 @@ jobs:
       run:
         working-directory: go
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - if: needs.changes.outputs.go == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.go == 'true'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
-      - run: go vet ./...
-      - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+      - if: needs.changes.outputs.go == 'true'
+        run: go vet ./...
+      - if: needs.changes.outputs.go == 'true'
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.12.2
           working-directory: go
-      - run: go test ./...
+      - if: needs.changes.outputs.go == 'true'
+        run: go test ./...
 
   java:
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -130,15 +206,19 @@ jobs:
       run:
         working-directory: java
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - if: needs.changes.outputs.java == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.java == 'true'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: ${{ matrix.java-version }}
           cache: maven
-      - run: mvn -B verify
+      - if: needs.changes.outputs.java == 'true'
+        run: mvn -B verify
 
   ruby:
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -147,16 +227,21 @@ jobs:
       run:
         working-directory: ruby
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1
+      - if: needs.changes.outputs.ruby == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.ruby == 'true'
+        uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
           working-directory: ruby
-      - run: bundle exec standardrb
-      - run: bundle exec rspec
+      - if: needs.changes.outputs.ruby == 'true'
+        run: bundle exec standardrb
+      - if: needs.changes.outputs.ruby == 'true'
+        run: bundle exec rspec
 
   php:
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -165,13 +250,19 @@ jobs:
       run:
         working-directory: php
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+      - if: needs.changes.outputs.php == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.php == 'true'
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-version }}
           extensions: openssl, curl, json
           coverage: pcov
-      - run: composer install --no-interaction --no-progress
-      - run: vendor/bin/phpstan analyse --memory-limit=512M
-      - run: vendor/bin/php-cs-fixer fix --dry-run --diff
-      - run: vendor/bin/phpunit
+      - if: needs.changes.outputs.php == 'true'
+        run: composer install --no-interaction --no-progress
+      - if: needs.changes.outputs.php == 'true'
+        run: vendor/bin/phpstan analyse --memory-limit=512M
+      - if: needs.changes.outputs.php == 'true'
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff
+      - if: needs.changes.outputs.php == 'true'
+        run: vendor/bin/phpunit

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,45 +13,30 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      dotnet: ${{ steps.filter.outputs.dotnet }}
-      node: ${{ steps.filter.outputs.node }}
-      python: ${{ steps.filter.outputs.python }}
-      rust: ${{ steps.filter.outputs.rust }}
-      java: ${{ steps.filter.outputs.java }}
-      go: ${{ steps.filter.outputs.go }}
-      ruby: ${{ steps.filter.outputs.ruby }}
-      php: ${{ steps.filter.outputs.php }}
+      dotnet: ${{ steps.cp.outputs.dotnet }}
+      node: ${{ steps.cp.outputs.node }}
+      python: ${{ steps.cp.outputs.python }}
+      rust: ${{ steps.cp.outputs.rust }}
+      java: ${{ steps.cp.outputs.java }}
+      go: ${{ steps.cp.outputs.go }}
+      ruby: ${{ steps.cp.outputs.ruby }}
+      php: ${{ steps.cp.outputs.php }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      # A package's steps run when its own dir changes, OR when shared test
-      # fixtures change (they feed every client), OR when this workflow changes.
-      - id: filter
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        with:
-          filters: |
-            dotnet: ['dotnet/**', 'fixtures/**', '.github/workflows/coverage.yml']
-            node: ['node/**', 'fixtures/**', '.github/workflows/coverage.yml']
-            python: ['python/**', 'fixtures/**', '.github/workflows/coverage.yml']
-            rust: ['rust/**', 'fixtures/**', '.github/workflows/coverage.yml']
-            java: ['java/**', 'fixtures/**', '.github/workflows/coverage.yml']
-            go: ['go/**', 'fixtures/**', '.github/workflows/coverage.yml']
-            ruby: ['ruby/**', 'fixtures/**', '.github/workflows/coverage.yml']
-            php: ['php/**', 'fixtures/**', '.github/workflows/coverage.yml']
+      - id: cp
+        uses: ./.github/actions/changed-packages
 
   dotnet:
     needs: changes
+    if: needs.changes.outputs.dotnet == 'true'
     runs-on: ubuntu-latest
     steps:
-      - if: needs.changes.outputs.dotnet == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.dotnet == 'true'
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: 8.0.x
-      - if: needs.changes.outputs.dotnet == 'true'
-        run: dotnet test dotnet/ -c Release --collect:"XPlat Code Coverage" --settings dotnet/coverlet.runsettings
-      - if: needs.changes.outputs.dotnet == 'true'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - run: dotnet test dotnet/ -c Release --collect:"XPlat Code Coverage" --settings dotnet/coverlet.runsettings
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: dotnet/tests/OpenBankingIO.Client.Tests/TestResults/**/coverage.cobertura.xml
           flags: dotnet
@@ -60,22 +45,18 @@ jobs:
 
   node:
     needs: changes
+    if: needs.changes.outputs.node == 'true'
     runs-on: ubuntu-latest
     steps:
-      - if: needs.changes.outputs.node == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.node == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-      - if: needs.changes.outputs.node == 'true'
-        run: npm ci
+      - run: npm ci
         working-directory: node
-      - if: needs.changes.outputs.node == 'true'
-        run: npm run coverage
+      - run: npm run coverage
         working-directory: node
-      - if: needs.changes.outputs.node == 'true'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: node/coverage/cobertura-coverage.xml
           flags: node
@@ -84,22 +65,18 @@ jobs:
 
   python:
     needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     steps:
-      - if: needs.changes.outputs.python == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.python == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
-      - if: needs.changes.outputs.python == 'true'
-        run: pip install -e .[dev]
+      - run: pip install -e .[dev]
         working-directory: python
-      - if: needs.changes.outputs.python == 'true'
-        run: pytest --cov=open_banking_io --cov-report=xml
+      - run: pytest --cov=open_banking_io --cov-report=xml
         working-directory: python
-      - if: needs.changes.outputs.python == 'true'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: python/coverage.xml
           flags: python
@@ -108,23 +85,19 @@ jobs:
 
   rust:
     needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
-      - if: needs.changes.outputs.rust == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.rust == 'true'
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
-      - if: needs.changes.outputs.rust == 'true'
-        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2.81.9
+      - uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2.81.9
         with:
           tool: cargo-llvm-cov
-      - if: needs.changes.outputs.rust == 'true'
-        run: cargo llvm-cov --cobertura --output-path cobertura.xml
+      - run: cargo llvm-cov --cobertura --output-path cobertura.xml
         working-directory: rust
-      - if: needs.changes.outputs.rust == 'true'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: rust/cobertura.xml
           flags: rust
@@ -133,24 +106,20 @@ jobs:
 
   go:
     needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
-      - if: needs.changes.outputs.go == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.go == 'true'
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.25'
-      - if: needs.changes.outputs.go == 'true'
-        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+      - run: go test -coverprofile=coverage.out -covermode=atomic ./...
         working-directory: go
-      - if: needs.changes.outputs.go == 'true'
-        run: |
+      - run: |
           go install github.com/boumenot/gocover-cobertura@latest
           "$(go env GOPATH)/bin/gocover-cobertura" < coverage.out > coverage.xml
         working-directory: go
-      - if: needs.changes.outputs.go == 'true'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: go/coverage.xml
           flags: go
@@ -159,21 +128,18 @@ jobs:
 
   java:
     needs: changes
+    if: needs.changes.outputs.java == 'true'
     runs-on: ubuntu-latest
     steps:
-      - if: needs.changes.outputs.java == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.java == 'true'
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: '21'
           cache: maven
-      - if: needs.changes.outputs.java == 'true'
-        run: mvn -B verify
+      - run: mvn -B verify
         working-directory: java
-      - if: needs.changes.outputs.java == 'true'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: java/target/site/jacoco/jacoco.xml
           flags: java
@@ -182,21 +148,18 @@ jobs:
 
   ruby:
     needs: changes
+    if: needs.changes.outputs.ruby == 'true'
     runs-on: ubuntu-latest
     steps:
-      - if: needs.changes.outputs.ruby == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.ruby == 'true'
-        uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
           working-directory: ruby
-      - if: needs.changes.outputs.ruby == 'true'
-        run: bundle exec rspec
+      - run: bundle exec rspec
         working-directory: ruby
-      - if: needs.changes.outputs.ruby == 'true'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ruby/coverage/coverage.xml
           flags: ruby
@@ -205,26 +168,42 @@ jobs:
 
   php:
     needs: changes
+    if: needs.changes.outputs.php == 'true'
     runs-on: ubuntu-latest
     steps:
-      - if: needs.changes.outputs.php == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - if: needs.changes.outputs.php == 'true'
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.3'
           extensions: openssl, curl, json
           coverage: pcov
-      - if: needs.changes.outputs.php == 'true'
-        run: composer install --no-interaction --no-progress
+      - run: composer install --no-interaction --no-progress
         working-directory: php
-      - if: needs.changes.outputs.php == 'true'
-        run: vendor/bin/phpunit --coverage-cobertura=coverage/cobertura.xml
+      - run: vendor/bin/phpunit --coverage-cobertura=coverage/cobertura.xml
         working-directory: php
-      - if: needs.changes.outputs.php == 'true'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: php/coverage/cobertura.xml
           flags: php
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Aggregate gate: the single required Coverage status check. Always runs so it
+  # reports even when language jobs are skipped; fails only if a needed job
+  # actually failed or was cancelled (skipped/success both pass).
+  coverage-gate:
+    if: always()
+    needs: [changes, dotnet, node, python, rust, go, java, ruby, php]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any coverage job failed
+        run: |
+          results='${{ join(needs.*.result, ',') }}'
+          echo "job results: $results"
+          case ",$results," in
+            *,failure,* | *,cancelled,*)
+              echo "A coverage job did not succeed."
+              exit 1
+              ;;
+          esac
+          echo "All coverage jobs succeeded or were skipped."

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,15 +10,48 @@ permissions:
   contents: read
 
 jobs:
-  dotnet:
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      dotnet: ${{ steps.filter.outputs.dotnet }}
+      node: ${{ steps.filter.outputs.node }}
+      python: ${{ steps.filter.outputs.python }}
+      rust: ${{ steps.filter.outputs.rust }}
+      java: ${{ steps.filter.outputs.java }}
+      go: ${{ steps.filter.outputs.go }}
+      ruby: ${{ steps.filter.outputs.ruby }}
+      php: ${{ steps.filter.outputs.php }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+      # A package's steps run when its own dir changes, OR when shared test
+      # fixtures change (they feed every client), OR when this workflow changes.
+      - id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            dotnet: ['dotnet/**', 'fixtures/**', '.github/workflows/coverage.yml']
+            node: ['node/**', 'fixtures/**', '.github/workflows/coverage.yml']
+            python: ['python/**', 'fixtures/**', '.github/workflows/coverage.yml']
+            rust: ['rust/**', 'fixtures/**', '.github/workflows/coverage.yml']
+            java: ['java/**', 'fixtures/**', '.github/workflows/coverage.yml']
+            go: ['go/**', 'fixtures/**', '.github/workflows/coverage.yml']
+            ruby: ['ruby/**', 'fixtures/**', '.github/workflows/coverage.yml']
+            php: ['php/**', 'fixtures/**', '.github/workflows/coverage.yml']
+
+  dotnet:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.changes.outputs.dotnet == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.dotnet == 'true'
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: 8.0.x
-      - run: dotnet test dotnet/ -c Release --collect:"XPlat Code Coverage" --settings dotnet/coverlet.runsettings
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - if: needs.changes.outputs.dotnet == 'true'
+        run: dotnet test dotnet/ -c Release --collect:"XPlat Code Coverage" --settings dotnet/coverlet.runsettings
+      - if: needs.changes.outputs.dotnet == 'true'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: dotnet/tests/OpenBankingIO.Client.Tests/TestResults/**/coverage.cobertura.xml
           flags: dotnet
@@ -26,17 +59,23 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   node:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - if: needs.changes.outputs.node == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.node == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-      - run: npm ci
+      - if: needs.changes.outputs.node == 'true'
+        run: npm ci
         working-directory: node
-      - run: npm run coverage
+      - if: needs.changes.outputs.node == 'true'
+        run: npm run coverage
         working-directory: node
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - if: needs.changes.outputs.node == 'true'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: node/coverage/cobertura-coverage.xml
           flags: node
@@ -44,17 +83,23 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   python:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - if: needs.changes.outputs.python == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.python == 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
-      - run: pip install -e .[dev]
+      - if: needs.changes.outputs.python == 'true'
+        run: pip install -e .[dev]
         working-directory: python
-      - run: pytest --cov=open_banking_io --cov-report=xml
+      - if: needs.changes.outputs.python == 'true'
+        run: pytest --cov=open_banking_io --cov-report=xml
         working-directory: python
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - if: needs.changes.outputs.python == 'true'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: python/coverage.xml
           flags: python
@@ -62,18 +107,24 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   rust:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - if: needs.changes.outputs.rust == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.rust == 'true'
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
-      - uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2.81.9
+      - if: needs.changes.outputs.rust == 'true'
+        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2.81.9
         with:
           tool: cargo-llvm-cov
-      - run: cargo llvm-cov --cobertura --output-path cobertura.xml
+      - if: needs.changes.outputs.rust == 'true'
+        run: cargo llvm-cov --cobertura --output-path cobertura.xml
         working-directory: rust
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - if: needs.changes.outputs.rust == 'true'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: rust/cobertura.xml
           flags: rust
@@ -81,19 +132,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   go:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - if: needs.changes.outputs.go == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.go == 'true'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.25'
-      - run: go test -coverprofile=coverage.out -covermode=atomic ./...
+      - if: needs.changes.outputs.go == 'true'
+        run: go test -coverprofile=coverage.out -covermode=atomic ./...
         working-directory: go
-      - run: |
+      - if: needs.changes.outputs.go == 'true'
+        run: |
           go install github.com/boumenot/gocover-cobertura@latest
           "$(go env GOPATH)/bin/gocover-cobertura" < coverage.out > coverage.xml
         working-directory: go
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - if: needs.changes.outputs.go == 'true'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: go/coverage.xml
           flags: go
@@ -101,17 +158,22 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   java:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - if: needs.changes.outputs.java == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.java == 'true'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: '21'
           cache: maven
-      - run: mvn -B verify
+      - if: needs.changes.outputs.java == 'true'
+        run: mvn -B verify
         working-directory: java
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - if: needs.changes.outputs.java == 'true'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: java/target/site/jacoco/jacoco.xml
           flags: java
@@ -119,17 +181,22 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   ruby:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1
+      - if: needs.changes.outputs.ruby == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.ruby == 'true'
+        uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
           working-directory: ruby
-      - run: bundle exec rspec
+      - if: needs.changes.outputs.ruby == 'true'
+        run: bundle exec rspec
         working-directory: ruby
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - if: needs.changes.outputs.ruby == 'true'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ruby/coverage/coverage.xml
           flags: ruby
@@ -137,19 +204,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   php:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+      - if: needs.changes.outputs.php == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - if: needs.changes.outputs.php == 'true'
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.3'
           extensions: openssl, curl, json
           coverage: pcov
-      - run: composer install --no-interaction --no-progress
+      - if: needs.changes.outputs.php == 'true'
+        run: composer install --no-interaction --no-progress
         working-directory: php
-      - run: vendor/bin/phpunit --coverage-cobertura=coverage/cobertura.xml
+      - if: needs.changes.outputs.php == 'true'
+        run: vendor/bin/phpunit --coverage-cobertura=coverage/cobertura.xml
         working-directory: php
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - if: needs.changes.outputs.php == 'true'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: php/coverage/cobertura.xml
           flags: php


### PR DESCRIPTION
## Problem

Every PR runs the **full** multi-language matrix. `ci.yml` and `coverage.yml` trigger on `pull_request` with no `paths:` filters, so a single-package change (e.g. the dep-bump PRs #59–#65) spins up all ~19 CI matrix jobs **plus** all 8 coverage jobs — building Rust, Java, PHP, etc. for a change that only touched one package.

We already use `dorny/paths-filter`, but only in `changed-packages.yml` to post an informational comment — it gates nothing.

## Fix

Add a lightweight `changes` job (paths-filter) to both `ci.yml` and `coverage.yml`, then gate **every step** of each language job on whether that package changed.

Each package's filter matches its own dir **plus** `fixtures/**` (shared test vectors feed every client) **plus** the workflow file itself (editing CI re-runs everything):

```yaml
python: ['python/**', 'fixtures/**', '.github/workflows/ci.yml']
```

When a package is unchanged, its job still runs but executes zero steps and reports success in seconds. The expensive work — dependency install, build, test, coverage upload — is what gets skipped.

## Why steps, not whole jobs

`main` branch protection requires ~30 named checks, including every matrix variant (`node (20)`, `python (3.10)`, `php (8.1)`, …) and `codecov/patch`. Skipping whole jobs risks leaving those required checks unreported and blocking merges. Gating *steps* keeps every job reporting its status while still skipping the heavy work — **no branch-protection changes needed.**

## Not touched (intentional)

- `semgrep.yml` / `gitleaks.yml` / `scorecard.yml` — repo-wide security scans, always run.
- `changed-packages.yml` — already lightweight/informational.
- `publish-*.yml` — tag-triggered; `publish-cli.yml` already path-filters its PR build.

## Caveats

- Runners still spin up for unchanged packages (~a few seconds each); only the heavy steps are skipped. This is the trade-off of keeping all required checks reporting without editing branch protection.
- On an infra-only PR (no package + no fixtures), all coverage uploads skip; codecov normally still posts `codecov/patch` as success when the diff has no coverable lines — worth confirming on the first such PR.
- This PR itself edits `ci.yml`/`coverage.yml`, so it should run **all** jobs fully (the workflow file is in every filter) — a good end-to-end check.