### PR TITLE
feat(dotnet): optional request timeout for default HttpClient [v0.3.0]

### DIFF
--- a/dotnet/src/OpenBankingIO.Client/OpenBankingClient.cs
+++ b/dotnet/src/OpenBankingIO.Client/OpenBankingClient.cs
@@ -24,7 +24,12 @@ public sealed class OpenBankingClient : IDisposable
     /// <param name="apiKey">The API key from your credentials bundle.</param>
     /// <param name="privateKeyPkcs8Base64">The base64 PKCS#8 encryption private key from your bundle.</param>
     /// <param name="httpClient">Optional injected client (e.g. for testing); otherwise one is created.</param>
-    public OpenBankingClient(string apiBaseUrl, string apiKey, string privateKeyPkcs8Base64, HttpClient? httpClient = null)
+    /// <param name="timeout">
+    /// Optional request timeout applied only to the default <see cref="HttpClient"/> the SDK creates when no
+    /// <paramref name="httpClient"/> is injected. A caller-owned client is never mutated — configure its
+    /// <see cref="HttpClient.Timeout"/> yourself. When null, the default 30s timeout is used.
+    /// </param>
+    public OpenBankingClient(string apiBaseUrl, string apiKey, string privateKeyPkcs8Base64, HttpClient? httpClient = null, TimeSpan? timeout = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(apiBaseUrl);
         ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
@@ -34,7 +39,7 @@ public sealed class OpenBankingClient : IDisposable
         _privateKey.ImportPkcs8PrivateKey(Convert.FromBase64String(privateKeyPkcs8Base64), out _);
 
         _ownsHttp = httpClient is null;
-        _http = httpClient ?? new HttpClient { Timeout = DefaultTimeout };
+        _http = httpClient ?? new HttpClient { Timeout = timeout ?? DefaultTimeout };
         _http.BaseAddress = new Uri(apiBaseUrl.TrimEnd('/') + "/");
         _http.DefaultRequestHeaders.Remove("X-Api-Key");
         _http.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
@@ -59,19 +64,19 @@ public sealed class OpenBankingClient : IDisposable
     }
 
     /// <summary>Builds a client from a credentials-bundle JSON string or a path to a bundle file.</summary>
-    public static OpenBankingClient FromCredentials(string jsonOrPath, HttpClient? httpClient = null)
+    public static OpenBankingClient FromCredentials(string jsonOrPath, HttpClient? httpClient = null, TimeSpan? timeout = null)
     {
         var json = File.Exists(jsonOrPath) ? File.ReadAllText(jsonOrPath) : jsonOrPath;
         var bundle = JsonSerializer.Deserialize<CredentialsBundle>(json, Json.Options)
             ?? throw new ArgumentException("Could not parse the credentials bundle", nameof(jsonOrPath));
-        return FromBundle(bundle, httpClient);
+        return FromBundle(bundle, httpClient, timeout);
     }
 
-    public static OpenBankingClient FromBundle(CredentialsBundle bundle, HttpClient? httpClient = null)
+    public static OpenBankingClient FromBundle(CredentialsBundle bundle, HttpClient? httpClient = null, TimeSpan? timeout = null)
     {
         if (string.IsNullOrWhiteSpace(bundle.ApiKey))
             throw new ArgumentException("The credentials bundle has no apiKey", nameof(bundle));
-        return new OpenBankingClient(bundle.ApiBaseUrl, bundle.ApiKey!, bundle.EncryptionKey.PrivateKey, httpClient);
+        return new OpenBankingClient(bundle.ApiBaseUrl, bundle.ApiKey!, bundle.EncryptionKey.PrivateKey, httpClient, timeout);
     }
 
     /// <summary>Lists the user's accounts with all sensitive fields decrypted.</summary>

--- a/dotnet/src/OpenBankingIO.Client/OpenBankingIO.Client.csproj
+++ b/dotnet/src/OpenBankingIO.Client/OpenBankingIO.Client.csproj
@@ -17,7 +17,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
     <PackageId>OpenBankingIO.Client</PackageId>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <Authors>open-banking.io</Authors>
     <Description>Server-to-server client for open-banking.io: API-key auth + client-side decryption of the zero-knowledge data envelopes with your exported private key.</Description>
     <PackageTags>open-banking;psd2;zero-knowledge;encryption;fintech</PackageTags>

--- a/dotnet/tests/OpenBankingIO.Client.Tests/BranchCoverageTests.cs
+++ b/dotnet/tests/OpenBankingIO.Client.Tests/BranchCoverageTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json;
 
 namespace OpenBankingIO.Client.Tests;
