### PR TITLE
fix(erpnext): comma-form frappe-dependencies so Frappe Cloud accepts it (v0.1.3)

### DIFF
--- a/erpnext/erpnext_open_banking/__init__.py
+++ b/erpnext/erpnext_open_banking/__init__.py
@@ -2,4 +2,4 @@
 # Author: open-banking.io
 # Licence: MIT
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/erpnext/pyproject.toml
+++ b/erpnext/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "erpnext-open-banking"
-version = "0.1.2"
+version = "0.1.3"
 description = "Connect your bank accounts to ERPNext via open-banking.io — no eIDAS certificates required."
 readme = "README.md"
 license = { text = "MIT" }
@@ -48,10 +48,13 @@ requires = ["setuptools>=68.0"]
 build-backend = "setuptools.build_meta"
 
 # Frappe/ERPNext version compatibility — read by bench and the Frappe Cloud
-# Marketplace (which requires NPM-style semver ranges). Tested on ERPNext v15.
+# Marketplace. Use the COMMA form: press parses it as
+# value.replace(" ","").replace(","," ") -> a bounded NpmSpec, so a space-form
+# range like ">=15.0.0 <16.0.0" collapses to an invalid ">=15.0.0<16.0.0".
+# Tested on ERPNext v15.
 [tool.bench.frappe-dependencies]
-frappe = ">=15.0.0 <16.0.0"
-erpnext = ">=15.0.0 <16.0.0"
+frappe = ">=15.0.0,<16.0.0"
+erpnext = ">=15.0.0,<16.0.0"
 
 [tool.setuptools.packages.find]
 include = ["erpnext_open_banking*"]


### PR DESCRIPTION
The v0.1.2 compat fix used the space form `>=15.0.0 <16.0.0` (copied from Frappe Cloud's own error-message example) — but that **still failed with the same error** when driving the real Add-App flow.

Root cause, from reading press's parser (`press/press/doctype/app/app.py`):
```python
version_string = version_string.replace(" ", "").replace(",", " ")
spec = sv.NpmSpec(version_string)
```
It strips spaces then turns commas into spaces. So the space form collapses to `>=15.0.0<16.0.0` (no separator) → invalid. The **comma** form `>=15.0.0,<16.0.0` (what `hrms` uses) converts to a valid bounded `>=15.0.0 <16.0.0`.

Switched both frappe/erpnext to the comma form. v0.1.3. Lint + 29 tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to **0.1.3**.
  * Refreshed compatibility settings for supported ERPNext/Frappe versions to match the current release format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->