### PR TITLE
feat(php): custom cURL options + configurable timeouts [v0.3.0]

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -50,7 +50,7 @@ Or construct it explicitly:
 $client = new Client($apiBaseUrl, $apiKey, $privateKeyPkcs8);
 ```
 
-### Custom transport & timeouts
+## Custom transport & timeouts
 
 Both the constructor and `Client::fromCredentials()` take an optional `array $options` for
 proxy, custom CA / mTLS, and timeout control. `curl_options` (a map of `CURLOPT_* => value`) is

--- a/php/README.md
+++ b/php/README.md
@@ -50,6 +50,27 @@ Or construct it explicitly:
 $client = new Client($apiBaseUrl, $apiKey, $privateKeyPkcs8);
 ```
 
+### Custom transport & timeouts
+
+Both the constructor and `Client::fromCredentials()` take an optional `array $options` for
+proxy, custom CA / mTLS, and timeout control. `curl_options` (a map of `CURLOPT_* => value`) is
+applied **last**, so it wins over the SDK defaults; `timeout` / `connect_timeout` (seconds)
+override the 30s / 10s defaults:
+
+```php
+$client = new Client($apiBaseUrl, $apiKey, $privateKeyPkcs8, [
+    'timeout' => 60,          // total request timeout (seconds)
+    'connect_timeout' => 5,   // connection-establishment timeout (seconds)
+    'curl_options' => [
+        CURLOPT_PROXY  => 'http://proxy.internal:8080',
+        CURLOPT_CAINFO => '/etc/ssl/corp-ca.pem',
+    ],
+]);
+
+// Same options are accepted by the bundle loader:
+$client = Client::fromCredentials('credentials.json', ['timeout' => 60]);
+```
+
 ## API
 
 - `getAccounts(): Account[]` — decrypts each account's envelope, display name and balances.

--- a/php/src/Client.php
+++ b/php/src/Client.php
@@ -25,7 +25,7 @@ final class Client
      * Client version, sent as the User-Agent. Tracks the published release tag
      * (PHP has no build manifest -- Packagist is tag-based), so bump this when tagging.
      */
-    public const VERSION = '0.2.1';
+    public const VERSION = '0.3.0';
 
     /** Total request timeout, in seconds. */
     private const TIMEOUT_SECONDS = 30;
@@ -37,7 +37,31 @@ final class Client
     private readonly string $apiKey;
     private readonly Envelope $envelope;
 
