### PR TITLE
security: scope release.yml write permission to the job (Token-Permissions)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: release-${{ github.event.inputs.package }}
@@ -33,6 +33,8 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       PACKAGE: ${{ github.event.inputs.package }}
       VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION
Follow-up to #70/#71. `release.yml` was the only workflow defaulting to top-level `contents: write`. Moved it to top-level `contents: read` with job-level `contents: write` on the release job (which tags + creates the GitHub Release). All other workflows already follow this least-privilege pattern.

Targets OpenSSF Scorecard **Token-Permissions** (currently 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)