### PR TITLE
chore: apply remaining CodeRabbit findings from #86/#96

### DIFF
--- a/.github/workflows/changed-packages-comment.yml
+++ b/.github/workflows/changed-packages-comment.yml
@@ -14,13 +14,20 @@ on:
     workflows: ['Changed packages']
     types: [completed]
 
-permissions:
-  actions: read
-  pull-requests: write
+permissions: {}
+
+# One comment run per source branch at a time — a newer push supersedes older runs.
+concurrency:
+  group: changed-packages-comment-${{ github.event.workflow_run.head_repository.owner.login }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
 
 jobs:
   comment:
     runs-on: ubuntu-latest
+    # Only this job needs the write token — keep it off the workflow level.
+    permissions:
+      actions: read
+      pull-requests: write
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/changed-packages.yml
+++ b/.github/workflows/changed-packages.yml
@@ -8,11 +8,18 @@ on:
 permissions:
   contents: read
 
+# Rapid pushes to the same PR queue redundant report runs — keep only the latest.
+concurrency:
+  group: changed-packages-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   report:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Detect changed package dirs
         id: filter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       erpnext: ${{ steps.cp.outputs.erpnext }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - id: cp
         uses: ./.github/actions/changed-packages
 
@@ -35,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: |
@@ -56,6 +60,8 @@ jobs:
         working-directory: node
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
@@ -78,6 +84,8 @@ jobs:
         working-directory: n8n
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
@@ -102,6 +110,8 @@ jobs:
         working-directory: python
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -120,6 +130,8 @@ jobs:
         working-directory: rust
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy, rustfmt
@@ -149,6 +161,8 @@ jobs:
         working-directory: go
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ matrix.go-version }}
@@ -174,6 +188,8 @@ jobs:
         working-directory: java
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
@@ -193,6 +209,8 @@ jobs:
         working-directory: ruby
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
@@ -213,6 +231,8 @@ jobs:
         working-directory: php
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-version }}
@@ -235,6 +255,8 @@ jobs:
         working-directory: beancount
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -256,6 +278,8 @@ jobs:
         working-directory: zapier
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
@@ -274,6 +298,8 @@ jobs:
         working-directory: erpnext
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}

