### PR TITLE
ci: make changed-packages comment work for fork PRs

### DIFF
--- a/.github/workflows/changed-packages-comment.yml
+++ b/.github/workflows/changed-packages-comment.yml
@@ -1,0 +1,116 @@
+name: Changed packages comment
+
+# Posts the sticky "Changed client packages" comment on behalf of the
+# read-only "Changed packages" PR workflow, so fork PRs work too.
+#
+# SECURITY: this workflow runs with a write token in the base-repo context
+# while consuming an artifact produced by untrusted PR code. It therefore
+# only reads booleans + a PR number from the artifact, builds the comment
+# body itself, and verifies the claimed PR's head SHA matches the run that
+# produced the artifact before commenting.
+
+on:
+  workflow_run:
+    workflows: ['Changed packages']
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download report artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: changed-packages-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post sticky comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+
+            const MARKER = '<!-- changed-packages-report -->';
+            const ALL = ['dotnet', 'node', 'n8n', 'python', 'rust', 'java', 'go', 'ruby', 'php', 'beancount'];
+
+            // The artifact comes from an untrusted PR run: accept only a
+            // numeric PR number and per-package booleans, nothing else.
+            const report = JSON.parse(fs.readFileSync('report.json', 'utf8'));
+            const issue_number = report.pr_number;
+            if (!Number.isInteger(issue_number) || issue_number <= 0) {
+              core.setFailed(`Invalid pr_number in artifact: ${report.pr_number}`);
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+
+            // The PR number is attacker-controlled; make sure it names the PR
+            // this run was actually triggered for.
+            const { data: pr } = await github.rest.pulls.get({
+              owner, repo, pull_number: issue_number,
+            });
+            if (pr.head.sha !== context.payload.workflow_run.head_sha) {
+              core.setFailed(
+                `PR #${issue_number} head ${pr.head.sha} does not match ` +
+                `workflow_run head ${context.payload.workflow_run.head_sha}`,
+              );
+              return;
+            }
+
+            const changed = new Set();
+            for (const p of ALL) {
+              if (report.changed?.[p] === true) changed.add(p);
+            }
+            const fixtures = report.changed?.fixtures === true;
+            // Shared fixtures feed every client → treat all as affected.
+            if (fixtures) for (const p of ALL) changed.add(p);
+
+            const ordered = ALL.filter((p) => changed.has(p));
+
+            let body = `${MARKER}\n### Changed client packages\n\n`;
+            if (ordered.length === 0) {
+              body +=
+                'No client package directories changed — only shared infra ' +
+                '(workflows, docs, tooling). Nothing to release from this PR.\n';
+            } else {
+              if (fixtures) {
+                body +=
+                  '`fixtures/**` changed — shared test vectors affect **all** ' +
+                  'clients, so every package is listed below.\n\n';
+              }
+              body += '| Package | Release after merge |\n|---|---|\n';
+              for (const p of ordered) {
+                body +=
+                  `| \`${p}\` | Actions → **Release** → package \`${p}\`, ` +
+                  `then it tags \`${p}/vX.Y.Z\` |\n`;
+              }
+              body +=
+                '\nOnly the package you pick in the **Release** workflow is ' +
+                'published; each `publish-<pkg>.yml` triggers solely on its own ' +
+                '`<pkg>/v*` tag. See `RELEASING.md`.\n';
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(
+              (c) => c.body && c.body.includes(MARKER),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body,
+              });
+            }

--- a/.github/workflows/changed-packages.yml
+++ b/.github/workflows/changed-packages.yml
@@ -3,9 +3,10 @@ name: Changed packages
 on:
   pull_request:
 
+# Runs with the read-only fork token; the sticky comment is posted by
+# changed-packages-comment.yml (workflow_run), which has write access.
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   report:
@@ -15,7 +16,7 @@ jobs:
 
       - name: Detect changed package dirs
         id: filter
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             dotnet:
@@ -41,9 +42,9 @@ jobs:
             fixtures:
               - 'fixtures/**'
 
-      - name: Build and post sticky comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - name: Write report artifact
         env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           DOTNET: ${{ steps.filter.outputs.dotnet }}
           NODE: ${{ steps.filter.outputs.node }}
           N8N: ${{ steps.filter.outputs.n8n }}
