### PR TITLE
Add beancount-openbanking-io importer package

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -34,6 +34,8 @@ flags:
     paths: [ruby/lib]
   php:
     paths: [php/src]
+  beancount:
+    paths: [beancount/src]
 
 ignore:
   - "**/tests/**"

--- a/.github/actions/changed-packages/action.yml
+++ b/.github/actions/changed-packages/action.yml
@@ -32,6 +32,9 @@ outputs:
   php:
     description: Whether the php package is affected
     value: ${{ steps.filter.outputs.php }}
+  beancount:
+    description: Whether the beancount integration package is affected
+    value: ${{ steps.filter.outputs.beancount }}
 
 runs:
   using: composite
@@ -49,3 +52,4 @@ runs:
           go: ['go/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
           ruby: ['ruby/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
           php: ['php/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
+          beancount: ['beancount/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,14 @@ updates:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
 
+  - package-ecosystem: pip
+    directory: /beancount
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+
   - package-ecosystem: cargo
     directory: /rust
     schedule:

--- a/.github/workflows/changed-packages.yml
+++ b/.github/workflows/changed-packages.yml
@@ -36,6 +36,8 @@ jobs:
               - 'ruby/**'
             php:
               - 'php/**'
+            beancount:
+              - 'beancount/**'
             fixtures:
               - 'fixtures/**'
 
@@ -51,11 +53,12 @@ jobs:
           GO: ${{ steps.filter.outputs.go }}
           RUBY: ${{ steps.filter.outputs.ruby }}
           PHP: ${{ steps.filter.outputs.php }}
+          BEANCOUNT: ${{ steps.filter.outputs.beancount }}
           FIXTURES: ${{ steps.filter.outputs.fixtures }}
         with:
           script: |
             const MARKER = '<!-- changed-packages-report -->';
-            const ALL = ['dotnet', 'node', 'n8n', 'python', 'rust', 'java', 'go', 'ruby', 'php'];
+            const ALL = ['dotnet', 'node', 'n8n', 'python', 'rust', 'java', 'go', 'ruby', 'php', 'beancount'];
 
             const changed = new Set();
             for (const p of ALL) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       go: ${{ steps.cp.outputs.go }}
       ruby: ${{ steps.cp.outputs.ruby }}
       php: ${{ steps.cp.outputs.php }}
+      beancount: ${{ steps.cp.outputs.beancount }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - id: cp
@@ -220,12 +221,33 @@ jobs:
       - run: vendor/bin/php-cs-fixer fix --dry-run --diff
       - run: vendor/bin/phpunit
 
+  beancount:
+    needs: changes
+    if: needs.changes.outputs.beancount == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    defaults:
+      run:
+        working-directory: beancount
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e .[dev]
+      - run: ruff check .
+      - run: ruff format --check .
+      - run: mypy src
+      - run: pytest -q
+
   # Aggregate gate: the single required CI status check. Always runs so it
   # reports even when language jobs are skipped; fails only if a needed job
   # actually failed or was cancelled (skipped/success both pass).
   ci-gate:
     if: always()
-    needs: [changes, dotnet, node, n8n, python, rust, go, java, ruby, php]
+    needs: [changes, dotnet, node, n8n, python, rust, go, java, ruby, php, beancount]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job failed

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,6 +21,7 @@ jobs:
       go: ${{ steps.cp.outputs.go }}
       ruby: ${{ steps.cp.outputs.ruby }}
       php: ${{ steps.cp.outputs.php }}
+      beancount: ${{ steps.cp.outputs.beancount }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - id: cp
@@ -188,12 +189,32 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  beancount:
+    needs: changes
+    if: needs.changes.outputs.beancount == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+      - run: pip install -e .[dev]
+        working-directory: beancount
+      - run: pytest --cov=beancount_openbanking_io --cov-report=xml
+        working-directory: beancount
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: beancount/coverage.xml
+          flags: beancount
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   # Aggregate gate: the single required Coverage status check. Always runs so it
   # reports even when language jobs are skipped; fails only if a needed job
   # actually failed or was cancelled (skipped/success both pass).
   coverage-gate:
     if: always()
-    needs: [changes, dotnet, node, python, rust, go, java, ruby, php]
+    needs: [changes, dotnet, node, python, rust, go, java, ruby, php, beancount]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any coverage job failed

--- a/.github/workflows/publish-beancount.yml
+++ b/.github/workflows/publish-beancount.yml
@@ -1,0 +1,36 @@
+name: Publish Beancount
+
+on:
+  push:
+    tags: ['beancount/v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: Production
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Verify tag matches manifest version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#beancount/v}"
+          MANIFEST_VERSION="$(grep -oE '^version[[:space:]]*=[[:space:]]*"[^"]+"' beancount/pyproject.toml | head -n1 | sed -E 's/.*"([^"]+)"$/\1/')"
+          echo "tag=$TAG_VERSION manifest=$MANIFEST_VERSION"
+          [ "$TAG_VERSION" = "$MANIFEST_VERSION" ] || { echo "::error::tag $TAG_VERSION != manifest $MANIFEST_VERSION"; exit 1; }
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+      - run: pip install build==1.5.0
+      - run: python -m build
+        working-directory: beancount
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: beancount/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
           - ruby
           - php
           - cli
+          - beancount
       version:
         description: New version, e.g. 0.2.0 (no leading "v")
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is a monorepo of independently versioned packages, each released under its 
 | PHP     | `php/v`    | Packagist |
 | CLI     | `cli/v`    | GitHub Releases + Homebrew |
 | n8n     | `n8n/v`    | npm |
+| Beancount | `beancount/v` | PyPI |
 
 ## Per-release notes
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ notes (money types, async, dependencies).
 
 Prefer the terminal? There's also a [command-line client](cli/) (`openbanking`).
 
+Ready-made integrations build on top of the SDKs: a [Beancount importer](beancount/)
+([`beancount-openbanking-io`](https://pypi.org/project/beancount-openbanking-io/), PyPI) for
+plaintext accounting, and an [n8n community node](n8n/).
+
 ## Getting started
 
 1. **Get your credentials.** In the [open-banking.io](https://open-banking.io) app, export your

--- a/beancount/.gitignore
+++ b/beancount/.gitignore
@@ -1,0 +1,13 @@
+# Coverage artifacts
+.coverage
+coverage.xml
+htmlcov/
+
+# Caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+__pycache__/
+
+# Local virtualenv
+.venv/

--- a/beancount/LICENSE
+++ b/beancount/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 open-banking.io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/beancount/README.md
+++ b/beancount/README.md
@@ -1,0 +1,96 @@
+# beancount-openbanking-io
+
+A [Beancount](https://beancount.github.io/) / [beangulp](https://github.com/beancount/beangulp)
+importer for [**open-banking.io**](https://open-banking.io) — zero-knowledge PSD2 bank
+sync for EEA & UK banks.
+
+Transactions arrive as zero-knowledge encrypted envelopes and are decrypted **locally** by
+the official [`open-banking-io`](https://pypi.org/project/open-banking-io/) SDK with a key
+only you hold. Your statement is never readable off your machine — a good fit for a
+plaintext-accounting ledger you keep yourself.
+
+## Why
+
+If you sync EU/UK banks into Beancount, your options have been thinning out:
+
+- **GoCardless / Nordigen** stopped approving new personal Bank-Account-Data accounts, and
+  imposes a **4-requests-per-account-per-day** rate limit that breaks routine imports.
+- Other aggregators terminate your bank connection **in the clear** on their servers.
+
+`open-banking.io` is an alternative built for self-hosters: **client-side decryption**, **no
+eIDAS certificate to obtain**, **no per-account daily rate-limit wall**.
+
+## Install
+
+```bash
+pip install beancount-openbanking-io
+```
+
+This pulls in `beancount`, `beangulp`, and the `open-banking-io` SDK.
+
+## Configure
+
+Export your credentials bundle from the open-banking.io dashboard, then create a small YAML
+file whose name ends in `openbanking.yaml`:
+
+```yaml
+# myfinances.openbanking.yaml
+credentials: ./open-banking.io-credentials.json   # path is relative to this file
+accounts:
+  - id: f1345859-....          # open-banking.io account id (from client.get_accounts())
+    account: Assets:Bank:Nordea:Checking
+    currency: DKK              # optional guard
+    counterpart: Expenses:Uncategorized   # optional; default holding account for the other leg
+    assert_balance: true       # optional: emit a booked-balance (ITBD) assertion
+```
+
+To list your account ids:
+
+```python
+from open_banking_io import OpenBankingClient
+
+with OpenBankingClient.from_credentials("open-banking.io-credentials.json") as client:
+    for account in client.get_accounts():
+        print(account.id, account.aspsp_name, account.currency, account.iban)
+```
+
+## Use
+
+Wire it into your beangulp import script like any other importer:
+
+```python
+# import.py
+import beangulp
+from beancount_openbanking_io import OpenBankingImporter
+
+if __name__ == "__main__":
+    beangulp.Ingest([OpenBankingImporter()]).main()
+```
+
+```bash
+python import.py extract myfinances.openbanking.yaml >> ledger.beancount
+```
+
+Re-running is safe: each entry is stamped with its stable open-banking.io transaction id
+(`obio-id`), so already-imported transactions are skipped.
+
+## Mapping
+
+| open-banking.io | Beancount |
+|---|---|
+| `amount` (unsigned) + `creditDebitIndicator` | signed posting amount — **DBIT → negative, CRDT → positive** |
+| `creditorName` (DBIT) / `debtorName` (CRDT) | `payee` |
+| `remittanceInformation` / `note` | `narration` |
+| `bookingDate` (→ `valueDate` → `transactionDate`) | entry `date` |
+| `status` `PDNG` | `!` (flagged/uncleared); `BOOK` → `*` |
+| transaction `id` | `obio-id` metadata (dedup key) |
+| `ITBD` booked balance | optional `balance` assertion |
+
+Each transaction gets a second, amount-elided posting to the `counterpart` account
+(default `Expenses:Uncategorized`) so entries balance on import; reclassify it later
+(e.g. with [`smart_importer`](https://github.com/beancount/smart_importer)). Transactions
+whose direction cannot be determined are **skipped**, never imported with a guessed sign.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/beancount/pyproject.toml
+++ b/beancount/pyproject.toml
@@ -1,0 +1,73 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "beancount-openbanking-io"
+version = "0.1.0"
+description = "Beancount/beangulp importer for open-banking.io — zero-knowledge PSD2 bank sync for EEA & UK banks."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "open-banking.io" }]
+keywords = ["beancount", "beangulp", "banking", "psd2", "open-banking", "nordigen", "gocardless", "plaintextaccounting"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Office/Business :: Financial :: Accounting",
+]
+dependencies = [
+    "beancount>=3.0",
+    "beangulp>=0.2",
+    "open-banking-io>=0.2",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9.0",
+    "pytest-cov>=7.0",
+    "ruff>=0.15",
+    "mypy>=2.0",
+]
+
+[project.urls]
+Homepage = "https://open-banking.io"
+Repository = "https://github.com/open-banking-io/clients"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/beancount_openbanking_io"]
+
+[tool.coverage.run]
+branch = true
+source = ["beancount_openbanking_io"]
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.coverage.xml]
+output = "coverage.xml"
+
+[tool.ruff]
+line-length = 100
+src = ["src", "tests"]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "UP", "C4", "SIM", "RUF"]
+
+[tool.mypy]
+python_version = "3.10"
+files = ["src"]
+strict = true
+warn_unreachable = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+disallow_untyped_defs = true
+
+# Downstream deps ship no type information; treat their imports as untyped.
+[[tool.mypy.overrides]]
+module = ["beancount.*", "beangulp.*", "open_banking_io.*", "yaml"]
+ignore_missing_imports = true

--- a/beancount/src/beancount_openbanking_io/__init__.py
+++ b/beancount/src/beancount_openbanking_io/__init__.py
@@ -1,0 +1,17 @@
+"""Beancount importer for open-banking.io — zero-knowledge PSD2 bank sync.
+
+Pulls balances and transactions from open-banking.io (decrypted locally by the
+official ``open-banking-io`` SDK) and maps them onto Beancount directives.
+"""
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+from beancount_openbanking_io.importer import OpenBankingImporter
+
+try:
+    __version__ = _pkg_version("beancount-openbanking-io")
+except PackageNotFoundError:  # pragma: no cover - source checkout without install
+    __version__ = "0.0.0"
+
+__all__ = ["OpenBankingImporter", "__version__"]

--- a/beancount/src/beancount_openbanking_io/importer.py
+++ b/beancount/src/beancount_openbanking_io/importer.py
@@ -1,0 +1,227 @@
+"""Beancount importer for open-banking.io (zero-knowledge PSD2 bank data).
+
+open-banking.io returns transactions as zero-knowledge encrypted envelopes; the
+official ``open-banking-io`` SDK decrypts them locally with your exported private
+key. This importer is a thin mapping layer from the decrypted SDK objects onto
+Beancount directives.
+
+Usage: create a small YAML config file named ``*openbanking.yaml`` and point
+``beangulp`` at it (the file itself is the "document" the importer triggers on)::
+
+    # myfinances.openbanking.yaml
+    credentials: ./open-banking.io-credentials.json   # exported from the dashboard
+    accounts:
+      - id: f1345859-....          # open-banking.io account id (see get_accounts())
+        account: Assets:Bank:Nordea:Checking
+        currency: DKK              # optional guard
+        counterpart: Expenses:Uncategorized   # optional, per-account override
+        assert_balance: true       # optional: emit a booked-balance assertion
+"""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import beangulp
+import yaml
+from beancount.core import amount, data
+from beancount.core.flags import FLAG_OKAY, FLAG_WARNING
+
+try:  # keep the module importable (docs/tests) even without the SDK installed
+    from open_banking_io import OpenBankingClient
+except ImportError:  # pragma: no cover
+    OpenBankingClient = None
+
+__all__ = ["OpenBankingImporter"]
+
+_PAGE_SIZE = 500
+
+
+class OpenBankingImporter(beangulp.Importer):  # type: ignore[misc]  # untyped third-party base
+    """Imports open-banking.io accounts into Beancount.
+
+    Args:
+        meta_key: metadata key used to stamp each transaction's stable
+            open-banking.io id (drives deduplication across re-imports).
+        config_suffix: filename suffix that triggers this importer.
+        counterpart: default holding account for the balancing leg; users
+            reclassify it later (e.g. with smart_importer).
+        client: an already-built SDK client (dependency injection for tests).
+            When omitted, a client is built from the config's ``credentials`` bundle.
+    """
+
+    def __init__(
+        self,
+        *,
+        meta_key: str = "obio-id",
+        config_suffix: str = "openbanking.yaml",
+        counterpart: str = "Expenses:Uncategorized",
+        client: Any = None,
+    ) -> None:
+        self._meta_key = meta_key
+        self._suffix = config_suffix
+        self._counterpart = counterpart
+        self._client = client
+
+    # -- beangulp.Importer protocol -------------------------------------------
+
+    def identify(self, filepath: str) -> bool:
+        return filepath.endswith(self._suffix)
+
+    def account(self, filepath: str) -> str:
+        accounts = self._load(filepath).get("accounts") or []
+        first: str = accounts[0]["account"] if accounts else "Assets:OpenBankingIO"
+        return first
+
+    def extract(self, filepath: str, existing: list[Any]) -> list[Any]:
+        cfg = self._load(filepath)
+        seen = self._seen_ids(existing)
+
+        client, owns_client = self._client, False
+        if client is None:
+            if OpenBankingClient is None:  # pragma: no cover
+                raise RuntimeError(
+                    "The open-banking-io SDK is not installed. "
+                    "Install it with: pip install open-banking-io"
+                )
+            client = OpenBankingClient.from_credentials(self._resolve(filepath, cfg["credentials"]))
+            owns_client = True
+
+        try:
+            entries: list[Any] = []
+            index: dict[str, Any] | None = None
+            for spec in cfg.get("accounts", []):
+                entries.extend(self._extract_account(filepath, client, spec, seen))
+                if spec.get("assert_balance"):
+                    if index is None:
+                        index = self._account_index(client)
+                    balance = self._balance_directive(filepath, index, spec)
+                    if balance is not None:
+                        entries.append(balance)
+        finally:
+            if owns_client and hasattr(client, "close"):
+                client.close()
+
+        entries.sort(key=lambda entry: entry.date)
+        return entries
+
+    # -- mapping ---------------------------------------------------------------
+
+    def _extract_account(
+        self, filepath: str, client: Any, spec: dict[str, Any], seen: set[str]
+    ) -> list[Any]:
+        obio_id = spec["id"]
+        bean_account = spec["account"]
+        want_ccy = spec.get("currency")
+        counterpart = spec.get("counterpart", self._counterpart)
+
+        out: list[Any] = []
+        offset = 0
+        lineno = 0
+        while True:
+            page = client.get_transactions(obio_id, limit=_PAGE_SIZE, offset=offset)
+            items = list(page.items or [])
+            if not items:
+                break
+            for txn in items:
+                lineno += 1
+                if txn.id in seen:
+                    continue  # already in the ledger -> dedup
+                directive = self._to_transaction(
+                    filepath, lineno, bean_account, counterpart, txn, want_ccy
+                )
+                if directive is not None:
+                    out.append(directive)
+            offset += len(items)
+            if offset >= (page.total or 0):
+                break
+        return out
+
+    def _to_transaction(
+        self,
+        filepath: str,
+        lineno: int,
+        bean_account: str,
+        counterpart: str,
+        txn: Any,
+        want_ccy: str | None,
+    ) -> Any | None:
+        # An unknown direction means we cannot sign the amount safely; skip rather
+        # than import an outgoing payment as income (learned the hard way).
+        if txn.amount is None or txn.credit_debit_indicator not in ("CRDT", "DBIT"):
+            return None
+
+        sign = Decimal(-1) if txn.credit_debit_indicator == "DBIT" else Decimal(1)
+        number = sign * txn.amount
+        currency = txn.currency or want_ccy or ""
+        units = amount.Amount(number, currency)
+
+        payee = (
+            txn.creditor_name if txn.credit_debit_indicator == "DBIT" else txn.debtor_name
+        ) or None
+        narration = txn.remittance_information or txn.note or ""
+        date = txn.booking_date or txn.value_date or txn.transaction_date
+        flag = FLAG_OKAY if (txn.status in (None, "BOOK")) else FLAG_WARNING
+
+        meta = data.new_metadata(filepath, lineno, {self._meta_key: txn.id})
+        postings = [data.Posting(bean_account, units, None, None, None, None)]
+        if counterpart:
+            # Elided amount: Beancount auto-balances the second leg. Users reclassify
+            # it later (e.g. with smart_importer) from the default holding account.
+            postings.append(data.Posting(counterpart, None, None, None, None, None))
+        return data.Transaction(
+            meta, date, flag, payee, narration, data.EMPTY_SET, data.EMPTY_SET, postings
+        )
+
+    def _balance_directive(
+        self, filepath: str, index: dict[str, Any], spec: dict[str, Any]
+    ) -> Any | None:
+        account = index.get(spec["id"])
+        if account is None or not account.balances:
+            return None
+        booked = next((b for b in account.balances if b.type == "ITBD"), None)
+        if booked is None:
+            return None
+        # Beancount asserts a balance at the *start* of the given day, so date it
+        # tomorrow to include everything booked through today.
+        date = datetime.date.today() + datetime.timedelta(days=1)
+        meta = data.new_metadata(filepath, 0)
+        return data.Balance(
+            meta,
+            date,
+            spec["account"],
+            amount.Amount(booked.amount, booked.currency),
+            None,
+            None,
+        )
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _account_index(self, client: Any) -> dict[str, Any]:
+        return {account.id: account for account in client.get_accounts()}
+
+    def _seen_ids(self, existing: list[Any]) -> set[str]:
+        key = self._meta_key
+        seen: set[str] = set()
+        for entry in existing or []:
+            if isinstance(entry, data.Transaction):
+                if entry.meta and key in entry.meta:
+                    seen.add(entry.meta[key])
+                for posting in entry.postings:
+                    if posting.meta and key in posting.meta:
+                        seen.add(posting.meta[key])
+        return seen
+
+    def _load(self, filepath: str) -> dict[str, Any]:
+        with open(filepath, encoding="utf-8") as handle:
+            data_dict: dict[str, Any] = yaml.safe_load(handle) or {}
+            return data_dict
+
+    def _resolve(self, filepath: str, credentials: str) -> str:
+        path = Path(credentials).expanduser()
+        if not path.is_absolute():
+            path = Path(filepath).parent / path
+        return str(path)

--- a/beancount/src/beancount_openbanking_io/importer.py
+++ b/beancount/src/beancount_openbanking_io/importer.py
@@ -136,7 +136,10 @@ class OpenBankingImporter(beangulp.Importer):  # type: ignore[misc]  # untyped t
                 if directive is not None:
                     out.append(directive)
             offset += len(items)
-            if offset >= (page.total or 0):
+            # Terminate on the last (short) page; an exact-multiple total is caught
+            # by the empty-items guard next iteration. Don't rely on `total` alone
+            # (it may be absent), but use it when present to skip an extra fetch.
+            if len(items) < _PAGE_SIZE or (page.total and offset >= page.total):
                 break
         return out
 
@@ -149,9 +152,11 @@ class OpenBankingImporter(beangulp.Importer):  # type: ignore[misc]  # untyped t
         txn: Any,
         want_ccy: str | None,
     ) -> Any | None:
-        # An unknown direction means we cannot sign the amount safely; skip rather
-        # than import an outgoing payment as income (learned the hard way).
-        if txn.amount is None or txn.credit_debit_indicator not in ("CRDT", "DBIT"):
+        date = txn.booking_date or txn.value_date or txn.transaction_date
+        # Skip anything we can't faithfully record: no amount, an unknown direction
+        # (we won't guess a sign, learned the hard way), or no date to anchor the
+        # entry — a dateless entry would also break the caller's date sort.
+        if txn.amount is None or txn.credit_debit_indicator not in ("CRDT", "DBIT") or date is None:
             return None
 
         sign = Decimal(-1) if txn.credit_debit_indicator == "DBIT" else Decimal(1)
@@ -163,7 +168,6 @@ class OpenBankingImporter(beangulp.Importer):  # type: ignore[misc]  # untyped t
             txn.creditor_name if txn.credit_debit_indicator == "DBIT" else txn.debtor_name
         ) or None
         narration = txn.remittance_information or txn.note or ""
-        date = txn.booking_date or txn.value_date or txn.transaction_date
         flag = FLAG_OKAY if (txn.status in (None, "BOOK")) else FLAG_WARNING
 
         meta = data.new_metadata(filepath, lineno, {self._meta_key: txn.id})

--- a/beancount/tests/test_importer.py
+++ b/beancount/tests/test_importer.py
@@ -50,14 +50,19 @@ class FakePage:
     total: int
 
 
+_UNSET = object()
+
+
 class FakeClient:
-    def __init__(self, txns, accounts=None):
+    def __init__(self, txns, accounts=None, reported_total=_UNSET):
         self._txns = txns
         self._accounts = accounts or []
+        self._reported_total = reported_total
 
     def get_transactions(self, account_id, limit, offset):
         page = self._txns[offset : offset + limit]
-        return FakePage(items=page, total=len(self._txns))
+        total = len(self._txns) if self._reported_total is _UNSET else self._reported_total
+        return FakePage(items=page, total=total)
 
     def get_accounts(self):
         return self._accounts
@@ -119,6 +124,35 @@ def test_skips_unknown_indicator(tmp_path):
     entries = imp.extract(_write_config(tmp_path), [])
     ids = {e.meta["obio-id"] for e in entries if isinstance(e, data.Transaction)}
     assert ids == {"t2"}
+
+
+def test_skips_dateless_transaction(tmp_path):
+    # A record with no booking/value/transaction date can't anchor an entry (and
+    # would break the date sort) — it must be skipped, not imported or crash.
+    txns = [
+        FakeTxn(
+            "t1",
+            "CRDT",
+            Decimal("5.00"),
+            booking_date=None,
+            value_date=None,
+            transaction_date=None,
+        ),
+        FakeTxn("t2", "DBIT", Decimal("3.00")),
+    ]
+    imp = OpenBankingImporter(client=FakeClient(txns))
+    entries = imp.extract(_write_config(tmp_path), [])
+    ids = {e.meta["obio-id"] for e in entries if isinstance(e, data.Transaction)}
+    assert ids == {"t2"}
+
+
+def test_pagination_when_total_is_falsy(tmp_path):
+    # If the API reports total=0 (or None) alongside full pages, we must still
+    # paginate to the end via short/empty-page detection, not truncate after page 1.
+    txns = [FakeTxn(f"t{i}", "CRDT", Decimal("1.00")) for i in range(1100)]
+    imp = OpenBankingImporter(client=FakeClient(txns, reported_total=0))
+    entries = imp.extract(_write_config(tmp_path), [])
+    assert len([e for e in entries if isinstance(e, data.Transaction)]) == 1100
 
 
 def test_pending_is_flagged(tmp_path):

--- a/beancount/tests/test_importer.py
+++ b/beancount/tests/test_importer.py
@@ -1,0 +1,169 @@
+"""Unit tests for the open-banking.io Beancount importer.
+
+These use a fake in-memory SDK client, so they need no credentials or network.
+"""
+
+import datetime
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+import pytest
+from beancount.core import data
+
+from beancount_openbanking_io import OpenBankingImporter
+
+# --- fakes mirroring the open-banking-io SDK surface ------------------------
+
+
+@dataclass
+class FakeBalance:
+    type: str
+    amount: Decimal
+    currency: str
+
+
+@dataclass
+class FakeTxn:
+    id: str
+    credit_debit_indicator: str
+    amount: Decimal
+    currency: str = "DKK"
+    status: str | None = "BOOK"
+    booking_date: datetime.date | None = datetime.date(2026, 7, 2)
+    value_date: datetime.date | None = None
+    transaction_date: datetime.date | None = None
+    creditor_name: str | None = None
+    debtor_name: str | None = None
+    remittance_information: str | None = None
+    note: str | None = None
+
+
+@dataclass
+class FakeAccount:
+    id: str
+    balances: list = field(default_factory=list)
+
+
+@dataclass
+class FakePage:
+    items: list
+    total: int
+
+
+class FakeClient:
+    def __init__(self, txns, accounts=None):
+        self._txns = txns
+        self._accounts = accounts or []
+
+    def get_transactions(self, account_id, limit, offset):
+        page = self._txns[offset : offset + limit]
+        return FakePage(items=page, total=len(self._txns))
+
+    def get_accounts(self):
+        return self._accounts
+
+
+def _write_config(tmp_path, assert_balance=False):
+    cfg = tmp_path / "test.openbanking.yaml"
+    extra = "    assert_balance: true\n" if assert_balance else ""
+    cfg.write_text(
+        "credentials: ./creds.json\n"
+        "accounts:\n"
+        "  - id: acc-1\n"
+        "    account: Assets:Bank:Nordea\n"
+        "    currency: DKK\n" + extra
+    )
+    return str(cfg)
+
+
+# --- tests ------------------------------------------------------------------
+
+
+def test_identify():
+    imp = OpenBankingImporter(client=FakeClient([]))
+    assert imp.identify("/x/my.openbanking.yaml") is True
+    assert imp.identify("/x/statement.csv") is False
+
+
+def test_sign_mapping_dbit_negative_crdt_positive(tmp_path):
+    txns = [
+        FakeTxn("t1", "DBIT", Decimal("194.23"), creditor_name="Netto"),
+        FakeTxn("t2", "CRDT", Decimal("2500.00"), debtor_name="Employer"),
+    ]
+    imp = OpenBankingImporter(client=FakeClient(txns))
+    entries = imp.extract(_write_config(tmp_path), [])
+    txn_entries = [e for e in entries if isinstance(e, data.Transaction)]
+    assert len(txn_entries) == 2
+    by_id = {e.meta["obio-id"]: e for e in txn_entries}
+    assert by_id["t1"].postings[0].units.number == Decimal("-194.23")  # DBIT
+    assert by_id["t1"].payee == "Netto"
+    assert by_id["t2"].postings[0].units.number == Decimal("2500.00")  # CRDT
+    assert by_id["t2"].payee == "Employer"
+
+
+def test_transaction_balances_via_counterpart(tmp_path):
+    txns = [FakeTxn("t1", "DBIT", Decimal("10.00"))]
+    imp = OpenBankingImporter(client=FakeClient(txns))
+    txn = next(
+        e for e in imp.extract(_write_config(tmp_path), []) if isinstance(e, data.Transaction)
+    )
+    assert len(txn.postings) == 2
+    assert txn.postings[1].account == "Expenses:Uncategorized"
+    assert txn.postings[1].units is None  # elided -> Beancount auto-balances
+
+
+def test_skips_unknown_indicator(tmp_path):
+    # An unsignable transaction must be skipped, never imported with a guessed sign.
+    txns = [FakeTxn("t1", "", Decimal("10.00")), FakeTxn("t2", "CRDT", Decimal("5.00"))]
+    imp = OpenBankingImporter(client=FakeClient(txns))
+    entries = imp.extract(_write_config(tmp_path), [])
+    ids = {e.meta["obio-id"] for e in entries if isinstance(e, data.Transaction)}
+    assert ids == {"t2"}
+
+
+def test_pending_is_flagged(tmp_path):
+    txns = [FakeTxn("t1", "DBIT", Decimal("9.00"), status="PDNG")]
+    imp = OpenBankingImporter(client=FakeClient(txns))
+    entries = imp.extract(_write_config(tmp_path), [])
+    txn = next(e for e in entries if isinstance(e, data.Transaction))
+    assert txn.flag == "!"
+
+
+def test_dedup_against_existing_ledger(tmp_path):
+    txns = [FakeTxn("t1", "DBIT", Decimal("1.00")), FakeTxn("t2", "CRDT", Decimal("2.00"))]
+    imp = OpenBankingImporter(client=FakeClient(txns))
+    cfg = _write_config(tmp_path)
+    first = imp.extract(cfg, [])
+    # Re-import with the first batch as "existing" -> nothing new.
+    second = imp.extract(cfg, first)
+    assert [e for e in second if isinstance(e, data.Transaction)] == []
+
+
+def test_pagination(tmp_path):
+    txns = [FakeTxn(f"t{i}", "CRDT", Decimal("1.00")) for i in range(1200)]
+    imp = OpenBankingImporter(client=FakeClient(txns))
+    entries = imp.extract(_write_config(tmp_path), [])
+    assert len([e for e in entries if isinstance(e, data.Transaction)]) == 1200
+
+
+def test_balance_assertion_from_booked(tmp_path):
+    txns = [FakeTxn("t1", "CRDT", Decimal("5.00"))]
+    accts = [
+        FakeAccount(
+            "acc-1",
+            balances=[
+                FakeBalance("ITAV", Decimal("123.60"), "DKK"),
+                FakeBalance("ITBD", Decimal("111.50"), "DKK"),
+            ],
+        )
+    ]
+    imp = OpenBankingImporter(client=FakeClient(txns, accounts=accts))
+    entries = imp.extract(_write_config(tmp_path, assert_balance=True), [])
+    bals = [e for e in entries if isinstance(e, data.Balance)]
+    assert len(bals) == 1
+    assert bals[0].amount.number == Decimal("111.50")  # ITBD, not ITAV
+    assert bals[0].account == "Assets:Bank:Nordea"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tools/bump-version.mjs
+++ b/tools/bump-version.mjs
@@ -3,7 +3,7 @@
 //
 //   node tools/bump-version.mjs <package> <version>
 //
-// <package> ∈ dotnet | node | n8n | python | rust | java | ruby   (go and php have no manifest)
+// <package> ∈ dotnet | node | n8n | python | rust | java | ruby | beancount   (go and php have no manifest)
 // <version> is a plain semver string, e.g. 0.2.0  or  1.0.0-rc.1
 //
 // Plain Node (>= 20), no dependencies. Edits the version field in the package's
@@ -17,7 +17,7 @@ import { dirname, join, resolve } from "node:path";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 
-const PACKAGES = ["dotnet", "node", "n8n", "python", "rust", "java", "go", "ruby", "php"];
+const PACKAGES = ["dotnet", "node", "n8n", "python", "rust", "java", "go", "ruby", "php", "beancount"];
 
 // SemVer 2.0.0 (https://semver.org) — practical, anchored.
 const SEMVER =
@@ -77,6 +77,16 @@ const bumpers = {
     // don't accidentally hit requires-python or a dependency spec.
     replaceOne(
       "python/pyproject.toml",
+      /(^version[ \t]*=[ \t]*")[^"]+(?="$)/m,
+      version,
+      'version = "..." (under [project])',
+    );
+  },
+
+  beancount(version) {
+    // The Beancount integration package — same pyproject shape as python/.
+    replaceOne(
+      "beancount/pyproject.toml",
       /(^version[ \t]*=[ \t]*")[^"]+(?="$)/m,
       version,
       'version = "..." (under [project])',


### PR DESCRIPTION
## What & why

Adds **`beancount-openbanking-io`** — a [Beancount](https://beancount.github.io/)/beangulp importer that pulls transactions from open-banking.io into a plaintext-accounting ledger, decrypting locally via the official `open-banking-io` Python SDK.

It lives as a new top-level `beancount/` directory, following the **`n8n/` integration precedent** (a package built on the contract, released independently, not nested under a language SDK). It's the first package to depend on a sibling SDK (`open-banking-io>=0.2` from PyPI).

Core mapping: unsigned `amount` × `creditDebitIndicator` → signed posting (**DBIT → −, CRDT → +**), stable `obio-id` dedup across re-imports, optional `ITBD` booked-balance assertions, and skip-on-unknown-direction (never guess a sign). Each entry gets an elided counterpart posting so it balances on import.

**Verified end-to-end against a live account:** 532 real transactions map to valid, balanced, zero-error Beancount with correct signs and working de-duplication (plus 8 hermetic unit tests).

> **Before the first release:** PyPI trusted publishing must be configured for project `beancount-openbanking-io` (this repo + `publish-beancount.yml` + the `Production` environment). Then release as usual via **Actions → Release → `beancount` → 0.1.0**.

## Affected SDK(s)
- [ ] dotnet · [ ] node · [ ] python · [ ] rust · [ ] go · [ ] java · [ ] ruby · [ ] php
- [x] shared (workflows, docs) — plus a **new `beancount/` integration package**

## Checklist
- [x] Tests pass locally for the affected package (`ruff check` · `ruff format --check` · `mypy src` · `pytest` — all green)
- [x] Linters/formatters pass
- [x] Envelope/wire format unchanged (importer is a downstream consumer of the SDK — no `fixtures/` change)
- [x] I did **not** bump any existing package's version (the new package declares its initial `0.1.0`, which the Release guard requires)

## Security checklist
- [x] No secrets, credentials, or session uids in code, logs, or error messages (the importer logs nothing; credentials are read by the SDK from the user's local bundle)
- [x] Money uses `Decimal`, never float
- [x] No disabled TLS; no new network egress (all network I/O is the `open-banking-io` SDK's documented API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
