### PR TITLE
fix(cli): pin cosign to v2.4.3 to unblock release signing

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -73,6 +73,14 @@ jobs:
       - name: Install cosign
         if: steps.ver.outputs.is_tag == 'true'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin to a pre-2.5 cosign. cosign 2.5.0 flipped `sign-blob`'s default to
+          # `--new-bundle-format`, under which `--output-signature`/`--output-certificate`
+          # are ignored and a `--bundle` path is required — which aborts the sign step
+          # ("create bundle file: open : no such file or directory") and broke every CLI
+          # release since v0.2.8. Keep the .sig/.pem artifact flow until we deliberately
+          # migrate the release + Homebrew verification to the bundle format.
+          cosign-release: 'v2.4.3'
 
       - name: Sign checksums (keyless)
         if: steps.ver.outputs.is_tag == 'true'


### PR DESCRIPTION
## Problem

CLI auto-publish has been **broken since v0.2.8**. Tags `cli/v0.2.8`, `cli/v0.2.9`, and `cli/v0.2.10` all fail at the **"Sign checksums (keyless)"** step, so **no GitHub Release, binaries, or Homebrew tap update** has shipped since `v0.2.7` — `brew install open-banking-io/tap/openbanking` still serves 0.2.7.

## Root cause

`sigstore/cosign-installer@v4.1.2` installs a cosign whose default flipped to `--new-bundle-format` (cosign **2.5.0**). In that mode `cosign sign-blob` **ignores** `--output-signature`/`--output-certificate` and requires a `--bundle` path, so the step aborts:

```
Error: signing checksums.txt: create bundle file: open : no such file or directory
```

Because signing is step 7 of 10 (before "Publish GitHub Release" and "Update Homebrew tap"), the **entire release aborts**.

## Fix

Pin `cosign-release: 'v2.4.3'` (last pre-flip release) on the installer, so the existing `.sig` + `.pem` artifact flow and the documented `cosign verify-blob` / Homebrew verification keep working. Minimal, low-risk unblock.

A deliberate follow-up can migrate to the new keyless **bundle format** (`sign-blob --bundle checksums.txt.sigstore.json`) and update the verification docs/consumers — tracked separately.

## Verifying after merge

Re-run the failed `cli/v0.2.10` release (the publish/Homebrew steps are idempotent) or cut `cli/v0.2.11`; confirm the sign step passes and the Homebrew tap advances past 0.2.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KezUhW1knvXBjf7GAaeJLt