### PR TITLE
docs: CHANGELOG + vuln-response timeline (CII Best Practices)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to the open-banking.io client SDKs are documented here.
+
+This is a monorepo of independently versioned packages, each released under its own
+`<package>/vX.Y.Z` git tag and following [Semantic Versioning](https://semver.org/):
+
+| Package | Tag prefix | Registry |
+| ------- | ---------- | -------- |
+| .NET    | `dotnet/v` | NuGet |
+| Node    | `node/v`   | npm |
+| Python  | `python/v` | PyPI |
+| Rust    | `rust/v`   | crates.io |
+| Go      | `go/v`     | Go modules |
+| Java    | `java/v`   | Maven Central |
+| Ruby    | `ruby/v`   | RubyGems |
+| PHP     | `php/v`    | Packagist |
+| CLI     | `cli/v`    | GitHub Releases + Homebrew |
+| n8n     | `n8n/v`    | npm |
+
+## Per-release notes
+
+Detailed, auto-generated notes for every release live on the
+[GitHub Releases page](https://github.com/open-banking-io/clients/releases), keyed by the
+`<package>/vX.Y.Z` tag. The release process is documented in [`RELEASING.md`](RELEASING.md).
+
+## Notable cross-cutting changes
+
+### 2026-06
+
+- Security hardening for the OpenSSF Scorecard: added CodeQL static analysis, native Go
+  fuzzing of the envelope parser, cosign signing of CLI release artifacts, least-privilege
+  workflow tokens, and remediation of all known dependency vulnerabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,8 +14,16 @@ Report privately via either:
 - **Email** — `security@open-banking.io`
 
 Please include: a description, affected SDK(s) and version(s), reproduction steps or a proof of concept,
-and an impact assessment. We acknowledge reports within **48 hours**, keep you updated, and coordinate a
-fix and disclosure. We're happy to credit you in the release notes.
+and an impact assessment.
+
+Our response targets:
+
+- **Acknowledgement** within **48 hours**.
+- **Initial assessment** (severity and whether it's in scope) within **7 days**.
+- **Fix and coordinated disclosure** as quickly as the severity warrants — we aim for within **90 days**,
+  and faster for issues under active exploitation.
+
+We keep you updated throughout and are happy to credit you in the release notes.
 
 ## Scope
 


### PR DESCRIPTION
Closes the only two documentation gaps from an OpenSSF Best Practices badge audit (~96% of passing criteria were already met).

- **CHANGELOG.md** (new) — documents the per-package `<pkg>/vX.Y.Z` versioning scheme and links to GitHub Releases for detailed notes.
- **SECURITY.md** — replaces the acknowledgement-only SLA with explicit response targets: 48h acknowledgement, 7-day initial assessment, ~90-day coordinated disclosure (hedged, faster for active exploitation).

These help qualify the project for the OpenSSF Best Practices badge (CII-Best-Practices check). The badge itself still needs maintainer registration at bestpractices.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)