### PR TITLE
n8n: address verification feedback (NodeApiError + codex node prefix)

### DIFF
--- a/n8n/nodes/OpenBankingIo/OpenBankingIo.node.json
+++ b/n8n/nodes/OpenBankingIo/OpenBankingIo.node.json
@@ -1,5 +1,5 @@
 {
-	"node": "n8n-nodes-base.openBankingIo",
+	"node": "@open-banking-io/n8n-nodes-open-banking-io.openBankingIo",
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
 	"categories": ["Finance & Accounting"],

--- a/n8n/nodes/OpenBankingIo/OpenBankingIo.node.ts
+++ b/n8n/nodes/OpenBankingIo/OpenBankingIo.node.ts
@@ -1,10 +1,12 @@
 import {
+	NodeApiError,
 	NodeOperationError,
 	type IDataObject,
 	type IExecuteFunctions,
 	type INodeExecutionData,
 	type INodeType,
 	type INodeTypeDescription,
+	type JsonObject,
 } from 'n8n-workflow';
 
 import {
@@ -275,7 +277,8 @@ export class OpenBankingIo implements INodeType {
 					out.push({ json: { error: (error as Error).message }, pairedItem: i });
 					continue;
 				}
-				throw error;
+				if (error instanceof NodeOperationError) throw error;
+				throw new NodeApiError(this.getNode(), error as JsonObject, { itemIndex: i });
 			}
 		}
 

