### PR TITLE
feat(n8n): send versioned User-Agent on API requests [v0.2.2]

### DIFF
--- a/n8n/nodes/OpenBankingIo/shared/client.ts
+++ b/n8n/nodes/OpenBankingIo/shared/client.ts
@@ -8,6 +8,7 @@ import type {
 } from 'n8n-workflow';
 
 import { decryptTo, importPrivateKey, type PrivateKey } from './envelope';
+import { USER_AGENT } from './version';
 import type {
 	Account,
 	AccountEnc,
@@ -94,6 +95,7 @@ export async function apiRequest<T>(
 		qs: stringQs,
 		body,
 		json: true,
+		headers: { 'User-Agent': USER_AGENT },
 	};
 	return ctx.helpers.httpRequestWithAuthentication.call(
 		ctx,

--- a/n8n/nodes/OpenBankingIo/shared/version.ts
+++ b/n8n/nodes/OpenBankingIo/shared/version.ts
@@ -1,0 +1,9 @@
+// The package version, sourced from package.json so it can never drift from the published
+// manifest. `resolveJsonModule` lets tsc inline the field at build time and lets vitest resolve
+// the import directly — mirroring how the node SDK derives its version (node/src/version.ts).
+import pkg from '../../../package.json';
+
+export const VERSION: string = pkg.version;
+
+/** The `User-Agent` sent on every API request: `open-banking-io/n8n/<version>`. */
+export const USER_AGENT = `open-banking-io/n8n/${VERSION}`;

--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-banking-io/n8n-nodes-open-banking-io",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-banking-io/n8n-nodes-open-banking-io",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3",

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-banking-io/n8n-nodes-open-banking-io",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "n8n community node for open-banking.io: API-key auth with client-side, zero-knowledge decryption of your bank accounts, balances and transactions.",
   "license": "MIT",
   "author": {

--- a/n8n/test/client.test.ts
+++ b/n8n/test/client.test.ts
@@ -1,9 +1,12 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { resolveBundle } from '../nodes/OpenBankingIo/shared/client';
+import type { IHttpRequestOptions } from 'n8n-workflow';
+
+import { apiRequest, resolveBundle, type RequestContext } from '../nodes/OpenBankingIo/shared/client';
+import { USER_AGENT, VERSION } from '../nodes/OpenBankingIo/shared/version';
 
 // `resolveBundle` parses the pasted bundle and applies the optional `baseUrlOverride` credential
 // field, so a credential can point at staging/local without re-exporting a different bundle.
@@ -36,5 +39,32 @@ describe('resolveBundle()', () => {
 
 	it('still rejects an invalid bundle', () => {
 		expect(() => resolveBundle({ bundle: 'not json' })).toThrow(/not valid JSON/);
+	});
+});
+
+// `apiRequest` issues the authenticated HTTP call. It must tag every request with a versioned
+// `User-Agent` so open-banking.io can identify traffic coming from this n8n community node — the
+// same `open-banking-io/<sdk>/<version>` convention the other SDKs use.
+describe('apiRequest()', () => {
+	function mockContext() {
+		const httpRequestWithAuthentication = vi.fn().mockResolvedValue({ ok: true });
+		const ctx = { helpers: { httpRequestWithAuthentication } } as unknown as RequestContext;
+		return { ctx, httpRequestWithAuthentication };
+	}
+
+	const bundle = { apiBaseUrl: 'https://api.example.test', apiKey: 'k', privateKey: 'p' };
+
+	it('sends a User-Agent of open-banking-io/n8n/<version>', async () => {
+		const { ctx, httpRequestWithAuthentication } = mockContext();
+
+		await apiRequest(ctx, bundle, 'GET', '/api/accounts');
+
+		expect(httpRequestWithAuthentication).toHaveBeenCalledTimes(1);
+		// Invoked as `httpRequestWithAuthentication.call(ctx, CREDENTIALS_NAME, options)`, so the
+		// recorded args are [credentialsName, options] (the `.call` thisArg is not an arg).
+		const options = httpRequestWithAuthentication.mock.calls[0][1] as IHttpRequestOptions;
+		// Imported from the same source as the client, so it can never drift from package.json.
+		expect(USER_AGENT).toBe(`open-banking-io/n8n/${VERSION}`);
+		expect(options.headers?.['User-Agent']).toBe(USER_AGENT);
 	});
 });

--- a/n8n/tsconfig.json
+++ b/n8n/tsconfig.json
@@ -10,6 +10,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "declaration": true,


### PR DESCRIPTION
## What

The n8n community node (`@open-banking-io/n8n-nodes-open-banking-io`) previously issued its authenticated API requests with n8n's default `User-Agent` and no open-banking version — unlike the other SDKs which identify as `open-banking-io/<sdk>/<version>`.

This adds a versioned `User-Agent: open-banking-io/n8n/<version>` header to every request built in `apiRequest`.

## How

- New `n8n/nodes/OpenBankingIo/shared/version.ts` derives `VERSION` from `package.json` and exports `USER_AGENT = ` `open-banking-io/n8n/${VERSION}` `` — mirroring `node/src/version.ts`, so the version can never drift from the published manifest.
- `client.ts` imports `USER_AGENT` and adds `headers: { 'User-Agent': USER_AGENT }` to the `IHttpRequestOptions` — the only behavioral change; everything else is untouched.
- Enabled `resolveJsonModule` in `tsconfig.json` so tsc (and vitest) resolve the JSON import (the `with { type: 'json' }` attribute isn't available under `module: Node16`, so a plain default import is used).
- Extended `test/client.test.ts` (vitest): mocks `httpRequestWithAuthentication` and asserts the `options.headers['User-Agent']` handed to the helper equals `open-banking-io/n8n/<version>`, importing the same `VERSION`/`USER_AGENT` source so test and client stay in sync.
- Bumped version to **0.2.2** via `tools/bump-version.mjs` (package.json + lockfile version fields only).

## Verification

- `npm ci` — clean
- `npm run build` — passes (tsc + gulp icons)
- `npm run lint` — passes
- `npm test` — 24 passed (5 files), including the new User-Agent assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KezUhW1knvXBjf7GAaeJLt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added identifying information to outgoing API requests through a standardized `User-Agent` header.

* **Chores**
  * Updated the Open Banking integration package to version 0.2.2.

* **Tests**
  * Added coverage confirming the `User-Agent` header is included in API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->