### PR TITLE
chore(zapier): bump to 0.2.0 for first platform upload

### DIFF
--- a/zapier/package-lock.json
+++ b/zapier/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-banking-io-zapier",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-banking-io-zapier",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "zapier-platform-core": "19.0.0"

--- a/zapier/package.json
+++ b/zapier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-banking-io-zapier",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Zapier integration for open-banking.io: connect your bank accounts and pull transactions into Zapier workflows with client-side, zero-knowledge decryption.",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
The v0.1.2 push cleared schema + style + integration checks and failed only at upload: Zapier enforces patch-version contiguity (\`Version 0.1.2 requires 0.1.1 to exist\`). Since 0.1.0/0.1.1 were never uploaded (earlier pushes failed before the upload step), the first platform version must be an x.y.0 — starting cleanly at **0.2.0**. Version-only change; 28 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Zapier package version from `0.1.2` to `0.2.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->