### PR TITLE
feat(erpnext): declare Frappe/ERPNext compatibility (marketplace fix, v0.1.2)

### DIFF
--- a/erpnext/erpnext_open_banking/__init__.py
+++ b/erpnext/erpnext_open_banking/__init__.py
@@ -2,4 +2,4 @@
 # Author: open-banking.io
 # Licence: MIT
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/erpnext/pyproject.toml
+++ b/erpnext/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "erpnext-open-banking"
-version = "0.1.1"
+version = "0.1.2"
 description = "Connect your bank accounts to ERPNext via open-banking.io — no eIDAS certificates required."
 readme = "README.md"
 license = { text = "MIT" }
@@ -46,6 +46,12 @@ Documentation = "https://open-banking.io"
 [build-system]
 requires = ["setuptools>=68.0"]
 build-backend = "setuptools.build_meta"
+
+# Frappe/ERPNext version compatibility — read by bench and the Frappe Cloud
+# Marketplace (which requires NPM-style semver ranges). Tested on ERPNext v15.
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0 <16.0.0"
+erpnext = ">=15.0.0 <16.0.0"
 
 [tool.setuptools.packages.find]
 include = ["erpnext_open_banking*"]


### PR DESCRIPTION
Driving the Frappe Cloud Marketplace **Add App** flow surfaced a real gap: it rejects the app with *"Invalid version format for app 'ERPNext Open Banking'. Please use NPM-style semver ranges (e.g. '>=15.0.0 <16.0.0')."*

Cause: `pyproject.toml` had no `[tool.bench.frappe-dependencies]` section, which is how a Frappe app declares its Frappe/ERPNext compatibility (same field `frappe/hrms` uses). Added:

```toml
[tool.bench.frappe-dependencies]
frappe = ">=15.0.0 <16.0.0"
erpnext = ">=15.0.0 <16.0.0"
```

Matches the ERPNext v15.75.0 bench the app was verified on. Bumped to v0.1.2. Lint + 29 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version to `0.1.2`.
  * Added explicit compatibility ranges for supported ERPNext/Frappe releases (`15.x` only), helping ensure smoother installs and upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->