--- a/zapier/lib/client.js
+++ b/zapier/lib/client.js
@@ -100,7 +100,7 @@ function importBundleKey(bundle) {
  */
 async function mapAccount(key, a) {
   const acc = await decryptTo(key, a.enc);
-  const name = await decryptTo(key, a.displayNameEnc);
+  const nameEnvelope = await decryptTo(key, a.displayNameEnc);
   const balances = await Promise.all(
     (a.balances ?? []).map(async (b) => {
       const dec = await decryptTo(key, b.enc);
@@ -127,7 +127,7 @@ async function mapAccount(key, a) {
     ownerName: acc?.ownerName ?? null,
     accountName: acc?.accountName ?? null,
     product: acc?.product ?? null,
-    displayName: name?.displayName ?? null,
+    displayName: nameEnvelope?.displayName ?? null,
     balances,
   };
 }

--- a/zapier/triggers/new_transaction.js
+++ b/zapier/triggers/new_transaction.js
@@ -60,20 +60,29 @@ const trigger = {
       const from = state.lastBookingDate ?? isoDaysAgo(lookbackDays);
 
       // Fetch all accounts, then transactions for each from the cursor date.
+      // The per-account fetches are independent, so they run in parallel;
+      // the results are merged sequentially to keep dedup/cursor logic simple.
       const accounts = await apiRequest(z, bundleResolved, 'GET', '/api/accounts');
+      const wiresByAccount = await Promise.all(
+        accounts.map((account) =>
+          collectTransactionWires(
+            (offset, limit) =>
+              apiRequest(z, bundleResolved, 'GET', transactionsPath(account.id), {
+                from,
+                offset,
+                limit,
+              }),
+            Number.POSITIVE_INFINITY,
+          ).then((wires) => ({ account, wires })),
+        ),
+      );
+
       const seen = new Set(state.seenIds ?? []);
       const fresh = [];
       const emitted = [];
       let maxBookingDate = from;
 
-      for (const account of accounts) {
-        const path = transactionsPath(account.id);
-        const wires = await collectTransactionWires(
-          (offset, limit) =>
-            apiRequest(z, bundleResolved, 'GET', path, { from, offset, limit }),
-          Number.POSITIVE_INFINITY,
-        );
-
+      for (const { account, wires } of wiresByAccount) {
         for (const wire of wires) {
           if (seen.has(wire.id)) continue;
           seen.add(wire.id);

--- a/zapier/triggers/new_transaction.js
+++ b/zapier/triggers/new_transaction.js
@@ -60,22 +60,30 @@ const trigger = {
       const from = state.lastBookingDate ?? isoDaysAgo(lookbackDays);
 
       // Fetch all accounts, then transactions for each from the cursor date.
-      // The per-account fetches are independent, so they run in parallel;
+      // The per-account fetches are independent, so they run in parallel —
+      // capped per chunk so many linked accounts can't burst the API — and
       // the results are merged sequentially to keep dedup/cursor logic simple.
+      const MAX_CONCURRENT_ACCOUNTS = 4;
       const accounts = await apiRequest(z, bundleResolved, 'GET', '/api/accounts');
-      const wiresByAccount = await Promise.all(
-        accounts.map((account) =>
-          collectTransactionWires(
-            (offset, limit) =>
-              apiRequest(z, bundleResolved, 'GET', transactionsPath(account.id), {
-                from,
-                offset,
-                limit,
-              }),
-            Number.POSITIVE_INFINITY,
-          ).then((wires) => ({ account, wires })),
-        ),
-      );
+      const wiresByAccount = [];
+      for (let i = 0; i < accounts.length; i += MAX_CONCURRENT_ACCOUNTS) {
+        const chunk = accounts.slice(i, i + MAX_CONCURRENT_ACCOUNTS);
+        wiresByAccount.push(
+          ...(await Promise.all(
+            chunk.map((account) =>
+              collectTransactionWires(
+                (offset, limit) =>
+                  apiRequest(z, bundleResolved, 'GET', transactionsPath(account.id), {
+                    from,
+                    offset,
+                    limit,
+                  }),
+                Number.POSITIVE_INFINITY,
+              ).then((wires) => ({ account, wires })),
+            ),
+          )),
+        );
+      }
 
       const seen = new Set(state.seenIds ?? []);
       const fresh = [];


### PR DESCRIPTION
Closes out the CodeRabbit findings from #86 and #96 that never became resolvable review threads (inline comments that failed to post, and outside-diff-range notes):

- **ci.yml** — `persist-credentials: false` on all 13 checkout steps (the repo-wide hardening pass deferred from both PRs; none of these jobs push).
- **changed-packages.yml** — per-PR concurrency guard (cancel superseded report runs) + hardened checkout.
- **changed-packages-comment.yml** — per-source-branch concurrency guard; `actions: read` / `pull-requests: write` moved from workflow level down to the comment job (least privilege).
- **zapier/triggers/new_transaction.js** — per-account transaction fetches were serialized by `await` in a loop; they now run in parallel and merge sequentially, keeping dedup/cursor behavior identical.
- **zapier/lib/client.js** — rename `name` → `nameEnvelope` in `mapAccount` (it holds a decrypted envelope object, not a string).

Zapier tests: 21 passing in a node:20 container (`npm ci && npm test`, same as CI).

Declined (with reasons already on the PR threads): pinning the erpnext CI pip deps (tracks Frappe-shipped releases deliberately, nothing to lock against) and re-adding zapier lint/typecheck (removed in #96 as no-ops; proper configs can come back separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-account transaction loading by fetching account transaction wires in parallel.
  * Fixed the Zapier transaction account `displayName` mapping to use the correct decrypted name value.
* **Chores**
  * Reduced redundant workflow executions by enabling concurrency controls.
  * Tightened workflow write permissions for changed-package comments.
  * Disabled git credential persistence across CI checkouts for safer runner behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->