### PR TITLE
feat(erpnext): marketplace readiness — mirror CI + lint (v0.1.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,8 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install pytest cryptography requests
+      - run: pip install ruff pytest cryptography requests
+      - run: ruff check erpnext_open_banking/ tests/
       - run: python -m pytest tests/ -v
 
   # Aggregate gate: the single required CI status check. Always runs so it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install ruff pytest cryptography requests
+      - run: pip install ruff==0.13.1 pytest cryptography requests
       - run: ruff check erpnext_open_banking/ tests/
       - run: python -m pytest tests/ -v
 

--- a/erpnext/.github/workflows/ci.yml
+++ b/erpnext/.github/workflows/ci.yml
@@ -27,6 +27,6 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install ruff pytest cryptography requests
+      - run: pip install ruff==0.13.1 pytest cryptography requests
       - run: ruff check erpnext_open_banking/ tests/
       - run: python -m pytest tests/ -v

--- a/erpnext/.github/workflows/ci.yml
+++ b/erpnext/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+# Runs in the open-banking-io/erpnext mirror repo (this app lives at its root
+# there, pushed by the monorepo's publish-erpnext.yml subtree-split). Gives the
+# marketplace-facing repo its own passing lint + test checks, per the Frappe
+# Cloud app-authoring guidelines. Dormant in the monorepo (GitHub only runs
+# workflows under the repo-root .github/).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.13']
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install ruff pytest cryptography requests
+      - run: ruff check erpnext_open_banking/ tests/
+      - run: python -m pytest tests/ -v

--- a/erpnext/erpnext_open_banking/__init__.py
+++ b/erpnext/erpnext_open_banking/__init__.py
@@ -2,4 +2,4 @@
 # Author: open-banking.io
 # Licence: MIT
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/erpnext/erpnext_open_banking/erpnext_open_banking/doctype/open_banking_connection/open_banking_connection.py
+++ b/erpnext/erpnext_open_banking/erpnext_open_banking/doctype/open_banking_connection/open_banking_connection.py
@@ -3,8 +3,6 @@
 # Licence: MIT
 
 
-import frappe
-from frappe import _
 from frappe.model.document import Document
 
 

--- a/erpnext/pyproject.toml
+++ b/erpnext/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "erpnext-open-banking"
-version = "0.1.0"
+version = "0.1.1"
 description = "Connect your bank accounts to ERPNext via open-banking.io — no eIDAS certificates required."
 readme = "README.md"
 license = { text = "MIT" }
@@ -58,3 +58,7 @@ erpnext_open_banking = ["**/*.json", "**/*.js", "**/*.txt", "**/*.md", "**/*.css
 [tool.pytest.ini_options]
 pythonpath = ["."]
 testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 110

--- a/erpnext/tests/test_mapper.py
+++ b/erpnext/tests/test_mapper.py
@@ -9,9 +9,7 @@ OBI decrypted transaction dicts map correctly to ERPNext Bank Transaction fields
 """
 
 from datetime import date
-from decimal import Decimal
 
-import pytest
 
 from erpnext_open_banking.erpnext_open_banking.utils.mapper import map_transaction
 


### PR DESCRIPTION
Makes the app meet the Frappe Cloud Marketplace **app-authoring guidelines** (which want passing GitHub Actions with linters + server tests) ahead of a listing submission.

- **`erpnext/.github/workflows/ci.yml`** — CI for the [open-banking-io/erpnext](https://github.com/open-banking-io/erpnext) mirror (ruff + pytest, 3.10/3.11/3.13). Dormant in the monorepo (GitHub only runs root workflows); active at the mirror root after the subtree-split, so the marketplace-facing repo shows green CI.
- **Monorepo erpnext CI job** now also runs `ruff check` (lint pre-release, not just in the mirror).
- **Fixed 4 ruff findings** (unused imports) that enabling lint surfaced.
- **`[tool.ruff]`** pinned in pyproject (py310, line-length 110) for deterministic lint.
- **v0.1.1** — release after merge carries the mirror CI + lint into the mirror.

Context: the app is verified end-to-end on a real ERPNext v15 bench and already distributed via `bench get-app https://github.com/open-banking-io/erpnext`. The actual marketplace *submission* is a Frappe Cloud UI flow under John's account (logo, listing copy, publish for review) — this PR is the code-side compliance for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated linting (Ruff) to the CI pipeline before running the test suite.
* **Bug Fixes**
  * Updated the package release version to **0.1.1**.
  * Removed unused imports to reduce noise in the codebase.
* **Chores**
  * Added Ruff linting configuration (target Python version and line length).
  * CI now runs linting and tests across multiple Python versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->