### PR TITLE
fix(python): derive __version__ from package metadata instead of hardcode

### DIFF
--- a/python/src/open_banking_io/__init__.py
+++ b/python/src/open_banking_io/__init__.py
@@ -4,6 +4,9 @@ Server-to-server client that authenticates with an API key and decrypts the
 zero-knowledge data envelopes locally with your exported private key.
 """
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
 from .client import OpenBankingClient
 from .models import (
     Account,
@@ -26,4 +29,7 @@ __all__ = [
     "TransactionPage",
 ]
 
-__version__ = "0.1.0"
+try:
+    __version__ = _pkg_version("open-banking-io")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0.dev0"

--- a/python/tests/test_unit.py
+++ b/python/tests/test_unit.py
@@ -38,6 +38,15 @@ def test_user_agent_unknown_when_package_missing(monkeypatch):
     assert _user_agent() == "open-banking-io/python/unknown"
 
 
+def test_version_matches_package_metadata():
+    """__version__ must agree with the version declared in pyproject.toml."""
+    from importlib.metadata import version as pkg_version
+
+    import open_banking_io
+
+    assert open_banking_io.__version__ == pkg_version("open-banking-io")
+
+
 def test_parse_date_none_and_value():
     assert _parse_date(None) is None
     assert _parse_date("") is None


### PR DESCRIPTION
fix(python): derive __version__ from package metadata instead of hardcoded string

`__version__` was hardcoded to `"0.1.0"` while `pyproject.toml` declares `"0.2.1"` — it went stale after the 0.2.0 release and never got bumped.

This derives `__version__` dynamically from `importlib.metadata` so it can never drift from the installed package version again. A regression test asserts `__version__` matches the package metadata.