### PR TITLE
n8n: optional API Base URL Override on credential (staging/dev support)

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -48,6 +48,10 @@ Create an **Open Banking IO API** credential and paste the **credentials bundle 
 you exported from open-banking.io (or the CLI). It contains `apiBaseUrl`, `apiKey`
 and `encryptionKey.privateKey`. Click **Test** to verify it can reach the API.
 
+Optionally set **API Base URL Override** to point the credential at a different
+environment (e.g. `https://api.staging.open-banking.io` or a local instance) without
+re-exporting a bundle. Leave it empty to use the `apiBaseUrl` from the bundle.
+
 ## Usage notes
 
 - Monetary amounts are returned as **decimal strings** (e.g. `"828.13"`) — never as

--- a/n8n/credentials/OpenBankingIoApi.credentials.ts
+++ b/n8n/credentials/OpenBankingIoApi.credentials.ts
@@ -26,6 +26,15 @@ export class OpenBankingIoApi implements ICredentialType {
 			description:
 				'Paste the credentials bundle JSON you exported from open-banking.io (or the CLI). It contains "apiBaseUrl", "apiKey" and "encryptionKey.privateKey". The private key never leaves this n8n instance — it is used only to decrypt data locally.',
 		},
+		{
+			displayName: 'API Base URL Override',
+			name: 'baseUrlOverride',
+			type: 'string',
+			default: '',
+			placeholder: 'https://api.staging.open-banking.io',
+			description:
+				'Optional. Overrides the "apiBaseUrl" embedded in the bundle — e.g. to point this credential at a staging or local environment. Leave empty to use the URL from the bundle.',
+		},
 	];
 
 	// The API key lives inside the pasted bundle, so we parse it out of the JSON at request time
@@ -40,9 +49,11 @@ export class OpenBankingIoApi implements ICredentialType {
 	};
 
 	// Lets the user click "Test" in the credential UI: lists connections with the parsed key.
