### PR TITLE
n8n: remove overrides field, publish 0.2.1

### DIFF
--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-banking-io/n8n-nodes-open-banking-io",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-banking-io/n8n-nodes-open-banking-io",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",
@@ -399,6 +399,13 @@
         "title-case": "3.0.3",
         "transliteration": "2.3.5"
       }
+    },
+    "node_modules/@n8n/expression-runtime/node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@n8n/tournament": {
       "version": "1.0.6",
@@ -2377,23 +2384,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fs-mkdirp-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-2.0.1.tgz",
@@ -3585,13 +3575,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3758,6 +3741,45 @@
         "uuid": "10.0.0",
         "xml2js": "0.6.2",
         "zod": "3.25.67"
+      }
+    },
+    "node_modules/n8n-workflow/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/n8n-workflow/node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/n8n-workflow/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/nanoid": {
@@ -5051,20 +5073,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/v8flags": {
       "version": "4.0.1",

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-banking-io/n8n-nodes-open-banking-io",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "n8n community node for open-banking.io: API-key auth with client-side, zero-knowledge decryption of your bank accounts, balances and transactions.",
   "license": "MIT",
   "author": {
@@ -52,11 +52,6 @@
   ],
   "peerDependencies": {
     "n8n-workflow": "*"
-  },
-  "overrides": {
-    "lodash": "^4.18.0",
-    "uuid": "^11.1.1",
-    "form-data": "^4.0.6"
   },
   "devDependencies": {
     "@types/node": "^25.9.3",


### PR DESCRIPTION
## What

Removes the `overrides` block from `n8n/package.json` and bumps the community node package to **0.2.1**.

## Why

n8n's verification team flagged this as the one remaining blocker:

> **[HIGH] `overrides` field in package.json** — not allowed in community node packages. Each community package installs into an isolated dependency tree, so overrides have no useful effect. Remove the entire `overrides` block and publish a new version.

The removed pins (`lodash`, `uuid`, `form-data`) only ever affected the **dev** dependency tree. The published package ships only `dist/` (`"files": ["dist"]`), and `n8n-workflow` is a peer dependency provided by n8n core at runtime — so this has **zero effect on the published artifact**, exactly as the reviewer states.

## Changes

- `n8n/package.json`: remove `overrides`, bump `0.2.0` → `0.2.1`
- `n8n/package-lock.json`: regenerated so it stays in sync (publish workflow runs `npm ci --ignore-scripts`)

## Verification (local, mirrors `publish-n8n.yml`)

- `npm ci --ignore-scripts` ✓ (lock ⟷ package.json in sync)
- `npm run lint` ✓
- `npm run format:check` ✓
- `npm run typecheck` ✓
- `npm run build` ✓
- `npm test` ✓ (23/23)

Note: remaining `npm audit` findings are all dev/peer-transitive under `n8n-workflow`, never shipped in `dist/`, and there is no CI audit gate — which is precisely why overrides are pointless in a community package.

## Publishing

npm publish is triggered by an `n8n/v0.2.1` tag on `main` (subtree-split → mirror → publish with provenance). Tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)