### PR TITLE
fix(zapier): pin zapier-platform-core exactly; release 0.1.1

### DIFF
--- a/zapier/package-lock.json
+++ b/zapier/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "open-banking-io-zapier",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-banking-io-zapier",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "zapier-platform-core": "^19.0.0"
+        "zapier-platform-core": "19.0.0"
       },
       "devDependencies": {
         "chai": "^4.5.0",
         "mocha": "^10.8.0",
-        "zapier-platform-schema": "^19.0.0"
+        "zapier-platform-schema": "19.0.0"
       },
       "engines": {
         "node": ">=20"

--- a/zapier/package.json
+++ b/zapier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-banking-io-zapier",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Zapier integration for open-banking.io: connect your bank accounts and pull transactions into Zapier workflows with client-side, zero-knowledge decryption.",
   "license": "MIT",
   "author": {
@@ -29,11 +29,11 @@
     "node": ">=20"
   },
   "dependencies": {
-    "zapier-platform-core": "^19.0.0"
+    "zapier-platform-core": "19.0.0"
   },
   "devDependencies": {
     "chai": "^4.5.0",
     "mocha": "^10.8.0",
-    "zapier-platform-schema": "^19.0.0"
+    "zapier-platform-schema": "19.0.0"
   }
 }

--- a/zapier/test/app.test.js
+++ b/zapier/test/app.test.js
@@ -55,12 +55,11 @@ describe('app definition', () => {
 
   it('pins zapier-platform packages to exact versions', () => {
     // `zapier push` refuses range specifiers like ^19.0.0 for core; the
-    // schema devDependency is pinned to match so validation and upload
-    // always agree on the platform version.
+    // schema devDependency is pinned the same way so validation results
+    // don't drift under a floating range.
+    const EXACT = /^\d+\.\d+\.\d+$/;
     const pkg = require('../package.json');
-    expect(pkg.dependencies['zapier-platform-core']).to.match(/^\d+\.\d+\.\d+$/);
-    expect(pkg.devDependencies['zapier-platform-schema']).to.equal(
-      pkg.dependencies['zapier-platform-core'],
-    );
+    expect(pkg.dependencies['zapier-platform-core']).to.match(EXACT);
+    expect(pkg.devDependencies['zapier-platform-schema']).to.match(EXACT);
   });
 });

--- a/zapier/test/app.test.js
+++ b/zapier/test/app.test.js
@@ -53,9 +53,14 @@ describe('app definition', () => {
     }
   });
 
-  it('pins zapier-platform-core to an exact version', () => {
-    // `zapier push` refuses range specifiers like ^19.0.0.
+  it('pins zapier-platform packages to exact versions', () => {
+    // `zapier push` refuses range specifiers like ^19.0.0 for core; the
+    // schema devDependency is pinned to match so validation and upload
+    // always agree on the platform version.
     const pkg = require('../package.json');
     expect(pkg.dependencies['zapier-platform-core']).to.match(/^\d+\.\d+\.\d+$/);
+    expect(pkg.devDependencies['zapier-platform-schema']).to.equal(
+      pkg.dependencies['zapier-platform-core'],
+    );
   });
 });

--- a/zapier/test/app.test.js
+++ b/zapier/test/app.test.js
@@ -52,4 +52,10 @@ describe('app definition', () => {
       }
     }
   });
+
+  it('pins zapier-platform-core to an exact version', () => {
+    // `zapier push` refuses range specifiers like ^19.0.0.
+    const pkg = require('../package.json');
+    expect(pkg.dependencies['zapier-platform-core']).to.match(/^\d+\.\d+\.\d+$/);
+  });
 });


### PR DESCRIPTION
The v0.1.0 release made it through tests, the tag/version check, and the subtree-split — then failed at the very last step: \`zapier push\` refuses range specifiers (\`Your app must depend on an exact version of zapier-platform-core\`).

- \`zapier-platform-core\` (and \`-schema\`) pinned to \`19.0.0\` exactly; lockfile regenerated.
- New test asserts the exact-pin so this can't regress (28 tests total, green in node:20 container).
- Version bumped to 0.1.1 — the v0.1.0 tag's pipeline already ran and nothing was uploaded, so we release fresh as \`zapier/v0.1.1\` rather than force-moving a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the Zapier integration package version to `0.1.1`.
  * Tightened Zapier platform dependency versioning by pinning platform packages to exact `X.Y.Z` releases (no version ranges).

* **Tests**
  * Added a test that validates the pinned platform versions are exact semantic version strings (`X.Y.Z`) for runtime and dev dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->