### PR TITLE
feat(cli): send versioned User-Agent on login token exchange

### DIFF
--- a/cli/internal/app/login.go
+++ b/cli/internal/app/login.go
@@ -159,6 +159,9 @@ func (a *App) exchangeToken(ctx context.Context, apiBaseURL, code, verifier stri
 		return cliTokenResponse{}, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	// Identify the CLI (and its version) to the server; without this the raw request would go out as
+	// Go's default Go-http-client/1.1 with no product/version. versionString defaults to "dev".
+	req.Header.Set("User-Agent", "open-banking-io/cli/"+a.versionString())
 
 	client := a.HTTPClient
 	if client == nil {

--- a/cli/internal/app/login_test.go
+++ b/cli/internal/app/login_test.go
@@ -64,6 +64,42 @@ func TestExchangeTokenSendsCodeAndVerifier(t *testing.T) {
 	}
 }
 
+func TestExchangeTokenSendsVersionedUserAgent(t *testing.T) {
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"apiKey":"ebk_minted","apiBaseUrl":"https://api.example","user":"a@b.c","prefix":"ebk_minted12"}`))
+	}))
+	defer srv.Close()
+
+	app := &App{HTTPClient: srv.Client(), Version: "1.2.3"}
+	if _, err := app.exchangeToken(context.Background(), srv.URL, "code", "verifier"); err != nil {
+		t.Fatalf("exchangeToken: %v", err)
+	}
+	if want := "open-banking-io/cli/1.2.3"; gotUA != want {
+		t.Errorf("User-Agent = %q, want %q", gotUA, want)
+	}
+}
+
+func TestExchangeTokenUserAgentDefaultsToDev(t *testing.T) {
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"apiKey":"ebk_minted","apiBaseUrl":"https://api.example","user":"a@b.c","prefix":"ebk_minted12"}`))
+	}))
+	defer srv.Close()
+
+	app := &App{HTTPClient: srv.Client()} // no Version set
+	if _, err := app.exchangeToken(context.Background(), srv.URL, "code", "verifier"); err != nil {
+		t.Fatalf("exchangeToken: %v", err)
+	}
+	if want := "open-banking-io/cli/dev"; gotUA != want {
+		t.Errorf("User-Agent = %q, want %q", gotUA, want)
+	}
+}
+
 func TestExchangeTokenSurfacesServerError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"invalid or expired login code"}`, http.StatusBadRequest)


### PR DESCRIPTION
## What

The CLI's raw login token-exchange request (`POST /auth/cli/token` in `exchangeToken`) previously set only `Content-Type`, so it went out with Go's default `User-Agent: Go-http-client/1.1` — no product identity, no open-banking version.

This sets `User-Agent: open-banking-io/cli/<version>`, mirroring the go SDK's convention (which sets its own `open-banking-io/go/<Version>` and is untouched here).

## How

- The CLI version was already threaded end-to-end: `main.version` (`-ldflags -X main.version=...`, default `"dev"`) is passed as `App.Version` in `main.go`, and `App.versionString()` returns it, defaulting to `"dev"` when unset. No new plumbing needed.
- `exchangeToken` now calls `req.Header.Set("User-Agent", "open-banking-io/cli/"+a.versionString())`.
- Added two tests: one asserting `open-banking-io/cli/1.2.3` with `Version` set, and one asserting the `dev` fallback with no `Version`.

Append-only / non-breaking. No changes to `cli/go.mod` or the go SDK.

## Testing

`go build ./...` and `go test ./...` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KezUhW1knvXBjf7GAaeJLt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * CLI authentication requests now identify the CLI and its version to the authentication service.
  * Requests use `dev` as the version when no release version is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->