### PR TITLE
docs(zapier): add CHANGELOG.md (required by zapier promote)

### DIFF
--- a/zapier/CHANGELOG.md
+++ b/zapier/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 1.0.1
+
+- Explicit input handling app-wide (`cleanInputData: false`): empty values fall back to sane defaults.
+- Base URLs (credentials bundle and override) are validated as http(s) URLs with clear error messages.
+- Auth fields link to the setup guide.
+
+## 1.0.0
+
+Initial release.
+
+- **New Transaction** polling trigger with incremental cursor and pending-transaction handling.
+- **Find Account** and **Find Transactions** searches with decrypted account and statement data.
+- **Sync Account** action to pull fresh transactions from the bank.
+- Zero-knowledge decryption: all sensitive data is decrypted inside Zapier with your private key; the service only ever stores ciphertext.


### PR DESCRIPTION
\`zapier promote\` refuses to run without a CHANGELOG.md in the app root (it attaches the version's entry to the promotion). Adds entries for 1.0.0 and 1.0.1. Also being placed directly on the mirror so 1.0.1 can be promoted without another release; this commit keeps the monorepo (source of truth) consistent for future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for versions 1.0.1 and 1.0.0.
  * Clarified input handling, URL validation, and setup guidance.
  * Included the original feature overview for polling, search, sync, and decryption behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->