### PR TITLE
fix(zapier): add search field to Find Account (check D009); release 0.1.2

### DIFF
--- a/zapier/package-lock.json
+++ b/zapier/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-banking-io-zapier",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-banking-io-zapier",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "zapier-platform-core": "19.0.0"

--- a/zapier/package.json
+++ b/zapier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-banking-io-zapier",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Zapier integration for open-banking.io: connect your bank accounts and pull transactions into Zapier workflows with client-side, zero-knowledge decryption.",
   "license": "MIT",
   "author": {

--- a/zapier/searches/list_accounts.js
+++ b/zapier/searches/list_accounts.js
@@ -7,10 +7,31 @@ module.exports = {
   noun: 'Account',
   display: {
     label: 'Find Account',
-    description: 'Lists all bank accounts with decrypted details and balances.',
+    description: 'Finds bank accounts by IBAN, name or bank — or lists all accounts.',
   },
   operation: {
-    perform: (z, bundle) => listAccounts(z, bundle.authData),
+    // Zapier integration check D009: a search needs at least one input field.
+    inputFields: [
+      {
+        key: 'query',
+        type: 'string',
+        label: 'Search Term',
+        required: false,
+        helpText:
+          'Optional. Case-insensitive match against IBAN, BBAN, account name, ' +
+          'display name, owner name and bank name. Leave empty to return all accounts.',
+      },
+    ],
+    perform: async (z, bundle) => {
+      const accounts = await listAccounts(z, bundle.authData);
+      const query = String(bundle.inputData.query ?? '').trim().toLowerCase();
+      if (!query) return accounts;
+      return accounts.filter((a) =>
+        [a.iban, a.bban, a.accountName, a.displayName, a.ownerName, a.aspspName]
+          .filter(Boolean)
+          .some((v) => String(v).toLowerCase().includes(query)),
+      );
+    },
     sample: {
       id: 'acc_001',
       aspspName: 'Danske Bank',


### PR DESCRIPTION
The v0.1.1 push cleared the exact-pin error but hit Zapier's server-side integration checks: **D009 — a search requires at least one input field** (\`list_accounts\` had none). That's the only blocking error; the remaining findings are non-blocking warnings (D028 cleanInputData, D002/D026 auth-field help links) that only matter for public App Directory review.

- *Find Account* gains an optional \`query\` field — case-insensitive substring match over IBAN, BBAN, account/display/owner name and bank name; empty query returns all accounts (dropdowns are unaffected — they use the hidden trigger).
- Version 0.1.2 (0.1.1's tag pipeline ran; nothing was uploaded).
- 28 tests green in node:20 container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional account search in the Zapier integration, allowing users to filter results by account details such as IBAN/BBAN, account name, owner, and bank.
  * If no search term is entered, all accounts are returned as before.

* **Chores**
  * Bumped the Zapier integration version to `0.1.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->