-    public function __construct(string $apiBaseUrl, string $apiKey, string $privateKeyPkcs8)
+    /** Effective total request timeout, in seconds (caller may override). */
+    private readonly int $timeoutSeconds;
+
+    /** Effective connection-establishment timeout, in seconds (caller may override). */
+    private readonly int $connectTimeoutSeconds;
+
+    /**
+     * Extra cURL options (CURLOPT_* => value) applied last, so callers win over SDK defaults.
+     *
+     * @var array<int, mixed>
+     */
+    private readonly array $curlOptions;
+
+    /**
+     * @param array{
+     *     curl_options?: array<int, mixed>,
+     *     timeout?: int,
+     *     connect_timeout?: int,
+     * } $options Optional transport overrides. Supported keys:
+     *   - `curl_options`: array of `CURLOPT_* => value` merged **last**, so a caller can set
+     *     `CURLOPT_PROXY`, `CURLOPT_CAINFO`, mTLS options, etc.
+     *   - `timeout`: total request timeout in seconds (overrides the SDK default).
+     *   - `connect_timeout`: connection-establishment timeout in seconds (overrides the SDK default).
+     */
+    public function __construct(string $apiBaseUrl, string $apiKey, string $privateKeyPkcs8, array $options = [])
     {
         if (trim($apiBaseUrl) === '') {
             throw new \InvalidArgumentException('apiBaseUrl is required');
@@ -52,12 +76,27 @@ final class Client
         $this->apiBaseUrl = rtrim($apiBaseUrl, '/');
         $this->apiKey = $apiKey;
         $this->envelope = Envelope::fromPkcs8Base64($privateKeyPkcs8);
+
+        $this->timeoutSeconds = isset($options['timeout']) ? (int) $options['timeout'] : self::TIMEOUT_SECONDS;
+        $this->connectTimeoutSeconds = isset($options['connect_timeout'])
+            ? (int) $options['connect_timeout']
+            : self::CONNECT_TIMEOUT_SECONDS;
+        /** @var array<int, mixed> $curlOptions */
+        $curlOptions = is_array($options['curl_options'] ?? null) ? $options['curl_options'] : [];
+        $this->curlOptions = $curlOptions;
     }
 
     /**
      * Builds a client from a credentials-bundle JSON string or a path to a bundle file.
      */
-    public static function fromCredentials(string $pathOrJson): self
+    /**
+     * @param array{
+     *     curl_options?: array<int, mixed>,
+     *     timeout?: int,
+     *     connect_timeout?: int,
+     * } $options Optional transport overrides; see the constructor.
+     */
+    public static function fromCredentials(string $pathOrJson, array $options = []): self
     {
         $raw = $pathOrJson;
         if (str_ends_with(strtolower(trim($pathOrJson)), '.json') || @is_file($pathOrJson)) {
@@ -88,7 +127,7 @@ final class Client
             throw new OpenBankingException('The credentials bundle has no encryption private key');
         }
 
-        return new self($apiBaseUrl, $apiKey, $privateKey);
+        return new self($apiBaseUrl, $apiKey, $privateKey, $options);
     }
 
     // -- Public API ------------------------------------------------------------
@@ -362,8 +401,8 @@ final class Client
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
         curl_setopt($ch, CURLOPT_USERAGENT, 'open-banking-io/php/' . self::VERSION);
-        curl_setopt($ch, CURLOPT_TIMEOUT, self::TIMEOUT_SECONDS);
-        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, self::CONNECT_TIMEOUT_SECONDS);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeoutSeconds);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->connectTimeoutSeconds);
 
         if ($body !== null) {
             $payload = json_encode($body, JSON_THROW_ON_ERROR);
@@ -372,6 +411,12 @@ final class Client
         }
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+
+        // Caller-supplied cURL options are applied LAST so they win over the SDK defaults
+        // (proxy, custom CA/CAINFO, mTLS client cert, keep-alive, etc.).
+        if ($this->curlOptions !== []) {
+            curl_setopt_array($ch, $this->curlOptions);
+        }
 
         $responseBody = curl_exec($ch);
         if ($responseBody === false) {

--- a/php/src/Client.php
+++ b/php/src/Client.php
@@ -88,8 +88,7 @@ final class Client
 
     /**
      * Builds a client from a credentials-bundle JSON string or a path to a bundle file.
-     */
-    /**
+     *
      * @param array{
      *     curl_options?: array<int, mixed>,
      *     timeout?: int,

--- a/php/tests/ClientTransportTest.php
+++ b/php/tests/ClientTransportTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenBankingIO\Tests;
+
+use OpenBankingIO\ApiException;
+use OpenBankingIO\Client;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the transport-override surface added in 0.3.0: the optional 4th constructor
+ * argument `array $options` with `curl_options`, `timeout`, and `connect_timeout` keys.
+ *
+ * Uses the same PHP-built-in mock server as the integration tests, with an added
+ * OBK_DELAY_MS knob so the request timeout can be driven against a slow server.
+ */
+final class ClientTransportTest extends TestCase
+{
+    use MockServerTrait;
+
+    protected function tearDown(): void
+    {
+        $this->stopMockServer();
+    }
+
+    /**
+     * @param array{curl_options?: array<int, mixed>, timeout?: int, connect_timeout?: int} $options
+     */
+    private function client(array $options = []): Client
+    {
+        return new Client(
+            $this->baseUrl,
+            $this->credentials['apiKey'],
+            $this->credentials['encryptionKey']['privateKey'],
+            $options,
+        );
+    }
+
+    /**
+     * A caller-supplied CURLOPT is applied last, winning over the SDK default:
+     * overriding CURLOPT_USERAGENT is reflected in what the server received.
+     */
+    public function testCurlOptionsAreAppliedAndWin(): void
+    {
+        $this->startMockServer();
+
+        $this->client([
+            'curl_options' => [CURLOPT_USERAGENT => 'custom-agent/9.9'],
+        ])->getAccounts();
+
+        $raw = file_get_contents($this->captureFile);
+        self::assertNotFalse($raw);
+        /** @var array<string, mixed> $all */
+        $all = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('custom-agent/9.9', $all['userAgent'] ?? null);
+    }
+
+    /**
+     * A transport-shaping option such as CURLOPT_PROXY is honored: pointing at a
+     * dead proxy port makes the otherwise-successful request fail.
+     */
+    public function testCurlProxyOptionIsHonored(): void
+    {
+        $this->startMockServer();
+
+        // A closed local port -- routing through it must make the request fail.
+        $deadProxy = '127.0.0.1:' . $this->findFreePort();
+
+        $this->expectException(ApiException::class);
+        $this->client([
+            'curl_options' => [CURLOPT_PROXY => $deadProxy],
+        ])->getAccounts();
+    }
+
+    /**
+     * The `timeout` override is honored: against a server that delays 2s, a 1s
+     * timeout aborts the request (whereas the control call with no override,
+     * which keeps the 30s SDK default, succeeds).
+     */
+    public function testTimeoutOverrideIsHonored(): void
+    {
+        $this->serverEnvOverrides = ['OBK_DELAY_MS' => '2000'];
+        $this->startMockServer();
+
+        // Control: no override -> default 30s timeout comfortably outlasts the 2s delay.
+        $accounts = $this->client()->getAccounts();
+        self::assertCount(1, $accounts);
+
+        // Override: 1s total timeout is shorter than the 2s server delay -> aborts.
+        $this->expectException(ApiException::class);
+        $this->client(['timeout' => 1])->getAccounts();
+    }
+
+    /**
+     * The `connect_timeout` override is honored: a 1s connect timeout against a
+     * non-routable host fails well under the 10s SDK default.
+     */
+    public function testConnectTimeoutOverrideIsHonored(): void
+    {
+        // No mock server needed -- 198.51.100.1 is TEST-NET-2 (RFC 5737), non-routable.
+        /** @var array{apiKey: string, encryptionKey: array{privateKey: string}} $credentials */
+        $credentials = Fixtures::load('credentials.json');
+        $client = new Client(
+            'http://198.51.100.1:9',
+            'api-key',
+            $credentials['encryptionKey']['privateKey'],
+            ['connect_timeout' => 1],
+        );
+
+        $start = microtime(true);
+        try {
+            $client->getAccounts();
+            self::fail('Expected the connect attempt to fail');
+        } catch (ApiException) {
+            // expected
+        }
+        $elapsed = microtime(true) - $start;
+
+        // A 1s connect timeout must abort well before the 10s SDK default would.
+        self::assertLessThan(8.0, $elapsed);
+    }
+}

--- a/php/tests/ClientTransportTest.php
+++ b/php/tests/ClientTransportTest.php
@@ -109,15 +109,21 @@ final class ClientTransportTest extends TestCase
         );
 
         $start = microtime(true);