--- a/n8n/nodes/OpenBankingIo/OpenBankingIoTrigger.node.json
+++ b/n8n/nodes/OpenBankingIo/OpenBankingIoTrigger.node.json
@@ -1,5 +1,5 @@
 {
-	"node": "n8n-nodes-base.openBankingIoTrigger",
+	"node": "@open-banking-io/n8n-nodes-open-banking-io.openBankingIoTrigger",
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
 	"categories": ["Finance & Accounting"],

--- a/n8n/nodes/OpenBankingIo/OpenBankingIoTrigger.node.ts
+++ b/n8n/nodes/OpenBankingIo/OpenBankingIoTrigger.node.ts
@@ -1,9 +1,11 @@
+import { NodeApiError } from 'n8n-workflow';
 import type {
 	IDataObject,
 	INodeExecutionData,
 	INodeType,
 	INodeTypeDescription,
 	IPollFunctions,
+	JsonObject,
 } from 'n8n-workflow';
 
 import {
@@ -61,63 +63,67 @@ export class OpenBankingIoTrigger implements INodeType {
 	};
 
 	async poll(this: IPollFunctions): Promise<INodeExecutionData[][] | null> {
-		const bundle = resolveBundle(await this.getCredentials('openBankingIoApi'));
-		const key = await importBundleKey(bundle);
-		const state = this.getWorkflowStaticData('node') as TriggerState;
-		const isManual = this.getMode() === 'manual';
+		try {
+			const bundle = resolveBundle(await this.getCredentials('openBankingIoApi'));
+			const key = await importBundleKey(bundle);
+			const state = this.getWorkflowStaticData('node') as TriggerState;
+			const isManual = this.getMode() === 'manual';
 
-		const lookbackDays = this.getNodeParameter('lookbackDays', 7) as number;
-		const from = state.lastBookingDate ?? isoDaysAgo(lookbackDays);
+			const lookbackDays = this.getNodeParameter('lookbackDays', 7) as number;
+			const from = state.lastBookingDate ?? isoDaysAgo(lookbackDays);
 
-		const accounts = await apiRequest<AccountWire[]>(this, bundle, 'GET', '/api/accounts');
+			const accounts = await apiRequest<AccountWire[]>(this, bundle, 'GET', '/api/accounts');
 
-		const seen = new Set(state.seenIds ?? []);
-		const fresh: INodeExecutionData[] = [];
-		// Track each emitted row's booking date so we can keep only the boundary-date IDs below.
-		const emitted: Array<{ id: string; bookingDate: string | null }> = [];
-		let maxBookingDate = from;
+			const seen = new Set(state.seenIds ?? []);
+			const fresh: INodeExecutionData[] = [];
+			// Track each emitted row's booking date so we can keep only the boundary-date IDs below.
+			const emitted: Array<{ id: string; bookingDate: string | null }> = [];
+			let maxBookingDate = from;
 
-		for (const account of accounts) {
-			const path = transactionsPath(account.id);
-			const wires = await collectTransactionWires(
-				(offset, limit) =>
-					apiRequest<TransactionPageWire>(this, bundle, 'GET', path, { from, offset, limit }),
-				Number.POSITIVE_INFINITY,
-			);
+			for (const account of accounts) {
+				const path = transactionsPath(account.id);
+				const wires = await collectTransactionWires(
+					(offset, limit) =>
+						apiRequest<TransactionPageWire>(this, bundle, 'GET', path, { from, offset, limit }),
+					Number.POSITIVE_INFINITY,
+				);
 
-			for (const wire of wires) {
-				if (seen.has(wire.id)) continue;
-				seen.add(wire.id);
-				const bookingDate = wire.bookingDate ?? null;
-				emitted.push({ id: wire.id, bookingDate });
-				fresh.push({
-					json: {
-						accountId: account.id,
-						...(await mapTransaction(key, wire)),
-					} as unknown as IDataObject,
-				});
-				if (bookingDate && bookingDate > maxBookingDate) {
-					maxBookingDate = bookingDate;
+				for (const wire of wires) {
+					if (seen.has(wire.id)) continue;
+					seen.add(wire.id);
+					const bookingDate = wire.bookingDate ?? null;
+					emitted.push({ id: wire.id, bookingDate });
+					fresh.push({
+						json: {
+							accountId: account.id,
+							...(await mapTransaction(key, wire)),
+						} as unknown as IDataObject,
+					});
+					if (bookingDate && bookingDate > maxBookingDate) {
+						maxBookingDate = bookingDate;
+					}
 				}
 			}
-		}
 
-		// A manual test run must not advance the cursor, so the user can re-test freely.
-		if (!isManual) {
-			state.lastBookingDate = maxBookingDate;
-			// Only rows on the new boundary date (or undated/pending ones) can be re-fetched next
-			// poll, so those are all we need to remember. If the date didn't advance, carry the
-			// prior boundary IDs forward; otherwise the earlier date is now out of range — drop it.
-			const boundaryIds = emitted
-				.filter((e) => e.bookingDate == null || e.bookingDate === maxBookingDate)
-				.map((e) => e.id);
-			state.seenIds =
-				maxBookingDate === from
-					? [...new Set([...(state.seenIds ?? []), ...boundaryIds])]
-					: boundaryIds;
-		}
+			// A manual test run must not advance the cursor, so the user can re-test freely.
+			if (!isManual) {
+				state.lastBookingDate = maxBookingDate;
+				// Only rows on the new boundary date (or undated/pending ones) can be re-fetched next
+				// poll, so those are all we need to remember. If the date didn't advance, carry the
+				// prior boundary IDs forward; otherwise the earlier date is now out of range — drop it.
+				const boundaryIds = emitted
+					.filter((e) => e.bookingDate == null || e.bookingDate === maxBookingDate)
+					.map((e) => e.id);
+				state.seenIds =
+					maxBookingDate === from
+						? [...new Set([...(state.seenIds ?? []), ...boundaryIds])]
+						: boundaryIds;
+			}
 
-		return fresh.length ? [fresh] : null;
+			return fresh.length ? [fresh] : null;
+		} catch (error) {
+			throw new NodeApiError(this.getNode(), error as JsonObject);
+		}
 	}
 }
 


### PR DESCRIPTION
n8n's package reviewer flagged three items in v0.1.5. All three fixed in this PR, folded into the pending 0.2.0 release (still unpublished on npm):

- **[HIGH]** `OpenBankingIo.node.ts` — `execute()` catch tail now wraps non-`NodeOperationError` errors in `NodeApiError`, preserving HTTP status/response context in the n8n UI. `NodeOperationError` instances re-throw as-is to keep their `itemIndex`.
- **[HIGH]** `OpenBankingIoTrigger.node.ts` — `poll()` body wrapped in try/catch, errors thrown as `NodeApiError`.
- **[MEDIUM ×2]** Codex `node` field in both `*.node.json` switched from the placeholder `n8n-nodes-base.*` to the scoped npm name `@open-banking-io/n8n-nodes-open-banking-io.*`.

After merge: run **Actions → Release → Run workflow** with `n8n` / `0.2.0` to cut `n8n/v0.2.0` and publish.