### PR TITLE
feat(cli): add OPENBANKING_API_BASE_URL env override

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -83,6 +83,10 @@ source <(openbanking completion zsh)    # also: bash, fish
 Credentials live in `$OPENBANKING_CONFIG` or
 `<XDG_CONFIG_HOME|~/.config>/open-banking/credentials.json` (written `0600`).
 
+Set `$OPENBANKING_API_BASE_URL` to point every command at a different environment
+(e.g. staging or local) without re-running `login` — it overrides the saved
+bundle's API base URL when non-empty.
+
 ## How it works
 
 `login` runs a localhost loopback + PKCE flow against the API. In the browser you

--- a/cli/internal/app/app.go
+++ b/cli/internal/app/app.go
@@ -6,12 +6,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/open-banking-io/clients/cli/internal/config"
 	"github.com/open-banking-io/clients/cli/internal/ui"
 	openbanking "github.com/open-banking-io/clients/go"
 )
+
+// apiBaseURLEnv overrides the saved bundle's API base URL when set, letting the CLI target a
+// staging/local environment without re-running `login`. Empty/whitespace keeps the bundle's value.
+// Mirrors the n8n node's "API Base URL Override" credential field.
+const apiBaseURLEnv = "OPENBANKING_API_BASE_URL"
 
 // App carries the I/O and configuration a command needs. The zero value is not usable; main wires
 // real os streams and the default config path, while tests inject buffers and a temp path.
@@ -97,9 +103,22 @@ func (a *App) Run(args []string) error {
 	return c.run(a, cargs)
 }
 
+// loadBundle reads the saved credentials bundle and applies the OPENBANKING_API_BASE_URL override
+// when set, so every command can target staging/local without re-running `login`.
+func (a *App) loadBundle() (config.Bundle, error) {
+	bundle, err := config.Load(a.ConfigPath)
+	if err != nil {
+		return config.Bundle{}, err
+	}
+	if override := trimTrailingSlash(strings.TrimSpace(os.Getenv(apiBaseURLEnv))); override != "" {
+		bundle.APIBaseURL = override
+	}
+	return bundle, nil
+}
+
 // client builds a decrypting SDK client from the saved credentials bundle (needs the encryption key).
 func (a *App) client() (*openbanking.Client, error) {
-	bundle, err := config.Load(a.ConfigPath)
+	bundle, err := a.loadBundle()
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +128,7 @@ func (a *App) client() (*openbanking.Client, error) {
 // publicClient builds a client for operations that don't decrypt data (e.g. banks), so they
 // work right after `login`, before any encryption key has been imported.
 func (a *App) publicClient() (*openbanking.Client, error) {
-	bundle, err := config.Load(a.ConfigPath)
+	bundle, err := a.loadBundle()
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/app/base_url_override_test.go
+++ b/cli/internal/app/base_url_override_test.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestAPIBaseURLEnvRedirectsClient verifies OPENBANKING_API_BASE_URL overrides the saved bundle's
+// API base URL, so a command targets staging/local without re-running `login`. The bundle is pinned
+// at a dead address; only the env override (with a trailing slash, to exercise trimming) can reach
+// the live test server.
+func TestAPIBaseURLEnvRedirectsClient(t *testing.T) {
+	bundle := fixtureBundle(t)
+	srv := startAPIServer(t, bundle.APIKey)
+	cfg := writeConfig(t, bundle, "http://127.0.0.1:1")
+
+	t.Setenv(apiBaseURLEnv, srv.URL+"/")
+
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
+	if err := app.Run([]string{"-o", "table", "accounts"}); err != nil {
+		t.Fatalf("Run accounts with base URL override: %v\nstderr: %s", err, errOut.String())
+	}
+	if got := out.String(); !strings.Contains(got, "DK6466952001724927") {
+		t.Errorf("override server output missing expected account\n--- output ---\n%s", got)
+	}
+}
+
+// TestAPIBaseURLEnvBlankKeepsBundle confirms a blank/whitespace override leaves the bundle's URL
+// untouched, so the env var is opt-in and never silently breaks the default flow.
+func TestAPIBaseURLEnvBlankKeepsBundle(t *testing.T) {
+	bundle := fixtureBundle(t)
+	srv := startAPIServer(t, bundle.APIKey)
+	cfg := writeConfig(t, bundle, srv.URL)
+
+	t.Setenv(apiBaseURLEnv, "   ")
+
+	app := &App{ConfigPath: cfg}
+	got, err := app.loadBundle()
+	if err != nil {
+		t.Fatalf("loadBundle: %v", err)
+	}
+	if got.APIBaseURL != srv.URL {
+		t.Errorf("blank override changed base URL: got %q, want %q", got.APIBaseURL, srv.URL)
+	}
+}


### PR DESCRIPTION
## Summary

The n8n node already lets you override the API base URL to target staging/local (the `baseUrlOverride` credential field added in 0.2.0). This brings the same capability to the `openbanking` CLI via an environment variable.

- New `OPENBANKING_API_BASE_URL` env var: when set, it overrides the saved credentials bundle's `apiBaseUrl` for **every** command — no need to re-run `login` or hand-edit the bundle.
- Empty/whitespace value is a no-op, so it's strictly opt-in. Trailing slashes are trimmed.
- Logic centralized in a new `App.loadBundle()` helper that both `client()` (decrypting) and `publicClient()` route through.

This is deliberately separate from `login`'s existing `--api` flag (which controls where you *authenticate*); the env var redirects the *data* commands, matching how the n8n override applies to the data/trigger nodes.

```sh
OPENBANKING_API_BASE_URL=https://staging.open-banking.io openbanking accounts
```

## Tests

- Integration test: bundle pinned at a dead address, env override (with trailing slash) pointed at the live test server → `accounts` succeeds, proving requests route through the override.
- Unit test: blank/whitespace override leaves the bundle URL untouched.

## Docs

- Documented `$OPENBANKING_API_BASE_URL` in the CLI README alongside `$OPENBANKING_CONFIG`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)