@@ -121,6 +122,63 @@ public class BranchCoverageTests
 
         var a = Assert.Single(await client.GetAccountsAsync());
         Assert.Equal("DK6466952001724927", a.Iban);
+    }
+
+    /// <summary>Reads the private <c>_http</c> field so we can assert its configured timeout.</summary>
+    private static HttpClient InnerHttp(OpenBankingClient client)
+        => (HttpClient)typeof(OpenBankingClient)
+            .GetField("_http", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(client)!;
+
+    [Fact]
+    public void Constructor_Timeout_Applied_To_Default_Client()
+    {
+        var (apiKey, privateKey) = Creds();
+        var timeout = TimeSpan.FromSeconds(7);
+        // No HttpClient injected → the SDK creates its own and must honour the caller's timeout.
+        using var client = new OpenBankingClient("https://example.test", apiKey, privateKey, timeout: timeout);
+
+        Assert.Equal(timeout, InnerHttp(client).Timeout);
+    }
+
+    [Fact]
+    public void Constructor_No_Timeout_Uses_Default_On_Default_Client()
+    {
+        var (apiKey, privateKey) = Creds();
+        // No timeout → the default 30s timeout is applied to the SDK-created client.
+        using var client = new OpenBankingClient("https://example.test", apiKey, privateKey);
+
+        Assert.Equal(TimeSpan.FromSeconds(30), InnerHttp(client).Timeout);
+    }
+
+    [Fact]
+    public void Constructor_Timeout_Never_Mutates_Injected_Client()
+    {
+        var (apiKey, privateKey) = Creds();
+        // A distinctive value that is neither the SDK default (30s) nor HttpClient's own default (100s).
+        var callerTimeout = TimeSpan.FromSeconds(42);
+        using var http = new HttpClient { Timeout = callerTimeout };
+
+        // Even though a timeout is requested, a caller-owned client must be left untouched.
+        using var client = new OpenBankingClient(
+            "https://example.test", apiKey, privateKey, http, timeout: TimeSpan.FromSeconds(7));
+
+        Assert.Same(http, InnerHttp(client));
+        Assert.Equal(callerTimeout, http.Timeout);
+    }
+
+    [Fact]
+    public void FromBundle_Threads_Timeout_To_Default_Client()
+    {
+        var creds = Fixtures.Read("credentials.json");
+        var bundle = JsonSerializer.Deserialize<CredentialsBundle>(creds, WebJson)! with
+        {
+            ApiBaseUrl = "https://example.test",
+        };
+        var timeout = TimeSpan.FromSeconds(13);
+
+        using var client = OpenBankingClient.FromBundle(bundle, timeout: timeout);
+        Assert.Equal(timeout, InnerHttp(client).Timeout);
     }
 
     [Fact]


### PR DESCRIPTION
## What

Adds a caller-configurable request timeout to the .NET SDK, part of the cross-SDK "bring-your-own-transport + set-your-timeout" work (plan section 7).

- New optional `TimeSpan? timeout = null` constructor parameter on `OpenBankingClient` (append-only, placed after the existing `HttpClient? httpClient = null`).
- The timeout is applied **only** to the default `HttpClient` the SDK creates when no client is injected (`new HttpClient { Timeout = timeout ?? DefaultTimeout }`). A caller-owned `HttpClient` is never mutated.
- Threaded through `FromCredentials` and `FromBundle`.
- User-Agent behavior preserved.

## Version

Bumped `<Version>` to `0.3.0` via `node tools/bump-version.mjs dotnet 0.3.0`.

## Tests

Added to `BranchCoverageTests`:
- `Constructor_Timeout_Applied_To_Default_Client` — timeout is set on the SDK-created client.
- `Constructor_No_Timeout_Uses_Default_On_Default_Client` — default 30s preserved.
- `Constructor_Timeout_Never_Mutates_Injected_Client` — injected client left untouched.
- `FromBundle_Threads_Timeout_To_Default_Client` — factory threads the timeout.

`cd dotnet && dotnet test` → 45 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KezUhW1knvXBjf7GAaeJLt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-request timeout configuration when creating the client.
  * Timeout settings are supported through credential- and bundle-based factory methods.
  * Clients created without a custom timeout continue using the 30-second default.
  * Injected `HttpClient` instances retain their existing timeout settings.

* **Chores**
  * Updated the .NET package version to 0.3.0.

* **Tests**
  * Added coverage for timeout configuration and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->