### PR TITLE
feat(zapier): App Directory publication prep; release 1.0.1

### DIFF
--- a/zapier/.github/workflows/promote.yml
+++ b/zapier/.github/workflows/promote.yml
@@ -1,0 +1,39 @@
+name: Promote
+
+# Runs in the open-banking-io/zapier mirror repo. Promotes an already-pushed
+# version to production on the Zapier platform (required before inviting
+# users or submitting to the App Directory). Manual, deliberate action.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to promote (must already be pushed, e.g. 1.0.1)'
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: promote
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - run: npm ci
+
+      - name: Promote version
+        env:
+          ZAPIER_DEPLOY_KEY: ${{ secrets.ZAPIER_DEPLOY_KEY }}
+          VERSION: ${{ inputs.version }}
+        run: npx --yes zapier-platform-cli@19 promote "$VERSION" --yes

--- a/zapier/.github/workflows/promote.yml
+++ b/zapier/.github/workflows/promote.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/zapier/authentication.js
+++ b/zapier/authentication.js
@@ -31,7 +31,8 @@ module.exports = {
       helpText:
         'Paste the credentials bundle JSON you exported from open-banking.io (or the CLI). ' +
         'It contains "apiBaseUrl", "apiKey" and "encryptionKey.privateKey". ' +
-        'The private key never leaves this Zapier connection — it is used only to decrypt data locally.',
+        'The private key never leaves this Zapier connection — it is used only to decrypt data locally. ' +
+        'See the [setup guide](https://github.com/open-banking-io/zapier#credentials) for how to export the bundle.',
       computed: false,
       altersDynamicFields: false,
     },
@@ -42,7 +43,9 @@ module.exports = {
       required: false,
       helpText:
         'Optional. Overrides the "apiBaseUrl" embedded in the bundle — e.g. to point ' +
-        'at a staging or local environment. Leave empty to use the URL from the bundle.',
+        'at a staging or self-hosted environment. Must be a full http(s) URL. Leave empty ' +
+        'to use the URL from the bundle. See the ' +
+        '[setup guide](https://github.com/open-banking-io/zapier#credentials) for details.',
       computed: false,
       altersDynamicFields: false,
     },

