### PR TITLE
feat(erpnext): release + mirror distribution infrastructure

### DIFF
--- a/.github/workflows/changed-packages-comment.yml
+++ b/.github/workflows/changed-packages-comment.yml
@@ -46,7 +46,7 @@ jobs:
             const fs = require('fs');
 
             const MARKER = '<!-- changed-packages-report -->';
-            const ALL = ['dotnet', 'node', 'n8n', 'python', 'rust', 'java', 'go', 'ruby', 'php', 'beancount', 'zapier'];
+            const ALL = ['dotnet', 'node', 'n8n', 'python', 'rust', 'java', 'go', 'ruby', 'php', 'beancount', 'zapier', 'erpnext'];
 
             // The artifact comes from an untrusted PR run: accept only a
             // numeric PR number and per-package booleans, nothing else.

--- a/.github/workflows/publish-erpnext.yml
+++ b/.github/workflows/publish-erpnext.yml
@@ -1,0 +1,88 @@
+name: Publish ERPNext
+
+# Source of truth is this monorepo (erpnext/). On an erpnext/v* tag we test the
+# app, then subtree-split erpnext/ and force-push it (plus a v* tag) to the
+# open-banking-io/erpnext mirror, where the Frappe app sits at the repo root so
+# users can `bench get-app https://github.com/open-banking-io/erpnext`.
+
+on:
+  push:
+    tags: ['erpnext/v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-erpnext-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.13']
+    defaults:
+      run:
+        working-directory: erpnext
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install pytest cryptography requests
+      - run: python -m pytest tests/ -v
+      # Fail before the mirror push if the tag doesn't match the manifest.
+      - name: Verify tag matches manifest version
+        if: startsWith(github.ref, 'refs/tags/erpnext/v')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#erpnext/v}"
+          MANIFEST_VERSION="$(grep -oE '^version[[:space:]]*=[[:space:]]*"[^"]+"' pyproject.toml | head -1 | sed -E 's/.*"([^"]+)"/\1/')"
+          INIT_VERSION="$(grep -oE '^__version__[[:space:]]*=[[:space:]]*"[^"]+"' erpnext_open_banking/__init__.py | head -1 | sed -E 's/.*"([^"]+)"/\1/')"
+          echo "tag=$TAG_VERSION pyproject=$MANIFEST_VERSION __init__=$INIT_VERSION"
+          [ "$TAG_VERSION" = "$MANIFEST_VERSION" ] || { echo "::error::tag $TAG_VERSION != pyproject $MANIFEST_VERSION"; exit 1; }
+          [ "$TAG_VERSION" = "$INIT_VERSION" ] || { echo "::error::tag $TAG_VERSION != __init__ $INIT_VERSION"; exit 1; }
+
+  mirror:
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/erpnext/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Compute mirror tag
+        run: echo "MIRROR_TAG=${GITHUB_REF_NAME#erpnext/}" >> "$GITHUB_ENV"
+
+      - name: Subtree-split erpnext/ and push to the open-banking-io/erpnext mirror
+        env:
+          MIRROR_TOKEN: ${{ secrets.MIRROR_PUSH_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name  "open-banking-io-bot"
+          git config user.email "bot@open-banking.io"
+          SPLIT_SHA="$(git subtree split --prefix=erpnext)"
+          echo "split sha: $SPLIT_SHA"
+          REMOTE="https://x-access-token:${MIRROR_TOKEN}@github.com/open-banking-io/erpnext.git"
+          git push --force "$REMOTE" "${SPLIT_SHA}:refs/heads/main"
+          git tag -f "${MIRROR_TAG}" "${SPLIT_SHA}"
+          git push --force "$REMOTE" "refs/tags/${MIRROR_TAG}"
+
+      - name: Verify the mirror received the tag
+        env:
+          MIRROR_TOKEN: ${{ secrets.MIRROR_PUSH_TOKEN }}
+        run: |
+          REMOTE="https://x-access-token:${MIRROR_TOKEN}@github.com/open-banking-io/erpnext.git"
+          for i in $(seq 1 10); do
+            if git ls-remote --exit-code "$REMOTE" "refs/tags/${MIRROR_TAG}" > /dev/null; then
+              echo "mirror tag ${MIRROR_TAG} present ✓"; exit 0
+            fi
+            echo "waiting for mirror tag ${MIRROR_TAG}..."; sleep 3
+          done
+          echo "::error::mirror tag ${MIRROR_TAG} not found on open-banking-io/erpnext — the subtree-split push failed (check MIRROR_PUSH_TOKEN)"
+          exit 1

--- a/.github/workflows/publish-erpnext.yml
+++ b/.github/workflows/publish-erpnext.yml
@@ -13,8 +13,11 @@ on:
 permissions:
   contents: read
 
+# Fixed group (not per-ref) so all erpnext releases serialize: the mirror push
+# is a non-idempotent `git push --force`, and overlapping runs for different
+# tags could otherwise apply out of order and revert the mirror to stale content.
 concurrency:
-  group: publish-erpnext-${{ github.ref }}
+  group: publish-erpnext
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ on:
           - php
           - cli
           - beancount
+          - erpnext
       version:
         description: New version, e.g. 0.2.0 (no leading "v")
         required: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,8 +11,9 @@ Every release is a **package-prefixed git tag**:
 <dir>/vX.Y.Z
 ```
 
-where `<dir>` ∈ `dotnet`, `node`, `python`, `rust`, `java`, `go`, `ruby`, `php`, and `X.Y.Z` is a
-[SemVer](https://semver.org) version (the literal `v` is part of the prefix, e.g. `node/v0.2.0`).
+where `<dir>` ∈ `dotnet`, `node`, `python`, `rust`, `java`, `go`, `ruby`, `php`, `beancount`, `erpnext`,
+`zapier`, `cli`, and `X.Y.Z` is a [SemVer](https://semver.org) version (the literal `v` is part of the
+prefix, e.g. `node/v0.2.0`).
 
 Each `publish-<dir>.yml` triggers **only** on its own `<dir>/v*` tags, so tagging `node/v0.2.0` publishes
 the Node package and nothing else.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,6 +29,9 @@ the Node package and nothing else.
 | `ruby`   | `ruby/lib/open_banking_io/version.rb` (`VERSION`) | gemspec |
 | `go`     | **none** — version *is* the tag; `Version` const in `go/client.go` is cosmetic (User-Agent) | — |
 | `php`    | **none** — Packagist derives version from the tag; `Client::VERSION` const is cosmetic | — |
+| `beancount` | `beancount/pyproject.toml` (`[project].version`) | — |
+| `erpnext` | `erpnext/pyproject.toml` (`[project].version`) | `erpnext/erpnext_open_banking/__init__.py` (`__version__`) |
+| `zapier` | `zapier/package.json` (`version`) | `zapier/package-lock.json` |
 
 ## Cutting a release (two steps — `main` is protected)
 
@@ -76,6 +79,25 @@ cut `cli/vX.Y.Z`.
 Prerequisites for the Homebrew step: the `open-banking-io/homebrew-tap` repo must
 exist, and a `HOMEBREW_TAP_TOKEN` secret (a PAT with write access to that tap repo)
 must be set on this repo — the default `GITHUB_TOKEN` can't push to another repo.
+
+### ERPNext app specifics (`erpnext_open_banking`)
+
+The `erpnext` package is a **Frappe/ERPNext app**, distributed by git (there is no
+registry — `bench get-app` clones a repo). Tagging `erpnext/vX.Y.Z` triggers
+`publish-erpnext.yml`, which runs the pytest suite, verifies `tag == pyproject ==
+__init__.__version__`, then **subtree-splits** `erpnext/` and force-pushes it (plus
+the `vX.Y.Z` tag) to the **`open-banking-io/erpnext` mirror**, where the app sits at
+the repo root so users can:
+
+```bash
+bench get-app https://github.com/open-banking-io/erpnext --branch v0.1.0
+bench --site <site> install-app erpnext_open_banking
+```
+
+Same subtree-split model as `n8n`, `php`, and `zapier`. Requires the
+`MIRROR_PUSH_TOKEN` secret (shared with the other mirrors) and the mirror repo to
+exist. Anything committed only to the mirror is wiped by the next release's
+force-push — the monorepo `erpnext/` is the single source of truth.
 
 ## The version-consistency gate
 

--- a/erpnext/README.md
+++ b/erpnext/README.md
@@ -46,19 +46,22 @@ your ERPNext instance.
 
 ## Installation
 
-This app lives in the `erpnext/` subdirectory of the
-[open-banking-io/clients](https://github.com/open-banking-io/clients) monorepo
-(alongside the Python, Node, Rust, Go and other SDKs), so clone the monorepo
-and point `bench get-app` at the subdirectory:
+Install directly from the dedicated app repo (a root-level mirror of this
+directory, so `bench get-app` works with a plain URL):
 
 ```bash
-git clone https://github.com/open-banking-io/clients.git /tmp/obi-clients
-
 # From your bench directory:
-bench get-app /tmp/obi-clients/erpnext
+bench get-app https://github.com/open-banking-io/erpnext --branch v0.1.0
 bench --site <your-site> install-app erpnext_open_banking
 bench --site <your-site> migrate
 ```
+
+> **Source of truth:** development happens in the `erpnext/` directory of the
+> [open-banking-io/clients](https://github.com/open-banking-io/clients) monorepo
+> (alongside the Python, Node, Rust, Go and other SDKs); each `erpnext/vX.Y.Z`
+> release subtree-splits it to the [open-banking-io/erpnext](https://github.com/open-banking-io/erpnext)
+> mirror that `bench` installs from. To install from a local checkout instead,
+> `bench get-app /path/to/clients/erpnext`.
 
 ## Setup
 

--- a/tools/bump-version.mjs
+++ b/tools/bump-version.mjs
@@ -17,7 +17,7 @@ import { dirname, join, resolve } from "node:path";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 
-const PACKAGES = ["dotnet", "node", "n8n", "python", "rust", "java", "go", "ruby", "php", "beancount"];
+const PACKAGES = ["dotnet", "node", "n8n", "python", "rust", "java", "go", "ruby", "php", "beancount", "erpnext"];
 
 // SemVer 2.0.0 (https://semver.org) — practical, anchored.
 const SEMVER =
@@ -90,6 +90,23 @@ const bumpers = {
       /(^version[ \t]*=[ \t]*")[^"]+(?="$)/m,
       version,
       'version = "..." (under [project])',
+    );
+  },
+
+  erpnext(version) {
+    // The ERPNext (Frappe) app — pyproject [project] version plus the
+    // app package's __version__ (Frappe reads it for the app metadata).
+    replaceOne(
+      "erpnext/pyproject.toml",
+      /(^version[ \t]*=[ \t]*")[^"]+(?="$)/m,
+      version,
+      'version = "..." (under [project])',
+    );
+    replaceOne(
+      "erpnext/erpnext_open_banking/__init__.py",
+      /(^__version__[ \t]*=[ \t]*")[^"]+(?="$)/m,
+      version,
+      '__version__ = "..."',
     );
   },
 


### PR DESCRIPTION
Gives the ERPNext app a proper installable home — the same subtree-split mirror pattern as n8n/php/zapier — so users can `bench get-app https://github.com/open-banking-io/erpnext` instead of cloning the whole monorepo.

**What's added**
- **`publish-erpnext.yml`** — on an `erpnext/v*` tag: runs the pytest suite (3.10/3.11/3.13), verifies `tag == pyproject == __init__.__version__`, then subtree-splits `erpnext/` and force-pushes it (+ the `vX.Y.Z` tag) to the new **[open-banking-io/erpnext](https://github.com/open-banking-io/erpnext)** mirror (created, empty).
- **`tools/bump-version.mjs`** — `erpnext` bumper updating both `erpnext/pyproject.toml` and `erpnext/erpnext_open_banking/__init__.py`; added to `PACKAGES`.
- **`release.yml`** — `erpnext` added to the Release-workflow package choices.
- **`changed-packages-comment.yml`** — `erpnext` added to the sticky-comment `ALL` list (it was missing since the app landed).
- **`RELEASING.md`** — version-source table rows for erpnext/beancount/zapier + an ERPNext-app release section.
- **`erpnext/README.md`** — install from the mirror URL.

**Context:** the app itself was just verified end-to-end on a real ERPNext v15.75.0 bench (install → configure → sync → 3 Bank Transactions created & submitted & reconciliation-visible). This PR is the distribution layer only — no app-logic changes.

After merge: **Actions → Release → erpnext → 0.1.0** populates the mirror and cuts the first release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ERPNext release path, including an automated publish workflow for `erpnext/v*` tags with version verification and mirror publishing.
* **Bug Fixes**
  * Expanded “Changed client packages” detection so ERPNext can be included in release notifications.
* **Documentation**
  * Updated release documentation and the ERPNext README with the new install approach and the ERPNext app release/versioning specifics.
* **Chores**
  * Added ERPNext as a supported target in the version-bumping tool and the manual release selector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->