@@ -55,60 +56,30 @@ jobs:
           PHP: ${{ steps.filter.outputs.php }}
           BEANCOUNT: ${{ steps.filter.outputs.beancount }}
           FIXTURES: ${{ steps.filter.outputs.fixtures }}
+        run: |
+          mkdir -p changed-packages-report
+          cat > changed-packages-report/report.json <<EOF
+          {
+            "pr_number": ${PR_NUMBER},
+            "changed": {
+              "dotnet": ${DOTNET},
+              "node": ${NODE},
+              "n8n": ${N8N},
+              "python": ${PYTHON},
+              "rust": ${RUST},
+              "java": ${JAVA},
+              "go": ${GO},
+              "ruby": ${RUBY},
+              "php": ${PHP},
+              "beancount": ${BEANCOUNT},
+              "fixtures": ${FIXTURES}
+            }
+          }
+          EOF
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          script: |
-            const MARKER = '<!-- changed-packages-report -->';
-            const ALL = ['dotnet', 'node', 'n8n', 'python', 'rust', 'java', 'go', 'ruby', 'php', 'beancount'];
-
-            const changed = new Set();
-            for (const p of ALL) {
-              if (process.env[p.toUpperCase()] === 'true') changed.add(p);
-            }
-            const fixtures = process.env.FIXTURES === 'true';
-            // Shared fixtures feed every client → treat all as affected.
-            if (fixtures) for (const p of ALL) changed.add(p);
-
-            const ordered = ALL.filter((p) => changed.has(p));
-
-            let body = `${MARKER}\n### Changed client packages\n\n`;
-            if (ordered.length === 0) {
-              body +=
-                'No client package directories changed — only shared infra ' +
-                '(workflows, docs, tooling). Nothing to release from this PR.\n';
-            } else {
-              if (fixtures) {
-                body +=
-                  '`fixtures/**` changed — shared test vectors affect **all** ' +
-                  'clients, so every package is listed below.\n\n';
-              }
-              body += '| Package | Release after merge |\n|---|---|\n';
-              for (const p of ordered) {
-                body +=
-                  `| \`${p}\` | Actions → **Release** → package \`${p}\`, ` +
-                  `then it tags \`${p}/vX.Y.Z\` |\n`;
-              }
-              body +=
-                '\nOnly the package you pick in the **Release** workflow is ' +
-                'published; each `publish-<pkg>.yml` triggers solely on its own ' +
-                '`<pkg>/v*` tag. See `RELEASING.md`.\n';
-            }
-
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner, repo, issue_number, per_page: 100,
-            });
-            const existing = comments.find(
-              (c) => c.body && c.body.includes(MARKER),
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner, repo, comment_id: existing.id, body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner, repo, issue_number, body,
-              });
-            }
+          name: changed-packages-report
+          path: changed-packages-report/report.json
+          retention-days: 1


### PR DESCRIPTION
## Summary

The `report` job in `changed-packages.yml` failed on fork PRs (e.g. #86, run 28901559706) with `403 Resource not accessible by integration`, because `pull_request` runs from forks get a read-only `GITHUB_TOKEN` regardless of the workflow's `permissions:` block.

This splits it into the GitHub-recommended `workflow_run` pattern:

- **`changed-packages.yml`** (`pull_request`, fork-safe): permissions reduced to `contents: read`. Detects changed package dirs via paths-filter and uploads `{pr_number, changed: {…}}` as a `changed-packages-report` artifact. The `report` job name is unchanged, so the required check is unaffected.
- **`changed-packages-comment.yml`** (new, `workflow_run` on "Changed packages"): posts/updates the same sticky comment with a write token.

## Security

The comment workflow runs with a write token against an artifact produced by untrusted PR code, so it:
- reads only per-package booleans and a PR number from the artifact and builds the markdown body itself,
- validates the PR number is a positive integer,
- verifies the claimed PR's head SHA matches `workflow_run.head_sha` before commenting, so a malicious PR can't target another PR.

Note: the `workflow_run` trigger reads the workflow from the default branch, so the comment only starts working after this merges. Do **not** add the `comment` job as a required check — it isn't attached to PR commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated “Changed packages” comment that stays updated on pull requests and lists affected client packages with release guidance.
  * Changed package detection now publishes a report for downstream handling, improving reliability of the posted summary.

* **Security Improvements**
  * Added checks to ensure the comment always matches the correct pull request, reducing the risk of incorrect updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->