### PR TITLE
chore(zapier): version 1.0.0 for the first platform upload

### DIFF
--- a/zapier/package-lock.json
+++ b/zapier/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-banking-io-zapier",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-banking-io-zapier",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "zapier-platform-core": "19.0.0"

--- a/zapier/package.json
+++ b/zapier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-banking-io-zapier",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Zapier integration for open-banking.io: connect your bank accounts and pull transactions into Zapier workflows with client-side, zero-knowledge decryption.",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Third and final version-numbering round with the Zapier platform: uploads are checked for contiguity against existing versions (\`0.1.2\` demanded \`0.1.1\`, \`0.2.0\` demanded \`0.1.x\`) — and since nothing has ever been uploaded, the accepted starting point is the canonical \`1.0.0\` (the \`zapier init\` scaffold default, and the version John's original deploy plan used). Version-only change; 28 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from `0.2.0` to `1.0.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->