+        $message = null;
         try {
             $client->getAccounts();
-            self::fail('Expected the connect attempt to fail');
-        } catch (ApiException) {
-            // expected
+            self::fail('Expected the connect attempt to time out');
+        } catch (ApiException $e) {
+            $message = $e->getMessage();
         }
         $elapsed = microtime(true) - $start;
 
-        // A 1s connect timeout must abort well before the 10s SDK default would.
+        // The failure must be a *timeout* specifically (cURL CURLE_OPERATION_TIMEDOUT,
+        // "Connection timed out after N milliseconds") -- not merely any fast failure,
+        // which would still pass if connect_timeout were ignored.
+        self::assertMatchesRegularExpression('/timed out|timeout/i', $message);
+
+        // ...and it must abort near the 1s override, well before the 10s SDK default.
         self::assertLessThan(8.0, $elapsed);
     }
 }

--- a/php/tests/mock-server/router.php
+++ b/php/tests/mock-server/router.php
@@ -21,6 +21,13 @@ $apiKey = getenv('OBK_API_KEY') ?: '';
 $captureFile = getenv('OBK_CAPTURE_FILE') ?: '';
 $accountsMode = getenv('OBK_ACCOUNTS_MODE') ?: '';
 
+// OBK_DELAY_MS delays every response by N milliseconds, so a test can drive the
+// client's request timeout against a deliberately slow server.
+$delayMs = (int) (getenv('OBK_DELAY_MS') ?: '0');
+if ($delayMs > 0) {
+    usleep($delayMs * 1000);
+}
+
 $accountId = '11111111-1111-4111-8111-111111111111';
 
 $requestUri = is_string($_SERVER['REQUEST_URI'] ?? null) ? $_SERVER['REQUEST_URI'] : '/';


### PR DESCRIPTION
## Summary

Adds bring-your-own-transport + configurable timeouts to the PHP SDK (part of the cross-SDK 0.3.0 effort). Fully **append-only** and **zero new dependencies** (stays on raw cURL).

- `Client::__construct` gains an optional 4th arg `array $options = []` (existing param order/names unchanged). Threaded through `Client::fromCredentials(..., array $options = [])`.
- Supported keys:
  - `curl_options` — map of `CURLOPT_* => value` applied **last** via `curl_setopt_array`, so a caller's proxy / custom CA (`CURLOPT_CAINFO`) / mTLS / keep-alive options win over the SDK defaults.
  - `timeout` — total request timeout in seconds (overrides the 30s default).
  - `connect_timeout` — connection timeout in seconds (overrides the 10s default).
- Default `User-Agent: open-banking-io/php/<version>` behavior is preserved.
- `Client::VERSION` bumped to `0.3.0` (PHP has no manifest; Packagist is tag-based).
- README: new "Custom transport & timeouts" example.

## Tests

New `tests/ClientTransportTest.php` (mirrors the existing mock-server pattern):
- caller `curl_options` is applied and wins over the SDK default (overrides `CURLOPT_USERAGENT`, asserted via the server capture);
- a `CURLOPT_PROXY` pointing at a dead port makes the request fail (transport option honored);
- `timeout` override aborts against a deliberately slow server while the default control call succeeds;
- `connect_timeout` override fails fast against a non-routable host.

Added an `OBK_DELAY_MS` knob to the mock-server router to drive the timeout test.

## Local verification

`composer install && vendor/bin/phpunit` → **OK (43 tests, 112 assertions)**. `phpstan analyse` (level max) clean; `php-cs-fixer` reports 0 files to fix. Run on PHP 8.5.7 with pcov.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KezUhW1knvXBjf7GAaeJLt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable request and connection timeouts.
  * Added support for custom cURL options, including proxy, custom certificates, mTLS, and user-agent settings.
  * Options are supported when creating clients directly or from credentials.
  * Caller-provided transport settings override SDK defaults.

* **Documentation**
  * Added PHP usage examples and configuration guidance for transport options.
  * Updated the client version to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->