### PR TITLE
docs: add OpenSSF Best Practices badge (passing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Semgrep](https://github.com/open-banking-io/clients/actions/workflows/semgrep.yml/badge.svg)](https://github.com/open-banking-io/clients/actions/workflows/semgrep.yml)
 [![Gitleaks](https://github.com/open-banking-io/clients/actions/workflows/gitleaks.yml/badge.svg)](https://github.com/open-banking-io/clients/actions/workflows/gitleaks.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/open-banking-io/clients/badge)](https://securityscorecards.dev/viewer/?uri=github.com/open-banking-io/clients)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13284/badge)](https://www.bestpractices.dev/projects/13284)
 [![codecov](https://codecov.io/gh/open-banking-io/clients/branch/main/graph/badge.svg)](https://codecov.io/gh/open-banking-io/clients)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 


### PR DESCRIPTION
The project earned the **OpenSSF Best Practices passing badge** ([project 13284](https://www.bestpractices.dev/projects/13284), 100% passing / 115% tiered). Adds the badge to the README next to the Scorecard badge.

This is also what Scorecard's **CII-Best-Practices** check looks for — embedding the badge moves that check off 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)