+	// Prefers the optional baseUrlOverride; falls back to the bundle's apiBaseUrl.
 	test: ICredentialTestRequest = {
 		request: {
-			baseURL: '={{ JSON.parse($credentials.bundle).apiBaseUrl.replace(/\\/+$/, "") }}',
+			baseURL:
+				'={{ (($credentials.baseUrlOverride || "").trim() || JSON.parse($credentials.bundle).apiBaseUrl).replace(/\\/+$/, "") }}',
 			url: '/api/connections',
 			method: 'GET',
 		},

--- a/n8n/nodes/OpenBankingIo/OpenBankingIo.node.ts
+++ b/n8n/nodes/OpenBankingIo/OpenBankingIo.node.ts
@@ -15,7 +15,7 @@ import {
 	mapAccount,
 	mapConnection,
 	mapTransaction,
-	parseBundle,
+	resolveBundle,
 	transactionsPath,
 	type Bundle,
 } from './shared/client';
@@ -231,7 +231,7 @@ export class OpenBankingIo implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
-		const bundle = parseBundle((await this.getCredentials('openBankingIoApi')).bundle as string);
+		const bundle = resolveBundle(await this.getCredentials('openBankingIoApi'));
 		const key = await importBundleKey(bundle);
 		const out: INodeExecutionData[] = [];
 

--- a/n8n/nodes/OpenBankingIo/OpenBankingIoTrigger.node.ts
+++ b/n8n/nodes/OpenBankingIo/OpenBankingIoTrigger.node.ts
@@ -11,7 +11,7 @@ import {
 	collectTransactionWires,
 	importBundleKey,
 	mapTransaction,
-	parseBundle,
+	resolveBundle,
 	transactionsPath,
 } from './shared/client';
 import type { AccountWire, TransactionPageWire } from './shared/models';
@@ -61,7 +61,7 @@ export class OpenBankingIoTrigger implements INodeType {
 	};
 
 	async poll(this: IPollFunctions): Promise<INodeExecutionData[][] | null> {
-		const bundle = parseBundle((await this.getCredentials('openBankingIoApi')).bundle as string);
+		const bundle = resolveBundle(await this.getCredentials('openBankingIoApi'));
 		const key = await importBundleKey(bundle);
 		const state = this.getWorkflowStaticData('node') as TriggerState;
 		const isManual = this.getMode() === 'manual';

--- a/n8n/nodes/OpenBankingIo/shared/client.ts
+++ b/n8n/nodes/OpenBankingIo/shared/client.ts
@@ -57,6 +57,20 @@ export function parseBundle(raw: string): Bundle {
 }
 
 /**
+ * Parses the credentials and applies the optional `baseUrlOverride` field. When set, it replaces
+ * the bundle's `apiBaseUrl` — letting a credential point at a staging/local environment without
+ * re-exporting a different bundle. Empty/whitespace override keeps the bundle's URL.
+ */
+export function resolveBundle(credentials: IDataObject): Bundle {
+	const bundle = parseBundle(credentials.bundle as string);
+	const override = String((credentials.baseUrlOverride as string) ?? '')
+		.trim()
+		.replace(/\/+$/, '');
+	if (override) bundle.apiBaseUrl = override;
+	return bundle;
+}
+
+/**
  * Issues an authenticated request through n8n's HTTP helper. The `X-Api-Key` header is injected
  * by the credential's `authenticate` block, so we never put the key on the wire ourselves.
  */

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-banking-io/n8n-nodes-open-banking-io",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "n8n community node for open-banking.io: API-key auth with client-side, zero-knowledge decryption of your bank accounts, balances and transactions.",
   "license": "MIT",
   "author": {

--- a/n8n/test/client.test.ts
+++ b/n8n/test/client.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { resolveBundle } from '../nodes/OpenBankingIo/shared/client';
+
+// `resolveBundle` parses the pasted bundle and applies the optional `baseUrlOverride` credential
+// field, so a credential can point at staging/local without re-exporting a different bundle.
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'fixtures');
+const BUNDLE = readFileSync(join(FIXTURES, 'credentials.json'), 'utf8');
+// The fixture bundle ships with this apiBaseUrl.
+const BUNDLE_URL = 'http://localhost:8081';
+
+describe('resolveBundle()', () => {
+	it('uses the bundle apiBaseUrl when no override is set', () => {
+		expect(resolveBundle({ bundle: BUNDLE }).apiBaseUrl).toBe(BUNDLE_URL);
+	});
+
+	it('applies a base-URL override, trimming trailing slashes', () => {
+		const bundle = resolveBundle({
+			bundle: BUNDLE,
+			baseUrlOverride: 'https://api.staging.open-banking.io/',
+		});
+		expect(bundle.apiBaseUrl).toBe('https://api.staging.open-banking.io');
+		// The rest of the bundle is untouched.
+		expect(bundle.apiKey).not.toBe('');
+		expect(bundle.privateKey).not.toBe('');
+	});
+
+	it('ignores a blank/whitespace override and keeps the bundle URL', () => {
+		expect(resolveBundle({ bundle: BUNDLE, baseUrlOverride: '   ' }).apiBaseUrl).toBe(BUNDLE_URL);
+		expect(resolveBundle({ bundle: BUNDLE, baseUrlOverride: '' }).apiBaseUrl).toBe(BUNDLE_URL);
+	});
+
+	it('still rejects an invalid bundle', () => {
+		expect(() => resolveBundle({ bundle: 'not json' })).toThrow(/not valid JSON/);
+	});
+});

--- a/n8n/test/node.test.ts
+++ b/n8n/test/node.test.ts
@@ -18,18 +18,24 @@ function fixture(rel: string): unknown {
 const BUNDLE = readFileSync(join(FIXTURES, 'credentials.json'), 'utf8');
 
 /** Builds a minimal IExecuteFunctions stand-in for one input item. */
-function makeContext(params: Record<string, unknown>, routes: Record<string, unknown>) {
+function makeContext(
+	params: Record<string, unknown>,
+	routes: Record<string, unknown>,
+	baseUrlOverride?: string,
+) {
+	// Requests should target the override host when set, otherwise the bundle's apiBaseUrl.
+	const host = (baseUrlOverride ?? 'http://localhost:8081').replace(/\/+$/, '');
 	const httpRequestWithAuthentication = vi.fn(async (_cred: string, options: { url: string }) => {
-		const path = options.url.replace('http://localhost:8081', '');
+		const path = options.url.replace(host, '');
 		for (const [prefix, body] of Object.entries(routes)) {
 			if (path.startsWith(prefix)) return body;
 		}
-		throw new Error(`unexpected request: ${path}`);
+		throw new Error(`unexpected request: ${options.url}`);
 	});
 
 	const ctx = {
 		getInputData: () => [{ json: {} }],
-		getCredentials: async () => ({ bundle: BUNDLE }),
+		getCredentials: async () => ({ bundle: BUNDLE, baseUrlOverride }),
 		getNodeParameter: (name: string, _i: number, fallback?: unknown) =>
 			name in params ? params[name] : fallback,
 		continueOnFail: () => false,
@@ -80,6 +86,21 @@ describe('OpenBankingIo node execute()', () => {
 		expect(txn.balanceAfterTransaction).toBe('633.90');
 		// One page was enough (total === items.length), so we stop after a single request.
 		expect(httpRequestWithAuthentication).toHaveBeenCalledTimes(1);
+	});
+
+	it('routes requests to the baseUrlOverride when set', async () => {
+		const { ctx, httpRequestWithAuthentication } = makeContext(
+			{ resource: 'account', operation: 'getMany' },
+			{ '/api/accounts': fixture('api/accounts.json') },
+			'https://api.staging.open-banking.io',
+		);
+
+		const [out] = await OpenBankingIo.prototype.execute.call(ctx as never);
+
+		expect(out).toHaveLength(1);
+		// The request URL used the override host, not the bundle's apiBaseUrl.
+		const calledUrl = httpRequestWithAuthentication.mock.calls[0][1].url as string;
+		expect(calledUrl).toBe('https://api.staging.open-banking.io/api/accounts');
 	});
 
 	it('surfaces a clear error for an invalid credentials bundle', async () => {


### PR DESCRIPTION
## Why

The n8n node's API base URL is only configurable via the `apiBaseUrl` field **inside** the pasted credentials bundle (JSON). To point the node at staging / a local instance / another region, a user has to export and paste a different bundle — the URL is hidden in a JSON blob and not discoverable or easy to change.

## What

Adds an optional **API Base URL Override** field on the **Open Banking IO API** credential:
- Empty → uses the bundle's `apiBaseUrl` (unchanged, fully backward compatible).
- Set → overrides it (e.g. `https://api.staging.open-banking.io`), trailing slashes trimmed.

Because it's on the **credential** (connection-level config), the data node, the trigger node, **and** the credential **Test** button all honour it with no per-node wiring. The resolution lives in one small helper:

```ts
export function resolveBundle(credentials: IDataObject): Bundle {
  const bundle = parseBundle(credentials.bundle as string);
  const override = String((credentials.baseUrlOverride as string) ?? '').trim().replace(/\/+$/, '');
  if (override) bundle.apiBaseUrl = override;
  return bundle;
}
```

No hardcoded prod/staging URLs anywhere; the `authenticate` block and zero-knowledge decryption are untouched.

## Files
- `credentials/OpenBankingIoApi.credentials.ts` — new `baseUrlOverride` property; `test` baseURL prefers the override.
- `nodes/OpenBankingIo/shared/client.ts` — new `resolveBundle()` helper (keeps `parseBundle`).
- `nodes/OpenBankingIo/OpenBankingIo.node.ts` & `OpenBankingIoTrigger.node.ts` — use `resolveBundle`.
- `test/client.test.ts` (new) + `test/node.test.ts` — override/fallback coverage.
- `README.md` — documents the field. `package.json` — 0.1.5 → 0.2.0 (minor; publish is a separate `n8n/v*` tag).

## Verification
`npm ci --ignore-scripts`, `lint`, `format:check`, `typecheck`, `build`, `test` (23 pass), and `prepublishOnly` (community-node scanner gate) all green locally.