--- a/zapier/index.js
+++ b/zapier/index.js
@@ -15,6 +15,12 @@ module.exports = {
   version: pkg.version,
   platformVersion: require('zapier-platform-core').version,
 
+  flags: {
+    // Integration check D028: opt out of the platform's automatic input
+    // cleaning; every perform handles ''/null explicitly instead.
+    cleanInputData: false,
+  },
+
   authentication,
 
   triggers: {

--- a/zapier/lib/client.js
+++ b/zapier/lib/client.js
@@ -23,6 +23,24 @@ function stripTrailingSlashes(value) {
 }
 
 /**
+ * Asserts a user/bundle-supplied base URL is a parseable http(s) URL
+ * (integration check D026: manually validate domain-style auth input).
+ * @param {string} value
+ * @param {string} label — for the error message
+ */
+function assertHttpUrl(value, label) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${label} must be a valid URL (got "${value}")`);
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error(`${label} must be an http(s) URL (got "${url.protocol}//…")`);
+  }
+}
+
+/**
  * Parses and validates the credentials-bundle JSON the user pasted into auth.
  * @param {string} raw — the bundle JSON string
  * @returns {Bundle}
@@ -46,6 +64,7 @@ function parseBundle(raw) {
   if (!apiBaseUrl) throw new Error('Credentials bundle is missing "apiBaseUrl"');
   if (!apiKey) throw new Error('Credentials bundle is missing "apiKey"');
   if (!privateKey) throw new Error('Credentials bundle is missing "encryptionKey.privateKey"');
+  assertHttpUrl(apiBaseUrl, '"apiBaseUrl" in the credentials bundle');
 
   return { apiBaseUrl, apiKey, privateKey };
 }
@@ -58,7 +77,10 @@ function parseBundle(raw) {
 function resolveBundle(authData) {
   const bundle = parseBundle(authData.bundle);
   const override = stripTrailingSlashes(String(authData.baseUrlOverride ?? '').trim());
-  if (override) bundle.apiBaseUrl = override;
+  if (override) {
+    assertHttpUrl(override, 'API Base URL Override');
+    bundle.apiBaseUrl = override;
+  }
   return bundle;
 }
 

--- a/zapier/package-lock.json
+++ b/zapier/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-banking-io-zapier",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-banking-io-zapier",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "zapier-platform-core": "19.0.0"

--- a/zapier/package.json
+++ b/zapier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-banking-io-zapier",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Zapier integration for open-banking.io: connect your bank accounts and pull transactions into Zapier workflows with client-side, zero-knowledge decryption.",
   "license": "MIT",
   "author": {

--- a/zapier/searches/list_transactions.js
+++ b/zapier/searches/list_transactions.js
@@ -55,8 +55,11 @@ module.exports = {
       const bundleResolved = resolveBundle(bundle.authData);
       const key = await importBundleKey(bundleResolved);
       const accountId = bundle.inputData.accountId;
-      // ?? (not ||) so an explicit 0 is honoured and returns no rows.
-      const limit = Number(bundle.inputData.limit ?? 50);
+      // ''/null mean "unset" (cleanInputData is off) → default 50; an
+      // explicit 0 is honoured and returns no rows; NaN falls back to 50.
+      const limitInput = bundle.inputData.limit;
+      const limitRaw = limitInput === '' || limitInput == null ? 50 : Number(limitInput);
+      const limit = Number.isFinite(limitRaw) && limitRaw >= 0 ? limitRaw : 50;
 
       const qs = {};
       if (bundle.inputData.from) qs.from = bundle.inputData.from;

--- a/zapier/test/client.test.js
+++ b/zapier/test/client.test.js
@@ -36,4 +36,25 @@ describe('resolveBundle()', () => {
   it('still rejects an invalid bundle', () => {
     expect(() => resolveBundle({ bundle: 'not json' })).to.throw(/not valid JSON/);
   });
+
+  it('rejects an override that is not a URL', () => {
+    expect(() => resolveBundle({ bundle: BUNDLE, baseUrlOverride: 'not a url' })).to.throw(
+      /must be a valid URL/,
+    );
+  });
+
+  it('rejects a non-http(s) override', () => {
+    expect(() => resolveBundle({ bundle: BUNDLE, baseUrlOverride: 'ftp://x.test' })).to.throw(
+      /must be an http\(s\) URL/,
+    );
+  });
+
+  it('rejects a bundle whose apiBaseUrl is not a URL', () => {
+    const bad = JSON.stringify({
+      apiBaseUrl: 'nonsense',
+      apiKey: 'k',
+      encryptionKey: { privateKey: 'p' },
+    });
+    expect(() => resolveBundle({ bundle: bad })).to.throw(/must be a valid URL/);
+  });
 });

--- a/zapier/triggers/new_transaction.js
+++ b/zapier/triggers/new_transaction.js
@@ -44,8 +44,12 @@ const trigger = {
       const bundleResolved = resolveBundle(bundle.authData);
 
       const key = await importBundleKey(bundleResolved);
-      // Mapped custom values are not guaranteed numeric — fall back on NaN/negatives.
-      const lookbackRaw = Number(bundle.inputData.lookbackDays ?? 7);
+      // Mapped custom values are not guaranteed numeric, and with
+      // cleanInputData off an empty string means "unset" — fall back to 7
+      // on '', NaN and negatives.
+      const lookbackInput = bundle.inputData.lookbackDays;
+      const lookbackRaw =
+        lookbackInput === '' || lookbackInput == null ? 7 : Number(lookbackInput);
       const lookbackDays = Number.isFinite(lookbackRaw) && lookbackRaw >= 0 ? lookbackRaw : 7;
 
       // Parse cursor state persisted by the previous poll (JSON string).


### PR DESCRIPTION
Prepares the integration for public App Directory submission by clearing every remaining \`zapier validate\` warning:

- **D028** — \`flags.cleanInputData: false\` app-wide, with explicit \`''\`/null handling in every input parse (\`lookbackDays\`, \`limit\` treat \`''\` as unset; explicit \`0\` still honoured).
- **D002** — both auth fields' helpText now link to the setup guide.
- **D026** — manual validation of domain-style input: the base-URL override and the bundle's \`apiBaseUrl\` must be parseable http(s) URLs (clear errors otherwise).
- **New Promote workflow** (mirror, \`workflow_dispatch\`) — \`zapier promote <version>\` becomes a deliberate button-press using the CI deploy key; promotion is required before user invites / directory submission.

Version 1.0.1; 31 tests green in the CI-identical container.

Remaining for the actual submission (Zapier developer UI, John's account): logo upload, listing copy/category, converting audience from private → public, and the review submission itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for custom API URLs to accept only valid `http(s)` addresses.
  * Fixed handling of empty or missing numeric inputs to apply consistent defaults (while still allowing `0`).
  * Adjusted transaction limit and lookback behavior to correctly treat blank values without relying on automatic input cleanup.
* **Documentation**
  * Updated connection help text for custom auth to clarify API URL requirements and add direct setup guidance links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->