### PR TITLE
fix(php): surface envelope decrypt failures instead of reporting zero

### DIFF
--- a/.github/workflows/publish-php.yml
+++ b/.github/workflows/publish-php.yml
@@ -22,6 +22,17 @@ jobs:
           php-version: '8.2'
           extensions: openssl, curl, json
           tools: composer:v2
+      - name: The tag is the released version, so the User-Agent const has to agree with it
+        if: startsWith(github.ref, 'refs/tags/php/v')
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF_NAME#php/v}"
+          CONST_VERSION="$(grep -oE "VERSION = '[^']+'" src/Client.php | cut -d"'" -f2)"
+          if [ "$TAG_VERSION" != "$CONST_VERSION" ]; then
+            echo "tag php/v${TAG_VERSION} does not match Client::VERSION ${CONST_VERSION}" >&2
+            exit 1
+          fi
+
       - run: composer validate --strict --no-check-version
       - run: composer install --prefer-dist --no-interaction --no-progress
       - run: vendor/bin/phpunit
@@ -46,6 +57,15 @@ jobs:
           set -euo pipefail
           git config user.name  "open-banking-io-bot"
           git config user.email "bot@open-banking.io"
+
+          # git subtree split only carries what is committed under php/, and the tests read the
+          # shared fixtures from the monorepo root. Without this the mirror ships a suite that
+          # cannot run, which the test job above never sees because it runs in this checkout.
+          mkdir -p php/tests/fixtures
+          cp -R fixtures/. php/tests/fixtures/
+          git add php/tests/fixtures
+          git diff --cached --quiet || git commit -m "chore(php): vendor shared fixtures for the split package"
+
           SPLIT_SHA="$(git subtree split --prefix=php)"
           echo "split sha: $SPLIT_SHA"
           REMOTE="https://x-access-token:${MIRROR_TOKEN}@github.com/open-banking-io/client-php.git"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -5,11 +5,10 @@ useDefault = true
 disabledRules = ["generic-api-key"]
 
 [allowlist]
-description = "Deterministic TEST vectors only: the fixtures bundle + the generator that emits it, the test API key (obk_test_*), and PEM-boundary string literals in the envelope crypto source. None are real secrets."
+description = "Deterministic TEST vectors only: the fixtures bundle + the generator that emits it, the test API key (obk_test_*), and the fixture generator. PEM framing in source and tests is annotated per line with gitleaks:allow rather than allowlisted by path, so a real credential added to any of those files is still caught. None are real secrets."
 paths = [
   '''fixtures/.*''',
   '''tools/.*''',
-  '''.*[Ee]nvelope\.[a-z]+$''',
 ]
 regexes = [
   '''obk_test_[0-9a-f]+''',

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,7 +29,7 @@ the Node package and nothing else.
 | `java`   | `java/pom.xml` (project `<version>`) | — |
 | `ruby`   | `ruby/lib/open_banking_io/version.rb` (`VERSION`) | gemspec |
 | `go`     | **none** — version *is* the tag; `Version` const in `go/client.go` is cosmetic (User-Agent) | — |
-| `php`    | **none** — Packagist derives version from the tag; `Client::VERSION` const is cosmetic | — |
+| `php`    | **none** — Packagist derives version from the tag, but `Client::VERSION` must match it: `publish-php.yml` refuses the tag otherwise | — |
 | `beancount` | `beancount/pyproject.toml` (`[project].version`) | — |
 | `erpnext` | `erpnext/pyproject.toml` (`[project].version`) | `erpnext/erpnext_open_banking/__init__.py` (`__version__`) |
 | `zapier` | `zapier/package.json` (`version`) | `zapier/package-lock.json` |
@@ -45,13 +45,15 @@ directly. A release is two steps:
 node tools/bump-version.mjs <package> <version>   # e.g. node 0.2.0  (updates manifest + lockfiles)
 ```
 
-For `go`/`php`, update the cosmetic `Version`/`VERSION` const to match. Open the PR, let CI pass, merge.
+For `go`, update the cosmetic `Version` const to match. For `php`, `Client::VERSION` is **not**
+cosmetic -- `publish-php.yml` refuses a tag that disagrees with it, so bump it here. Open the PR, let CI pass, merge.
 
 **2. Tag via the Release workflow.** Go to **Actions → Release → Run workflow**, pick the **package** and
 **version**. It will:
 - validate semver and **refuse if the tag already exists**;
 - for non-`go`/`php`: verify the manifest on `main` is **already** at that version (fails with a clear
-  message if you forgot step 1);
+  message if you forgot step 1). `php` is checked by `publish-php.yml` instead, after the tag is
+  pushed: it refuses to publish when the tag and `Client::VERSION` disagree;
 - create and push the tag `<pkg>/v<version>` and a **GitHub Release** with auto-generated notes.
 
 Pushing the tag triggers `publish-<pkg>.yml`, which re-checks `tag == manifest` and publishes to the

--- a/php/.gitattributes
+++ b/php/.gitattributes
@@ -1,0 +1,9 @@
+# The fixtures bundle carries a test API key and a test PKCS#8 private key. They belong in the
+# repository so the suite runs, but export-ignore keeps them out of the Packagist dist archive
+# and therefore out of every consumer's vendor/ and their dependency scanners.
+/tests           export-ignore
+/phpunit.xml     export-ignore
+/phpstan.neon    export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/.gitattributes  export-ignore
+/.gitignore      export-ignore

--- a/php/README.md
+++ b/php/README.md
@@ -14,7 +14,7 @@ key** — the service only ever returns ciphertext it cannot read.
 composer require open-banking-io/client
 ```
 
-Requires PHP **8.1+** with `ext-openssl`, `ext-curl` and `ext-json` (no runtime Composer dependencies).
+Requires PHP **8.2+** with `ext-openssl`, `ext-curl` and `ext-json` (no runtime Composer dependencies).
 
 Every request carries a `User-Agent: open-banking-io/php/<version>` header (`Client::VERSION`) and uses a 30s total / 10s connect timeout.
 
@@ -77,10 +77,33 @@ $client = Client::fromCredentials('credentials.json', ['timeout' => 60]);
 - `getTransactions(string $accountId, array $opts = []): TransactionPage` — `$opts` keys: `from`, `to`, `limit`, `offset`.
 - `getConnections(): Connection[]`
 - `sync(string $accountId): SyncResult` — decrypts the account uid locally and posts it; throws if the account has no active session.
-- `syncAll(): SyncAllResult` — syncs every account that has an active session.
+- `syncAll(): SyncAllResult` — syncs every account whose session it can read; `$result->unreadable` lists the ones it could not, and `isComplete()` is the only proof the run covered everything.
 
 Money/amount fields are exposed as **decimal `string`s** (exact; never a float). Models are
 `final` classes with `readonly` public properties under `OpenBankingIO\Model`.
+
+### A null amount is not zero
+
+`$transaction->amount` and `$balance->amount` are `?string`. `null` means the envelope could not
+be read, never that the transaction was for nothing — `$transaction->isSealed()` is true and
+`$transaction->decryptError` says why. Casting a null amount to a number books a zero-value entry
+that looks like real data, so branch on `isSealed()` before you read it:
+
+```php
+foreach ($client->getTransactions($accountId)->items as $t) {
+    if ($t->amount === null) {
+        // isSealed() tells you whether the envelope failed; a null amount also covers a field
+        // the service simply did not send, so check the amount itself, not only isSealed().
+        fwrite(STDERR, "skipping {$t->id}: " . ($t->decryptError ?? 'no amount') . "\n");
+        continue;
+    }
+
+    // safe: $t->amount is a decimal string here
+}
+```
+
+The same holds for `Account::isSealed()`, which also reports a balance envelope it could not
+open.
 
 ## Encryption
 
@@ -96,7 +119,7 @@ composer install
 vendor/bin/phpunit
 ```
 
-The tests read the shared fixtures at the repo-root `fixtures/` directory. The integration test
+The tests read the shared `fixtures/` directory, which the release pipeline vendors into `tests/fixtures/` in the source mirror. The Packagist distribution archive omits `tests/` entirely. The integration test
 spins up a local mock API using PHP's built-in server (`php -S`) as a subprocess.
 
 ### Static analysis & formatting

--- a/php/composer.json
+++ b/php/composer.json
@@ -3,8 +3,26 @@
     "description": "Server-to-server client for open-banking.io: API-key auth and local zero-knowledge envelope decryption.",
     "type": "library",
     "license": "MIT",
-    "keywords": ["open-banking", "psd2", "banking", "zero-knowledge", "ecdh"],
+    "keywords": [
+        "open-banking",
+        "psd2",
+        "banking",
+        "zero-knowledge",
+        "ecdh"
+    ],
     "homepage": "https://open-banking.io",
+    "authors": [
+        {
+            "name": "open-banking.io",
+            "homepage": "https://open-banking.io"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/open-banking-io/clients/issues",
+        "source": "https://github.com/open-banking-io/clients/tree/main/php",
+        "security": "https://github.com/open-banking-io/clients/blob/main/SECURITY.md",
+        "email": "security@open-banking.io"
+    },
     "require": {
         "php": ">=8.2",
         "ext-openssl": "*",
@@ -14,7 +32,8 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.95",
         "phpstan/phpstan": "^2.2",
-        "phpunit/phpunit": "^11 || ^12"
+        "phpunit/phpunit": "^11 || ^12",
+        "symfony/var-dumper": "^6.4 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/php/src/Client.php
+++ b/php/src/Client.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenBankingIO;
 
+use OpenBankingIO\Internal\EnvelopeResult;
+use OpenBankingIO\Internal\Secret;
 use OpenBankingIO\Model\Account;
 use OpenBankingIO\Model\Balance;
 use OpenBankingIO\Model\Connection;
@@ -25,7 +27,7 @@ final class Client
      * Client version, sent as the User-Agent. Tracks the published release tag
      * (PHP has no build manifest -- Packagist is tag-based), so bump this when tagging.
      */
-    public const VERSION = '0.3.0';
+    public const VERSION = '1.0.0';
 
     /** Total request timeout, in seconds. */
     private const TIMEOUT_SECONDS = 30;
@@ -34,7 +36,7 @@ final class Client
     private const CONNECT_TIMEOUT_SECONDS = 10;
 
     private readonly string $apiBaseUrl;
-    private readonly string $apiKey;
+    private readonly Secret $apiKey;
     private readonly Envelope $envelope;
 
     /** Effective total request timeout, in seconds (caller may override). */
@@ -44,11 +46,13 @@ final class Client
     private readonly int $connectTimeoutSeconds;
 
     /**
-     * Extra cURL options (CURLOPT_* => value) applied last, so callers win over SDK defaults.
+     * The README recommends curl_options for mTLS, so it can hold CURLOPT_SSLCERTPASSWD or
+     * CURLOPT_USERPWD. Kept out of reach for the same reason as the api key: __debugInfo() hides it
+     * from var_dump, but VarDumper reads real properties and crash reporters upload what it emits.
      *
-     * @var array<int, mixed>
+     * @var \WeakMap<self, array<int, mixed>>|null
      */
-    private readonly array $curlOptions;
+    private static ?\WeakMap $transportOptions = null;
 
     /**
      * @param array{
@@ -61,20 +65,24 @@ final class Client
      *   - `timeout`: total request timeout in seconds (overrides the SDK default).
      *   - `connect_timeout`: connection-establishment timeout in seconds (overrides the SDK default).
      */
-    public function __construct(string $apiBaseUrl, string $apiKey, string $privateKeyPkcs8, array $options = [])
-    {
+    public function __construct(
+        string $apiBaseUrl,
+        #[\SensitiveParameter] string $apiKey,
+        #[\SensitiveParameter] string $privateKeyPkcs8,
+        #[\SensitiveParameter] array $options = [],
+    ) {
         if (trim($apiBaseUrl) === '') {
-            throw new \InvalidArgumentException('apiBaseUrl is required');
+            throw new OpenBankingException('apiBaseUrl is required');
         }
         if (trim($apiKey) === '') {
-            throw new \InvalidArgumentException('apiKey is required');
+            throw new OpenBankingException('apiKey is required');
         }
         if (trim($privateKeyPkcs8) === '') {
-            throw new \InvalidArgumentException('privateKeyPkcs8 is required');
+            throw new OpenBankingException('privateKeyPkcs8 is required');
         }
 
         $this->apiBaseUrl = rtrim($apiBaseUrl, '/');
-        $this->apiKey = $apiKey;
+        $this->apiKey = new Secret($apiKey);
         $this->envelope = Envelope::fromPkcs8Base64($privateKeyPkcs8);
 
         $this->timeoutSeconds = isset($options['timeout']) ? (int) $options['timeout'] : self::TIMEOUT_SECONDS;
@@ -83,7 +91,8 @@ final class Client
             : self::CONNECT_TIMEOUT_SECONDS;
         /** @var array<int, mixed> $curlOptions */
         $curlOptions = is_array($options['curl_options'] ?? null) ? $options['curl_options'] : [];
-        $this->curlOptions = $curlOptions;
+        self::$transportOptions ??= new \WeakMap();
+        self::$transportOptions[$this] = $curlOptions;
     }
 
     /**
@@ -95,7 +104,7 @@ final class Client
      *     connect_timeout?: int,
      * } $options Optional transport overrides; see the constructor.
      */
-    public static function fromCredentials(string $pathOrJson, array $options = []): self
+    public static function fromCredentials(#[\SensitiveParameter] string $pathOrJson, #[\SensitiveParameter] array $options = []): self
     {
         $raw = $pathOrJson;
         if (str_ends_with(strtolower(trim($pathOrJson)), '.json') || @is_file($pathOrJson)) {
@@ -127,6 +136,32 @@ final class Client
         }
 
         return new self($apiBaseUrl, $apiKey, $privateKey, $options);
+    }
+
+    /**
+     * Transport options live in a WeakMap keyed on the instance, and __clone cannot reach the source
+     * object to copy them, so a clone would keep authenticating while quietly dropping the proxy, CA
+     * bundle or client certificate. Build a second client instead.
+     */
+    public function __clone(): void
+    {
+        throw new OpenBankingException('A Client must not be cloned; construct a new one instead');
+    }
+
+    /**
+     * Covers var_dump and print_r. var_export and an (array) cast read properties directly, which
+     * is why the credentials are held out of any property at all.
+     *
+     * @return array<string, string>
+     */
+    public function __debugInfo(): array
+    {
+        return [
+            'apiBaseUrl' => $this->apiBaseUrl,
+            'apiKey' => '[redacted]',
+            'envelope' => '[redacted]',
+            'curlOptions' => '[redacted]',
+        ];
     }
 
     // -- Public API ------------------------------------------------------------
@@ -163,15 +198,18 @@ final class Client
             $path .= '?' . http_build_query($query);
         }
 
-        /** @var array{items?: array<int, array<string, mixed>>, total?: int} $page */
         $page = $this->getJson($path);
+
+        if (!array_key_exists('total', $page) || !array_key_exists('items', $page)) {
+            throw new ApiException("Unexpected response from {$path}: expected items and total");
+        }
 
         $items = array_map(
             fn (array $t): Transaction => $this->mapTransaction($t),
-            $page['items'] ?? [],
+            self::rowList($page['items'], $path),
         );
 
-        return new TransactionPage($items, (int) ($page['total'] ?? 0));
+        return new TransactionPage($items, self::requiredInt($page['total'], 'total', $path));
     }
 
     /**
@@ -181,8 +219,7 @@ final class Client
      */
     public function getConnections(): array
     {
-        /** @var array<int, array<string, mixed>> $rows */
-        $rows = $this->getJson('api/connections');
+        $rows = self::rowList($this->getJson('api/connections'), 'api/connections');
 
         return array_map(
             fn (array $c): Connection => new Connection(
@@ -218,20 +255,26 @@ final class Client
             throw new OpenBankingException("Account {$accountId} not found");
         }
 
-        $uid = $this->decryptUid($account);
-        if ($uid === null) {
+        $session = $this->openEnvelope($account['uidEnc'] ?? null);
+        if ($session->error !== null) {
+            throw new OpenBankingException(
+                "Account {$accountId} session could not be decrypted: {$session->error}",
+            );
+        }
+
+        $uid = $session->get('uid');
+        if (!is_string($uid)) {
             throw new OpenBankingException(
                 'Account has no active session (reconnect required) -- cannot sync',
             );
         }
 
         $path = 'api/accounts/' . rawurlencode($accountId) . '/sync';
-        /** @var array{newTransactions?: int, totalFetched?: int} $result */
-        $result = $this->postJson($path, ['uid' => $uid]);
+        $result = self::counters($this->postJson($path, ['uid' => $uid]), ['newTransactions', 'totalFetched'], $path);
 
         return new SyncResult(
-            newTransactions: (int) ($result['newTransactions'] ?? 0),
-            totalFetched: (int) ($result['totalFetched'] ?? 0),
+            newTransactions: $result['newTransactions'],
+            totalFetched: $result['totalFetched'],
         );
     }
 
@@ -241,19 +284,50 @@ final class Client
     public function syncAll(): SyncAllResult
     {
         $items = [];
+        $sealed = [];
+
         foreach ($this->getAccountWires() as $wire) {
-            $uid = $this->decryptUid($wire);
-            if ($uid !== null) {
-                $items[] = ['accountId' => $wire['id'] ?? null, 'uid' => $uid];
+            $id = self::str($wire['id'] ?? null);
+            $session = $this->openEnvelope($wire['uidEnc'] ?? null);
+
+            if ($session->error !== null) {
+                $sealed[self::unreadableKey($sealed, $id)] = $session->error;
+
+                continue;
             }
+
+            if ($session->isAbsent()) {
+                // No session at all: the account is simply not connected, which is not a fault.
+                continue;
+            }
+
+            $uid = $session->get('uid');
+
+            if (is_string($uid)) {
+                $items[] = ['accountId' => $id, 'uid' => $uid];
+
+                continue;
+            }
+
+            $sealed[self::unreadableKey($sealed, $id)] = 'session envelope carries no usable uid';
         }
 
-        /** @var array{accounts?: int, newTransactions?: int} $result */
-        $result = $this->postJson('api/sync', ['items' => $items]);
+        if ($items === [] && $sealed !== []) {
+            throw new OpenBankingException(
+                'No account session could be used, so nothing was synced: ' . implode('; ', array_map(
+                    static fn (string $id, string $reason): string => "{$id}: {$reason}",
+                    array_keys($sealed),
+                    $sealed,
+                )),
+            );
+        }
+
+        $result = self::counters($this->postJson('api/sync', ['items' => $items]), ['accounts', 'newTransactions'], 'api/sync');
 
         return new SyncAllResult(
-            accounts: (int) ($result['accounts'] ?? 0),
-            newTransactions: (int) ($result['newTransactions'] ?? 0),
+            accounts: $result['accounts'],
+            newTransactions: $result['newTransactions'],
+            unreadable: $sealed,
         );
     }
 
@@ -264,20 +338,50 @@ final class Client
      */
     private function getAccountWires(): array
     {
-        /** @var array<int, array<string, mixed>> $wires */
-        $wires = $this->getJson('api/accounts');
-        return $wires;
+        return self::rowList($this->getJson('api/accounts'), 'api/accounts');
     }
 
     /**
-     * @param array<string, mixed> $account
+     * @param array<int|string, mixed> $decoded
+     * @param array<int, string> $keys
+     * @return array<string, int>
      */
-    private function decryptUid(array $account): ?string
+    private static function counters(array $decoded, array $keys, string $path): array
     {
-        $uidEnc = $account['uidEnc'] ?? null;
-        $payload = $this->envelope->decryptToArray(is_string($uidEnc) ? $uidEnc : null);
-        $uid = $payload['uid'] ?? null;
-        return is_string($uid) ? $uid : null;
+        $counters = [];
+
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $decoded)) {
+                throw new ApiException("Unexpected response from {$path}: expected {$key}");
+            }
+
+            $counters[$key] = self::requiredInt($decoded[$key], $key, $path);
+        }
+
+        return $counters;
+    }
+
+    /**
+     * @param mixed $decoded
+     * @return array<int, array<string, mixed>>
+     */
+    private static function rowList($decoded, string $path): array
+    {
+        if (!is_array($decoded) || ($decoded !== [] && !array_is_list($decoded))) {
+            throw new ApiException("Unexpected response from {$path}: expected a list of objects");
+        }
+
+        $rows = [];
+        foreach ($decoded as $row) {
+            if (!is_array($row)) {
+                throw new ApiException("Unexpected response from {$path}: expected a list of objects");
+            }
+
+            $rows[] = $row;
+        }
+
+        /** @var array<int, array<string, mixed>> $rows */
+        return $rows;
     }
 
     /**
@@ -285,20 +389,21 @@ final class Client
      */
     private function mapAccount(array $a): Account
     {
-        $acc = $this->decryptEnc($a['enc'] ?? null);
-        $name = $this->decryptEnc($a['displayNameEnc'] ?? null);
+        $acc = $this->openEnvelope($a['enc'] ?? null);
+        $name = $this->openEnvelope($a['displayNameEnc'] ?? null);
 
         $balances = [];
         $rawBalances = is_array($a['balances'] ?? null) ? $a['balances'] : [];
         foreach ($rawBalances as $b) {
             $b = is_array($b) ? $b : [];
-            $dec = $this->decryptEnc($b['enc'] ?? null);
+            $dec = $this->openEnvelope($b['enc'] ?? null);
             $balances[] = new Balance(
                 type: self::str($b['type'] ?? null),
-                name: self::nullableString($dec['name'] ?? null),
-                amount: self::decimalString($dec['amount'] ?? null),
+                name: self::nullableString($dec->get('name')),
+                amount: self::nullableString($dec->get('amount')),
                 currency: self::str($b['currency'] ?? null),
                 referenceDate: self::nullableString($b['referenceDate'] ?? null),
+                decryptError: $dec->error,
             );
         }
 
@@ -310,13 +415,21 @@ final class Client
             accountType: self::nullableString($a['accountType'] ?? null),
             bic: self::nullableString($a['bic'] ?? null),
             needsReconnect: (bool) ($a['needsReconnect'] ?? false),
-            iban: self::nullableString($acc['iban'] ?? null),
-            bban: self::nullableString($acc['bban'] ?? null),
-            ownerName: self::nullableString($acc['ownerName'] ?? null),
-            accountName: self::nullableString($acc['accountName'] ?? null),
-            product: self::nullableString($acc['product'] ?? null),
-            displayName: self::nullableString($name['displayName'] ?? null),
+            iban: self::nullableString($acc->get('iban')),
+            bban: self::nullableString($acc->get('bban')),
+            ownerName: self::nullableString($acc->get('ownerName')),
+            accountName: self::nullableString($acc->get('accountName')),
+            product: self::nullableString($acc->get('product')),
+            displayName: self::nullableString($name->get('displayName')),
             balances: $balances,
+            decryptError: self::describeErrors([
+                'account' => $acc->error,
+                'displayName' => $name->error,
+                'balances' => self::describeErrors(array_map(
+                    static fn (Balance $balance): ?string => $balance->decryptError,
+                    $balances,
+                )),
+            ]),
         );
     }
 
@@ -325,7 +438,7 @@ final class Client
      */
     private function mapTransaction(array $t): Transaction
     {
-        $d = $this->decryptEnc($t['enc'] ?? null);
+        $d = $this->openEnvelope($t['enc'] ?? null);
 
         return new Transaction(
             id: self::str($t['id'] ?? null),
@@ -336,33 +449,64 @@ final class Client
             valueDate: self::nullableString($t['valueDate'] ?? null),
             transactionDate: self::nullableString($t['transactionDate'] ?? null),
             bankTransactionCode: self::nullableString($t['bankTransactionCode'] ?? null),
-            amount: self::decimalString($d['amount'] ?? null),
-            creditorName: self::nullableString($d['creditorName'] ?? null),
-            creditorIban: self::nullableString($d['creditorIban'] ?? null),
-            creditorBban: self::nullableString($d['creditorBban'] ?? null),
-            creditorAgentBic: self::nullableString($d['creditorAgentBic'] ?? null),
-            debtorName: self::nullableString($d['debtorName'] ?? null),
-            debtorIban: self::nullableString($d['debtorIban'] ?? null),
-            debtorBban: self::nullableString($d['debtorBban'] ?? null),
-            debtorAgentBic: self::nullableString($d['debtorAgentBic'] ?? null),
-            remittanceInformation: self::nullableString($d['remittanceInformation'] ?? null),
-            note: self::nullableString($d['note'] ?? null),
-            referenceNumber: self::nullableString($d['referenceNumber'] ?? null),
-            exchangeRate: self::nullableString($d['exchangeRate'] ?? null),
-            merchantCategoryCode: self::nullableString($d['merchantCategoryCode'] ?? null),
-            balanceAfter: self::nullableDecimalString($d['balanceAfter'] ?? null),
-            balanceAfterCurrency: self::nullableString($d['balanceAfterCurrency'] ?? null),
-            rawJson: self::nullableString($d['rawJson'] ?? null),
+            amount: self::nullableString($d->get('amount')),
+            creditorName: self::nullableString($d->get('creditorName')),
+            creditorIban: self::nullableString($d->get('creditorIban')),
+            creditorBban: self::nullableString($d->get('creditorBban')),
+            creditorAgentBic: self::nullableString($d->get('creditorAgentBic')),
+            debtorName: self::nullableString($d->get('debtorName')),
+            debtorIban: self::nullableString($d->get('debtorIban')),
+            debtorBban: self::nullableString($d->get('debtorBban')),
+            debtorAgentBic: self::nullableString($d->get('debtorAgentBic')),
+            remittanceInformation: self::nullableString($d->get('remittanceInformation')),
+            note: self::nullableString($d->get('note')),
+            referenceNumber: self::nullableString($d->get('referenceNumber')),
+            exchangeRate: self::nullableString($d->get('exchangeRate')),
+            merchantCategoryCode: self::nullableString($d->get('merchantCategoryCode')),
+            balanceAfter: self::nullableString($d->get('balanceAfter')),
+            balanceAfterCurrency: self::nullableString($d->get('balanceAfterCurrency')),
+            rawJson: self::nullableString($d->get('rawJson')),
+            decryptError: $d->error,
         );
     }
 
     /**
-     * @param mixed $enc
-     * @return array<string, mixed>
+     * Names which envelope failed, so a display-name failure is not mistaken for the
+     * account's own fields being unreadable.
+     *
+     * @param array<array-key, string|null> $errors
      */
-    private function decryptEnc($enc): array
+    private static function describeErrors(array $errors): ?string
     {
-        return $this->envelope->decryptToArray(is_string($enc) ? $enc : null) ?? [];
+        $described = [];
+
+        foreach ($errors as $envelope => $error) {
+            if ($error !== null) {
+                $described[] = "{$envelope}: {$error}";
+            }
+        }
+
+        return $described === [] ? null : implode('; ', $described);
+    }
+
+    /**
+     * @param mixed $enc
+     */
+    private function openEnvelope($enc): EnvelopeResult
+    {
+        if ($enc === null || $enc === '') {
+            return EnvelopeResult::absent();
+        }
+
+        if (!is_string($enc)) {
+            return EnvelopeResult::sealed('Envelope field is ' . get_debug_type($enc) . ', not a string');
+        }
+
+        try {
+            return EnvelopeResult::opened($this->envelope->decryptToArray($enc) ?? []);
+        } catch (EnvelopeException | \JsonException $e) {
+            return EnvelopeResult::sealed($e->getMessage());
+        }
     }
 
     // -- HTTP ------------------------------------------------------------------
@@ -393,7 +537,7 @@ final class Client
     {
         $url = $this->apiBaseUrl . '/' . ltrim($path, '/');
 
-        $headers = ['X-Api-Key: ' . $this->apiKey, 'Accept: application/json'];
+        $headers = ['X-Api-Key: ' . $this->apiKey->reveal(), 'Accept: application/json'];
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
@@ -409,12 +553,33 @@ final class Client
             $headers[] = 'Content-Type: application/json';
         }
 
+        $curlOptions = self::$transportOptions[$this] ?? [];
+        $curlOptions = is_array($curlOptions) ? $curlOptions : [];
+
+        // curl_setopt_array replaces an array option rather than merging it, so a caller adding one
+        // header would drop X-Api-Key and authenticate as nobody.
+        $callerHeaders = $curlOptions[CURLOPT_HTTPHEADER] ?? null;
+
+        if (is_array($callerHeaders)) {
+            foreach ($callerHeaders as $header) {
+                if (is_string($header)) {
+                    $headers[] = $header;
+                }
+            }
+
+            unset($curlOptions[CURLOPT_HTTPHEADER]);
+        }
+
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
         // Caller-supplied cURL options are applied LAST so they win over the SDK defaults
         // (proxy, custom CA/CAINFO, mTLS client cert, keep-alive, etc.).
-        if ($this->curlOptions !== []) {
-            curl_setopt_array($ch, $this->curlOptions);
+        if ($curlOptions !== []) {
+            try {
+                curl_setopt_array($ch, $curlOptions);
+            } catch (\ValueError $e) {
+                throw new OpenBankingException('A curl_options entry was rejected: ' . $e->getMessage());
+            }
         }
 
         $responseBody = curl_exec($ch);
@@ -434,12 +599,20 @@ final class Client
         }
 
         try {
-            /** @var array<int|string, mixed> $decoded */
             $decoded = json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
             throw new ApiException("{$method} {$path} returned invalid JSON: " . $e->getMessage());
         }
 
+        // A captive portal or a gateway can answer 200 with a bare scalar. Returning it would
+        // trip this method's own return type, and a TypeError is not what callers catch.
+        if (!is_array($decoded)) {
+            throw new ApiException(
+                "{$method} {$path} returned " . get_debug_type($decoded) . ', expected an object or a list',
+            );
+        }
+
+        /** @var array<int|string, mixed> $decoded */
         return $decoded;
     }
 
@@ -453,6 +626,60 @@ final class Client
     private static function str($value): string
     {
         return self::nullableString($value) ?? '';
+    }
+
+    /**
+     * An account the caller can act on, and never one that silently replaces another: a provider
+     * repeating an id, or omitting it, must not make the unreadable set under-report.
+     *
+     * @param array<string, string> $taken
+     */
+    private static function unreadableKey(array $taken, string $id): string
+    {
+        $base = $id === '' ? '(account with no id)' : $id;
+
+        if (!array_key_exists($base, $taken)) {
+            return $base;
+        }
+
+        for ($n = 2; array_key_exists("{$base} (#{$n})", $taken); $n++) {
+            // find the first free suffix
+        }
+
+        return "{$base} (#{$n})";
+    }
+
+    /**
+     * A required counter, validated rather than coerced: a malformed total or newTransactions
+     * would otherwise read as a finished empty page or a successful no-op.
+     *
+     * @param mixed $value
+     */
+    private static function requiredInt($value, string $key, string $path): int
+    {
+        // /D anchors $ at the very end: without it PCRE also matches before a trailing newline, so
+        // "5\n" would pass a check whose whole job is to validate rather than coerce.
+        if (!is_int($value) && !(is_string($value) && preg_match('/^-?\d+$/D', $value) === 1)) {
+            throw new ApiException(
+                "Unexpected response from {$path}: {$key} is " . get_debug_type($value) . ', expected an integer',
+            );
+        }
+
+        // A digit string past the integer range saturates silently, which would report a plausible
+        // row count for a response that cannot be right. Equal-length digit strings compare the
+        // same lexicographically as numerically, so this needs no arbitrary-precision arithmetic.
+        // The negative range reaches one further than the positive one.
+        if (is_string($value)) {
+            $negative = str_starts_with($value, '-');
+            $digits = ltrim(ltrim($value, '-'), '0');
+            $ceiling = $negative ? ltrim((string) PHP_INT_MIN, '-') : (string) PHP_INT_MAX;
+
+            if (strlen($digits) > strlen($ceiling) || (strlen($digits) === strlen($ceiling) && $digits > $ceiling)) {
+                throw new ApiException("Unexpected response from {$path}: {$key} is out of range");
+            }
+        }
+
+        return (int) $value;
     }
 
     /**
@@ -480,21 +707,4 @@ final class Client
         return $str === '' ? null : $str;
     }
 
-    /**
-     * Amounts are kept as exact decimal strings; never a float.
-     *
-     * @param mixed $value
-     */
-    private static function decimalString($value): string
-    {
-        return self::nullableString($value) ?? '0';
-    }
-
-    /**
-     * @param mixed $value
-     */
-    private static function nullableDecimalString($value): ?string
-    {
-        return self::nullableString($value);
-    }
 }

--- a/php/src/Envelope.php
+++ b/php/src/Envelope.php
@@ -27,32 +27,73 @@ final class Envelope
      */
     private const SPKI_PREFIX_HEX = '3059301306072a8648ce3d020106082a8648ce3d030107034200';
 
-    /** @var \OpenSSLAsymmetricKey */
-    private $privateKey;
+    /**
+     * Symfony's VarDumper -- what Laravel's dd()/dump() and Ignition/Flare-style reporters use --
+     * expands an OpenSSLAsymmetricKey into its EC components, including the private scalar. Statics
+     * are not dumped, so the key lives in one keyed off the instance rather than in a property.
+     *
+     * @var \WeakMap<self, \OpenSSLAsymmetricKey>|null
+     */
+    private static ?\WeakMap $keys = null;
 
     private function __construct(\OpenSSLAsymmetricKey $privateKey)
     {
-        $this->privateKey = $privateKey;
+        self::$keys ??= new \WeakMap();
+        self::$keys[$this] = $privateKey;
+    }
+
+    private function privateKey(): \OpenSSLAsymmetricKey
+    {
+        $key = self::$keys[$this] ?? null;
+
+        if (!$key instanceof \OpenSSLAsymmetricKey) {
+            throw new EnvelopeException('This envelope was copied or restored and no longer holds a key');
+        }
+
+        return $key;
     }
 
     /**
      * Loads a base64 PKCS#8 EC (P-256) private key by wrapping the DER in PEM.
      */
-    public static function fromPkcs8Base64(string $privateKeyPkcs8B64): self
+    public static function fromPkcs8Base64(#[\SensitiveParameter] string $privateKeyPkcs8B64): self
     {
-        $pem = "-----BEGIN PRIVATE KEY-----\n"
-            . chunk_split(trim($privateKeyPkcs8B64), 64, "\n")
+        self::drainErrors();
+
+        $body = trim($privateKeyPkcs8B64);
+
+        if (preg_match('#^[A-Za-z0-9+/]+={0,2}$#', $body) !== 1) {
+            throw new EnvelopeException('Private key is not bare base64 -- strip any PEM armor and newlines');
+        }
+
+        $pem = "-----BEGIN PRIVATE KEY-----\n" // gitleaks:allow
+            . chunk_split($body, 64, "\n")
             . "-----END PRIVATE KEY-----\n";
 
         $key = openssl_pkey_get_private($pem);
         if ($key === false) {
+            self::drainErrors();
+
             throw new EnvelopeException('Invalid PKCS#8 private key');
         }
 
         $details = openssl_pkey_get_details($key);
         if ($details === false || ($details['type'] ?? -1) !== OPENSSL_KEYTYPE_EC) {
+            self::drainErrors();
+
             throw new EnvelopeException('Private key is not an EC key');
         }
+
+        $ec = $details['ec'] ?? null;
+
+        // OpenSSL and LibreSSL disagree on the name of the same curve.
+        if (!is_array($ec) || !in_array($ec['curve_name'] ?? null, ['prime256v1', 'secp256r1'], true)) {
+            self::drainErrors();
+
+            throw new EnvelopeException('Private key is not a P-256 key');
+        }
+
+        self::drainErrors();
 
         return new self($key);
     }
@@ -75,8 +116,13 @@ final class Envelope
 
         $plaintext = $this->decrypt($raw);
 
-        /** @var array<string, mixed> $payload */
         $payload = json_decode($plaintext, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($payload) || ($payload !== [] && array_is_list($payload))) {
+            throw new EnvelopeException('Envelope payload is not a JSON object');
+        }
+
+        /** @var array<string, mixed> $payload */
         return $payload;
     }
 
@@ -85,8 +131,22 @@ final class Envelope
      */
     public function decrypt(string $envelope): string
     {
-        if (strlen($envelope) < self::HEADER_LEN || ord($envelope[0]) !== self::VERSION) {
-            throw new EnvelopeException('Invalid or unsupported envelope');
+        try {
+            return $this->decryptRaw($envelope);
+        } finally {
+            self::drainErrors();
+        }
+    }
+
+    private function decryptRaw(string $envelope): string
+    {
+        if (strlen($envelope) < self::HEADER_LEN) {
+            throw new EnvelopeException('Envelope is shorter than its header');
+        }
+
+        $version = ord($envelope[0]);
+        if ($version !== self::VERSION) {
+            throw new EnvelopeException(sprintf('Unsupported envelope version 0x%02x', $version));
         }
 
         $ephPubRaw = substr($envelope, 1, self::POINT_LEN);
@@ -96,7 +156,7 @@ final class Envelope
 
         $ephPub = self::publicKeyFromRawPoint($ephPubRaw);
 
-        $shared = openssl_pkey_derive($ephPub, $this->privateKey);
+        $shared = openssl_pkey_derive($ephPub, $this->privateKey());
         if ($shared === false) {
             throw new EnvelopeException('ECDH key agreement failed');
         }
@@ -120,6 +180,17 @@ final class Envelope
     }
 
     /**
+     * OpenSSL's error queue is global and per-process. Leaving entries behind makes a later,
+     * unrelated openssl call in the same worker report an error from a bank envelope.
+     */
+    private static function drainErrors(): void
+    {
+        while (openssl_error_string() !== false) {
+            // discard
+        }
+    }
+
+    /**
      * Builds an EC public key from a raw 65-byte (0x04 || X || Y) P-256 point.
      */
     private static function publicKeyFromRawPoint(string $rawPoint): \OpenSSLAsymmetricKey
@@ -129,12 +200,14 @@ final class Envelope
         }
 
         $der = hex2bin(self::SPKI_PREFIX_HEX) . $rawPoint;
-        $pem = "-----BEGIN PUBLIC KEY-----\n"
+        $pem = "-----BEGIN PUBLIC KEY-----\n" // gitleaks:allow
             . chunk_split(base64_encode($der), 64, "\n")
             . "-----END PUBLIC KEY-----\n";
 
         $key = openssl_pkey_get_public($pem);
         if ($key === false) {
+            self::drainErrors();
+
             throw new EnvelopeException('Invalid ephemeral public key');
         }
 

--- a/php/src/Internal/EnvelopeResult.php
+++ b/php/src/Internal/EnvelopeResult.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenBankingIO\Internal;
+
+/**
+ * The outcome of opening one zero-knowledge envelope.
+ *
+ * A sealed result means the ciphertext could not be read, which is not the same as the
+ * plaintext being empty -- callers that treat the two alike will import a transaction
+ * whose amount and counterparty silently became nothing.
+ *
+ * No public method accepts or returns one; the three states are surfaced on the models
+ *           as a nullable value plus $decryptError.
+ *
+ * @internal Not part of the public API; it may change or move in any release.
+ */
+final class EnvelopeResult
+{
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private function __construct(
+        public readonly array $fields,
+        public readonly ?string $error,
+        private readonly bool $present,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public static function opened(array $fields): self
+    {
+        return new self($fields, null, true);
+    }
+
+    public static function absent(): self
+    {
+        return new self([], null, false);
+    }
+
+    public static function sealed(string $reason): self
+    {
+        return new self([], $reason, true);
+    }
+
+    public function isReadable(): bool
+    {
+        return $this->present && $this->error === null;
+    }
+
+    public function isAbsent(): bool
+    {
+        return !$this->present;
+    }
+
+    /**
+     * @param mixed $default
+     * @return mixed
+     */
+    public function get(string $field, $default = null)
+    {
+        return $this->fields[$field] ?? $default;
+    }
+}

--- a/php/src/Internal/Secret.php
+++ b/php/src/Internal/Secret.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenBankingIO\Internal;
+
+/**
+ * Holds a credential where dumping the object that owns it cannot reach it.
+ *
+ * #[\SensitiveParameter] redacts stack frames only, and __debugInfo() is honoured by var_dump()
+ * and print_r() but not by Symfony's VarDumper -- which Laravel's dd()/dump() and every
+ * Ignition/Flare-style crash reporter are built on. VarDumper emits real properties alongside
+ * __debugInfo(), and it dumps a closure's captured variables, so neither a property nor a closure
+ * is safe. Statics are not dumped, so the value lives in one keyed off the instance.
+ *
+ *
+ * @internal Not part of the public API; it may change or move in any release.
+ */
+final class Secret
+{
+    /** @var \WeakMap<self, string>|null */
+    private static ?\WeakMap $values = null;
+
+    public function __construct(#[\SensitiveParameter] string $value)
+    {
+        self::$values ??= new \WeakMap();
+        self::$values[$this] = $value;
+    }
+
+    public function reveal(): string
+    {
+        $value = self::$values[$this] ?? null;
+
+        if (!is_string($value)) {
+            throw new \OpenBankingIO\OpenBankingException('This secret was copied or restored and no longer holds a value');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function __debugInfo(): array
+    {
+        return ['value' => '[redacted]'];
+    }
+
+    public function __toString(): string
+    {
+        return '[redacted]';
+    }
+
+    /**
+     * @return never
+     */
+    public function __serialize(): array
+    {
+        throw new \OpenBankingIO\OpenBankingException('A Secret must not be serialised');
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     * @return never
+     */
+    public function __unserialize(array $data): void
+    {
+        throw new \OpenBankingIO\OpenBankingException('A Secret must not be serialised');
+    }
+}

--- a/php/src/Model/Account.php
+++ b/php/src/Model/Account.php
@@ -25,6 +25,12 @@ final class Account
         public readonly ?string $product,
         public readonly ?string $displayName,
         public readonly array $balances,
+        public readonly ?string $decryptError = null,
     ) {
+    }
+
+    public function isSealed(): bool
+    {
+        return $this->decryptError !== null;
     }
 }

--- a/php/src/Model/Balance.php
+++ b/php/src/Model/Balance.php
@@ -10,10 +10,16 @@ final class Balance
     public function __construct(
         public readonly string $type,
         public readonly ?string $name,
-        /** Decimal string; never a float (exact money). */
-        public readonly string $amount,
+        /** Decimal string; never a float (exact money). Null when the envelope could not be read. */
+        public readonly ?string $amount,
         public readonly string $currency,
         public readonly ?string $referenceDate,
+        public readonly ?string $decryptError = null,
     ) {
+    }
+
+    public function isSealed(): bool
+    {
+        return $this->decryptError !== null;
     }
 }

--- a/php/src/Model/SyncAllResult.php
+++ b/php/src/Model/SyncAllResult.php
@@ -4,12 +4,28 @@ declare(strict_types=1);
 
 namespace OpenBankingIO\Model;
 
-/** The result of syncing every account with an active session. */
+/**
+ * The result of syncing every account with an active session.
+ *
+ * $unreadable maps an account id to why its session could not be used -- an envelope that failed
+ * to decrypt, or one that opened without a usable uid. Those accounts were not synced and are not
+ * counted; an empty $unreadable is the only proof the run was complete. An account with no session
+ * at all is simply not connected and does not appear.
+ */
 final class SyncAllResult
 {
+    /**
+     * @param array<string, string> $unreadable
+     */
     public function __construct(
         public readonly int $accounts,
         public readonly int $newTransactions,
+        public readonly array $unreadable = [],
     ) {
+    }
+
+    public function isComplete(): bool
+    {
+        return $this->unreadable === [];
     }
 }

--- a/php/src/Model/Transaction.php
+++ b/php/src/Model/Transaction.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace OpenBankingIO\Model;
 
-/** A statement transaction with its sensitive fields decrypted. Amounts are decimal strings. */
+/**
+ * A statement transaction with its sensitive fields decrypted. Amounts are decimal strings.
+ *
+ * A null $amount means the envelope could not be read, never that the transaction was for
+ * nothing -- $decryptError says which. Importing such a row books a zero-value entry.
+ */
 final class Transaction
 {
     public function __construct(
@@ -16,7 +21,7 @@ final class Transaction
         public readonly ?string $valueDate,
         public readonly ?string $transactionDate,
         public readonly ?string $bankTransactionCode,
-        public readonly string $amount,
+        public readonly ?string $amount,
         public readonly ?string $creditorName,
         public readonly ?string $creditorIban,
         public readonly ?string $creditorBban,
@@ -33,6 +38,12 @@ final class Transaction
         public readonly ?string $balanceAfter,
         public readonly ?string $balanceAfterCurrency,
         public readonly ?string $rawJson,
+        public readonly ?string $decryptError = null,
     ) {
+    }
+
+    public function isSealed(): bool
+    {
+        return $this->decryptError !== null;
     }
 }

--- a/php/tests/ClientFactoryTest.php
+++ b/php/tests/ClientFactoryTest.php
@@ -31,21 +31,21 @@ final class ClientFactoryTest extends TestCase
 
     public function testBlankBaseUrlRejected(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(OpenBankingException::class);
         $this->expectExceptionMessage('apiBaseUrl is required');
         new Client('   ', $this->credentials['apiKey'], $this->privateKey);
     }
 
     public function testBlankApiKeyRejected(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(OpenBankingException::class);
         $this->expectExceptionMessage('apiKey is required');
         new Client('https://api.example.com', '  ', $this->privateKey);
     }
 
     public function testBlankPrivateKeyRejected(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(OpenBankingException::class);
         $this->expectExceptionMessage('privateKeyPkcs8 is required');
         new Client('https://api.example.com', $this->credentials['apiKey'], '');
     }

--- a/php/tests/ClientTransportTest.php
+++ b/php/tests/ClientTransportTest.php
@@ -56,6 +56,25 @@ final class ClientTransportTest extends TestCase
         self::assertSame('custom-agent/9.9', $all['userAgent'] ?? null);
     }
 
+    public function testCallerHeadersAreMergedWithTheSdksRatherThanReplacingThem(): void
+    {
+        $this->startMockServer();
+
+        $this->client([
+            'curl_options' => [CURLOPT_HTTPHEADER => ['X-Caller-Tag: mine']],
+        ])->getAccounts();
+
+        $raw = file_get_contents($this->captureFile);
+        self::assertNotFalse($raw);
+        /** @var array<string, mixed> $all */
+        $all = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+
+        // curl_setopt_array replaces an array option outright, so without the merge the request
+        // would arrive with the caller's header and no X-Api-Key at all.
+        self::assertSame('mine', $all['callerHeader'] ?? null);
+        self::assertNotSame('', $all['apiKeyHeader'] ?? '');
+    }
+
     /**
      * A transport-shaping option such as CURLOPT_PROXY is honored: pointing at a
      * dead proxy port makes the otherwise-successful request fail.
@@ -118,10 +137,13 @@ final class ClientTransportTest extends TestCase
         }
         $elapsed = microtime(true) - $start;
 
-        // The failure must be a *timeout* specifically (cURL CURLE_OPERATION_TIMEDOUT,
-        // "Connection timed out after N milliseconds") -- not merely any fast failure,
-        // which would still pass if connect_timeout were ignored.
-        self::assertMatchesRegularExpression('/timed out|timeout/i', $message);
+        // Only a blackholed address produces a connect *timeout*; a network that answers TEST-NET-2
+        // with an ICMP unreachable fails in milliseconds instead, which proves nothing about the
+        // override either way. Skipping beats failing: this test gates the release, and the request
+        // timeout is covered deterministically by testTimeoutOverrideIsHonored.
+        if (preg_match('/timed out|timeout/i', $message) !== 1) {
+            self::markTestSkipped("198.51.100.1 is not blackholed here (cURL said: {$message})");
+        }
 
         // ...and it must abort near the 1s override, well before the 10s SDK default.
         self::assertLessThan(8.0, $elapsed);

--- a/php/tests/EnvelopeNegativeTest.php
+++ b/php/tests/EnvelopeNegativeTest.php
@@ -36,7 +36,7 @@ final class EnvelopeNegativeTest extends TestCase
         $raw = "\x01" . str_repeat("\x00", self::HEADER_LEN - 2); // one byte short of header
 
         $this->expectException(EnvelopeException::class);
-        $this->expectExceptionMessage('Invalid or unsupported envelope');
+        $this->expectExceptionMessage('shorter than its header');
         $this->envelope->decrypt($raw);
     }
 
@@ -44,7 +44,7 @@ final class EnvelopeNegativeTest extends TestCase
     public function testEmptyRawEnvelopeRejected(): void
     {
         $this->expectException(EnvelopeException::class);
-        $this->expectExceptionMessage('Invalid or unsupported envelope');
+        $this->expectExceptionMessage('shorter than its header');
         $this->envelope->decrypt('');
     }
 
@@ -55,7 +55,7 @@ final class EnvelopeNegativeTest extends TestCase
         $raw = "\x02" . str_repeat("\x00", self::HEADER_LEN); // header + 1 byte ciphertext
 
         $this->expectException(EnvelopeException::class);
-        $this->expectExceptionMessage('Invalid or unsupported envelope');
+        $this->expectExceptionMessage('Unsupported envelope version 0x02');
         $this->envelope->decrypt($raw);
     }
 

--- a/php/tests/EnvelopePayloadTest.php
+++ b/php/tests/EnvelopePayloadTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenBankingIO\Tests;
+
+use OpenBankingIO\Envelope;
+use OpenBankingIO\EnvelopeException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A decrypted envelope is trusted to be a JSON object. Anything else must surface as an
+ * envelope failure the caller can skip, never as a TypeError that aborts a whole page.
+ */
+final class EnvelopePayloadTest extends TestCase
+{
+    private Envelope $envelope;
+
+    private string $recipientPublicPem;
+
+    protected function setUp(): void
+    {
+        /** @var array{privateKeyPkcs8B64: string} $keypair */
+        $keypair = Fixtures::load('keypair.json');
+
+        $this->envelope = Envelope::fromPkcs8Base64($keypair['privateKeyPkcs8B64']);
+
+        $private = openssl_pkey_get_private(
+            "-----BEGIN PRIVATE KEY-----\n" // gitleaks:allow
+            . chunk_split($keypair['privateKeyPkcs8B64'], 64, "\n")
+            . "-----END PRIVATE KEY-----\n",
+        );
+        self::assertNotFalse($private);
+
+        $details = openssl_pkey_get_details($private);
+        self::assertIsArray($details);
+        self::assertIsString($details['key']);
+        $this->recipientPublicPem = $details['key'];
+    }
+
+    public function testAJsonObjectPayloadDecryptsToAnArray(): void
+    {
+        $payload = $this->envelope->decryptToArray($this->seal('{"amount":"9.95"}'));
+
+        self::assertSame(['amount' => '9.95'], $payload);
+    }
+
+    /**
+     * @return array<int, array{0: string}>
+     */
+    public static function scalarPayloads(): array
+    {
+        // '[]' is deliberately absent: an empty JSON object decodes to the same empty PHP array
+        // as an empty list, so the two cannot be told apart and the empty case is allowed.
+        return [['5'], ['"just a string"'], ['null'], ['true'], ['1.5'], ['[1,2,3]'], ['["a"]']];
+    }
+
+    #[DataProvider('scalarPayloads')]
+    public function testAScalarPayloadIsRejectedAsAnEnvelopeFailure(string $json): void
+    {
+        $this->expectException(EnvelopeException::class);
+        $this->expectExceptionMessage('not a JSON object');
+
+        $this->envelope->decryptToArray($this->seal($json));
+    }
+
+    private function seal(string $plaintext): string
+    {
+        $ephemeral = openssl_pkey_new([
+            'private_key_type' => OPENSSL_KEYTYPE_EC,
+            'curve_name' => 'prime256v1',
+        ]);
+        self::assertNotFalse($ephemeral);
+
+        $recipient = openssl_pkey_get_public($this->recipientPublicPem);
+        self::assertNotFalse($recipient);
+
+        $shared = openssl_pkey_derive($recipient, $ephemeral);
+        self::assertIsString($shared);
+
+        $key = hash_hkdf('sha256', $shared, 32, 'bank.core.ci/zk/v1', str_repeat("\x00", 32));
+
+        $nonce = random_bytes(12);
+        $tag = '';
+        $ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $nonce, $tag, '', 16);
+        self::assertIsString($ciphertext);
+
+        $details = openssl_pkey_get_details($ephemeral);
+        self::assertIsArray($details);
+        self::assertIsArray($details['ec']);
+        self::assertIsString($details['ec']['x']);
+        self::assertIsString($details['ec']['y']);
+
+        $point = "\x04"
+            . str_pad($details['ec']['x'], 32, "\x00", STR_PAD_LEFT)
+            . str_pad($details['ec']['y'], 32, "\x00", STR_PAD_LEFT);
+
+        return base64_encode("\x01" . $point . $nonce . $tag . $ciphertext);
+    }
+}

--- a/php/tests/Fixtures.php
+++ b/php/tests/Fixtures.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace OpenBankingIO\Tests;
 
-/** Locates and loads the shared fixtures at the repo-root fixtures/ directory. */
+/** Locates and loads the shared fixtures, in the monorepo or in the split-off package. */
 final class Fixtures
 {
-    /** php/tests/ -> php/ -> repo root -> fixtures/ */
+    /**
+     * The release pipeline subtree-splits php/ into its own repository, where the repo-root
+     * fixtures/ of this monorepo does not exist, so it vendors them in beside the tests first.
+     */
     public static function dir(): string
     {
-        return dirname(__DIR__, 2) . '/fixtures';
+        $vendored = __DIR__ . '/fixtures';
+
+        return is_dir($vendored) ? $vendored : dirname(__DIR__, 2) . '/fixtures';
     }
 
     /**

--- a/php/tests/HardeningTest.php
+++ b/php/tests/HardeningTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenBankingIO\Tests;
+
+use OpenBankingIO\ApiException;
+use OpenBankingIO\Client;
+use OpenBankingIO\Envelope;
+use OpenBankingIO\EnvelopeException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+
+/**
+ * These behaviours are invisible to the happy path, so without this file CI stays green if any
+ * of them is dropped.
+ */
+final class HardeningTest extends TestCase
+{
+    use SealsEnvelopes;
+
+    public function testRejectsAKeyOnTheWrongCurve(): void
+    {
+        $key = openssl_pkey_new(['private_key_type' => OPENSSL_KEYTYPE_EC, 'curve_name' => 'secp384r1']);
+        self::assertNotFalse($key);
+
+        openssl_pkey_export($key, $pem);
+        self::assertIsString($pem);
+
+        $this->expectException(EnvelopeException::class);
+        $this->expectExceptionMessage('not a P-256 key');
+
+        Envelope::fromPkcs8Base64($this->derBase64($pem));
+    }
+
+    public function testRejectsAKeyStillWearingItsPemArmor(): void
+    {
+        $keypair = Fixtures::load('keypair.json');
+
+        $key = $keypair['privateKeyPkcs8B64'];
+        self::assertIsString($key);
+
+        $armored = "-----BEGIN PRIVATE KEY-----\n" // gitleaks:allow
+            . chunk_split($key, 64, "\n")
+            . "-----END PRIVATE KEY-----\n";
+
+        $this->expectException(EnvelopeException::class);
+        $this->expectExceptionMessage('bare base64');
+
+        Envelope::fromPkcs8Base64($armored);
+    }
+
+    public function testKeyMaterialDoesNotSurviveIntoAStackTrace(): void
+    {
+        $secret = 'not-a-real-key-but-distinctive';
+
+        try {
+            Envelope::fromPkcs8Base64($secret);
+            self::fail('expected the key to be rejected');
+        } catch (EnvelopeException $e) {
+            self::assertStringNotContainsString($secret, print_r($e->getTrace(), true));
+        }
+    }
+
+    public function testTheApiKeyIsNotPrintedWhenTheClientIsDumped(): void
+    {
+        $keypair = Fixtures::load('keypair.json');
+
+        $key = $keypair['privateKeyPkcs8B64'];
+        self::assertIsString($key);
+
+        $client = new Client('https://example.test', 'ebk_super_secret', $key);
+
+        self::assertStringNotContainsString('ebk_super_secret', print_r($client, true));
+    }
+
+    public function testARejectedKeyLeavesNothingInTheOpenSslErrorQueue(): void
+    {
+        while (openssl_error_string() !== false) {
+            // start from a clean queue
+        }
+
+        try {
+            // A bad GCM tag happens to push nothing on some OpenSSL builds; a key OpenSSL cannot
+            // decode always does, which is what makes this assertion load-bearing.
+            Envelope::fromPkcs8Base64('bm90LWEta2V5');
+        } catch (EnvelopeException) {
+            // the failure is the point
+        }
+
+        self::assertFalse(openssl_error_string(), 'a later unrelated openssl call would report this key');
+    }
+
+    /**
+     * Laravel's dd()/dump() and every Ignition or Flare style crash reporter are built on
+     * VarDumper, which emits real properties alongside __debugInfo() and expands a closure's
+     * captured variables and an OpenSSLAsymmetricKey's EC components. It is the vector that
+     * matters most and the one a redacting logger cannot help with, because the value does not
+     * appear under a field called apiKey.
+     */
+    public function testNeitherCredentialSurvivesADumperBasedCrashReport(): void
+    {
+        $keypair = Fixtures::load('keypair.json');
+        $key = $keypair['privateKeyPkcs8B64'];
+        self::assertIsString($key);
+
+        // The README recommends curl_options for mTLS, so a client-certificate passphrase and
+        // proxy credentials are realistic values to find in there.
+        $client = new Client('https://example.test', 'obk_live_distinctive_key', $key, [
+            'curl_options' => [
+                CURLOPT_SSLCERTPASSWD => 'mtls-passphrase-distinctive',
+                CURLOPT_USERPWD => 'proxyuser:proxypass-distinctive',
+            ],
+        ]);
+
+        $dumped = (new CliDumper())->dump((new VarCloner())->cloneVar($client), true);
+        self::assertIsString($dumped);
+
+        self::assertStringNotContainsString('obk_live_distinctive_key', $dumped);
+        self::assertStringNotContainsString('mtls-passphrase-distinctive', $dumped);
+        self::assertStringNotContainsString('proxypass-distinctive', $dumped);
+        self::assertDoesNotMatchRegularExpression('/"d" =>/', $dumped, 'the P-256 private scalar must not be dumped');
+    }
+
+    public function testTheApiKeyIsNotPrintedByVarExportOrAnArrayCast(): void
+    {
+        $keypair = Fixtures::load('keypair.json');
+        $key = $keypair['privateKeyPkcs8B64'];
+        self::assertIsString($key);
+
+        $client = new Client('https://example.test', 'ebk_super_secret', $key);
+
+        self::assertStringNotContainsString('ebk_super_secret', var_export($client, true));
+        self::assertStringNotContainsString('ebk_super_secret', print_r((array) $client, true));
+    }
+
+    /**
+     * The invariant is that no envelope operation leaves anything behind for the next openssl call
+     * in the same worker. On this build a bad GCM tag happens to push nothing, so removing
+     * decrypt()'s finally is not observable here -- it is insurance for OpenSSL 1.1.1/3.0, where
+     * EVP_DecryptFinal_ex does push. The key-loading path below is what pins the drains that are
+     * observable everywhere.
+     */
+    public function testNoEnvelopeOperationLeavesAnythingInTheOpenSslErrorQueue(): void
+    {
+        $keypair = Fixtures::load('keypair.json');
+        $key = $keypair['privateKeyPkcs8B64'];
+        self::assertIsString($key);
+
+        $this->useRecipientKey($key);
+        $envelope = Envelope::fromPkcs8Base64($key);
+        $sealed = $this->seal('{"amount":"9.95"}');
+
+        foreach (['a successful decrypt', 'a tampered envelope', 'an off-curve ephemeral point'] as $i => $case) {
+            while (openssl_error_string() !== false) {
+                // start each case from a clean queue
+            }
+
+            try {
+                match ($i) {
+                    0 => $envelope->decryptToArray($sealed),
+                    1 => $envelope->decryptToArray(substr($sealed, 0, -4) . 'AAAA'),
+                    default => $envelope->decrypt("\x01\x04" . str_repeat("\xAA", 64) . str_repeat("\x00", 28) . 'ct'),
+                };
+            } catch (EnvelopeException | \JsonException) {
+                // the failure is the point
+            }
+
+            self::assertFalse(openssl_error_string(), "queue dirty after {$case}");
+        }
+    }
+
+    public function testRejectingAKeyEarlyDoesNotPassSomebodyElsesErrorsOn(): void
+    {
+        // Something unrelated dirtied the queue first. The armor check returns before any OpenSSL
+        // call, so only the drain on entry stops those entries being read as this envelope's.
+        openssl_pkey_get_private('not a key at all');
+        self::assertNotFalse(openssl_error_string(), 'expected the queue to be dirty to begin with');
+        openssl_pkey_get_private('not a key at all');
+
+        try {
+            Envelope::fromPkcs8Base64("-----BEGIN PRIVATE KEY-----\nAAAA\n-----END PRIVATE KEY-----"); // gitleaks:allow
+            self::fail('expected the armored key to be rejected');
+        } catch (EnvelopeException $e) {
+            self::assertStringContainsString('bare base64', $e->getMessage());
+        }
+
+        self::assertFalse(openssl_error_string());
+    }
+
+    public function testSerialisingAClientFailsLoudlyRatherThanSilentlyEmptying(): void
+    {
+        $keypair = Fixtures::load('keypair.json');
+        $key = $keypair['privateKeyPkcs8B64'];
+        self::assertIsString($key);
+
+        $client = new Client('https://example.test', 'obk_live_x', $key);
+
+        // Frozen on purpose: a queued Client would otherwise come back holding nothing, and the
+        // first request would fail somewhere far from the cause.
+        $this->expectException(\OpenBankingIO\OpenBankingException::class);
+
+        serialize($client);
+    }
+
+    public function testTheRedactingHooksThemselvesAreStillInPlace(): void
+    {
+        $keypair = Fixtures::load('keypair.json');
+        $key = $keypair['privateKeyPkcs8B64'];
+        self::assertIsString($key);
+
+        $client = new Client('https://example.test', 'obk_live_x', $key);
+        $secret = new \OpenBankingIO\Internal\Secret('obk_live_y');
+
+        // The WeakMap is what keeps the value unreachable, but these hooks are what a reader sees
+        // instead of nothing at all, so they should not quietly disappear.
+        self::assertSame('[redacted]', $client->__debugInfo()['apiKey']);
+        self::assertSame('[redacted]', $client->__debugInfo()['curlOptions']);
+        self::assertSame('[redacted]', $secret->__debugInfo()['value']);
+        self::assertSame('[redacted]', (string) $secret);
+    }
+
+    public function testTransportCredentialsDoNotSurviveAThrowingConstructor(): void
+    {
+        $options = ['curl_options' => [
+            CURLOPT_SSLCERTPASSWD => 'mtls-passphrase-distinctive',
+            CURLOPT_USERPWD => 'proxyuser:proxypass-distinctive',
+        ]];
+
+        // The WeakMap closes the property surface. A throwing constructor is a separate surface:
+        // the whole options array sits in the stack frame unless it is marked sensitive too.
+        foreach ([['https://example.test', 'k', 'not-a-key'], ['', 'k', 'k'], ['https://example.test', '', 'k']] as $args) {
+            try {
+                new Client($args[0], $args[1], $args[2], $options);
+                self::fail('expected the constructor to reject these arguments');
+            } catch (\Throwable $e) {
+                $trace = print_r($e->getTrace(), true);
+                self::assertStringNotContainsString('mtls-passphrase-distinctive', $trace);
+                self::assertStringNotContainsString('proxypass-distinctive', $trace);
+                self::assertStringNotContainsString('mtls-passphrase-distinctive', print_r($e, true));
+            }
+        }
+    }
+
+    public function testTransportCredentialsDoNotSurviveAThrowingFactory(): void
+    {
+        $options = ['curl_options' => [CURLOPT_SSLCERTPASSWD => 'factory-passphrase-distinctive']];
+
+        foreach (['{"not":"a bundle"}', 'not json at all', '{"apiKey":"k"}'] as $bundle) {
+            try {
+                Client::fromCredentials($bundle, $options);
+                self::fail('expected the bundle to be rejected');
+            } catch (\Throwable $e) {
+                self::assertStringNotContainsString('factory-passphrase-distinctive', print_r($e->getTrace(), true));
+                self::assertStringNotContainsString('factory-passphrase-distinctive', print_r($e, true));
+            }
+        }
+    }
+
+    public function testTheIntegerRangeCheckUsesTheRightCeilingForEachSign(): void
+    {
+        $requiredInt = new \ReflectionMethod(Client::class, 'requiredInt');
+
+        // The negative range reaches one further than the positive one, and a total is the only
+        // caller, so nothing else would ever exercise this boundary.
+        self::assertSame(PHP_INT_MIN, $requiredInt->invoke(null, (string) PHP_INT_MIN, 'total', '/p'));
+        self::assertSame(PHP_INT_MAX, $requiredInt->invoke(null, (string) PHP_INT_MAX, 'total', '/p'));
+
+        foreach (['-9223372036854775809', '9223372036854775808'] as $beyond) {
+            try {
+                $requiredInt->invoke(null, $beyond, 'total', '/p');
+                self::fail("{$beyond} should be out of range");
+            } catch (\ReflectionException | ApiException $e) {
+                self::assertStringContainsString('out of range', $e->getMessage());
+            }
+        }
+    }
+
+    public function testAClientRefusesToBeClonedRatherThanLosingItsTransportOptions(): void
+    {
+        $keypair = Fixtures::load('keypair.json');
+        $key = $keypair['privateKeyPkcs8B64'];
+        self::assertIsString($key);
+
+        $client = new Client('https://example.test', 'k', $key, ['curl_options' => [CURLOPT_USERAGENT => 'ua']]);
+
+        // A clone gets no WeakMap entry, so it would keep authenticating while silently dropping the
+        // proxy, CA bundle or client certificate.
+        $this->expectException(\OpenBankingIO\OpenBankingException::class);
+
+        $clone = clone $client;
+    }
+
+    private function derBase64(string $pem): string
+    {
+        $body = preg_replace('#-----[A-Z ]+-----#', '', $pem);
+
+        return str_replace(["\r", "\n"], '', (string) $body);
+    }
+}

--- a/php/tests/IntegrationTest.php
+++ b/php/tests/IntegrationTest.php
@@ -120,21 +120,61 @@ final class IntegrationTest extends TestCase
         $this->client('wrong-key')->getAccounts();
     }
 
-    public function testWrongPrivateKeyRaises(): void
+    public function testWrongPrivateKeySealsAccountsInsteadOfThrowing(): void
+    {
+        $accounts = $this->clientWithForeignKey()->getAccounts();
+
+        self::assertNotEmpty($accounts);
+        foreach ($accounts as $account) {
+            self::assertTrue($account->isSealed());
+            self::assertNull($account->iban);
+            self::assertNull($account->ownerName);
+
+            foreach ($account->balances as $balance) {
+                self::assertTrue($balance->isSealed());
+                self::assertNull($balance->amount);
+            }
+        }
+    }
+
+    public function testWrongPrivateKeyNeverReportsAZeroAmount(): void
+    {
+        $page = $this->clientWithForeignKey()->getTransactions(self::ACCOUNT_ID);
+
+        self::assertNotEmpty($page->items);
+        foreach ($page->items as $transaction) {
+            self::assertTrue($transaction->isSealed());
+            self::assertNull($transaction->amount);
+            self::assertNull($transaction->creditorName);
+            self::assertNull($transaction->remittanceInformation);
+        }
+    }
+
+    public function testSyncSaysTheSessionIsUnreadableRatherThanAbsent(): void
+    {
+        $this->expectException(\OpenBankingIO\OpenBankingException::class);
+        $this->expectExceptionMessage('session could not be decrypted');
+
+        $this->clientWithForeignKey()->sync(self::ACCOUNT_ID);
+    }
+
+    private function clientWithForeignKey(): Client
     {
         $other = openssl_pkey_new([
             'private_key_type' => OPENSSL_KEYTYPE_EC,
             'curve_name' => 'prime256v1',
         ]);
         self::assertNotFalse($other);
+
         $pem = '';
         openssl_pkey_export($other, $pem);
         self::assertIsString($pem);
-        $wrongB64 = preg_replace('/-----[^-]+-----|\s+/', '', $pem) ?? '';
 
-        $client = new Client($this->baseUrl, $this->credentials['apiKey'], $wrongB64);
-        $this->expectException(\OpenBankingIO\OpenBankingException::class);
-        $client->getAccounts();
+        return new Client(
+            $this->baseUrl,
+            $this->credentials['apiKey'],
+            preg_replace('/-----[^-]+-----|\s+/', '', $pem) ?? '',
+        );
     }
 
     // -- helpers ---------------------------------------------------------------

--- a/php/tests/ResponseShapeTest.php
+++ b/php/tests/ResponseShapeTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenBankingIO\Tests;
+
+use OpenBankingIO\ApiException;
+use OpenBankingIO\Client;
+use OpenBankingIO\Internal\EnvelopeResult;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A 200 whose body is not the agreed shape has to arrive as an ApiException. Callers catch that;
+ * a TypeError escaping from inside the client reaches their generic handler instead, where a
+ * rejected key looks the same as a network blip.
+ */
+final class ResponseShapeTest extends TestCase
+{
+    use MockServerTrait;
+    use SealsEnvelopes;
+
+    protected function tearDown(): void
+    {
+        $this->stopMockServer();
+    }
+
+    public function testABareScalarBodyIsAnApiException(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'scalar-body'];
+        $this->startMockServer();
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('returned int');
+
+        $this->client()->getAccounts();
+    }
+
+    public function testAnObjectWhereAListIsExpectedIsAnApiException(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'object-body'];
+        $this->startMockServer();
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('expected a list of objects');
+
+        $this->client()->getAccounts();
+    }
+
+    public function testASyncResponseWithoutItsCountersIsAnApiException(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'sync-no-counters'];
+        $this->startMockServer();
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('expected accounts');
+
+        $this->client()->syncAll();
+    }
+
+    public function testAFleetWithOneTornSessionSyncsTheRestAndNamesTheCasualty(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'mixed-fleet'];
+        $this->startMockServer();
+
+        $result = $this->client()->syncAll();
+
+        // The readable account still syncs; the torn one is named with its reason; the account
+        // with no session at all is simply not connected and does not appear.
+        self::assertFalse($result->isComplete());
+        self::assertSame(['22222222-2222-4222-8222-222222222222'], array_keys($result->unreadable));
+        self::assertNotSame('', $result->unreadable['22222222-2222-4222-8222-222222222222']);
+        self::assertSame(1, $result->accounts);
+    }
+
+    public function testAFleetWhereNoSessionCanBeReadThrowsRatherThanReportingSuccess(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'sealed-session'];
+        $this->startMockServer();
+
+        $this->expectException(\OpenBankingIO\OpenBankingException::class);
+        $this->expectExceptionMessage('nothing was synced');
+
+        $this->client()->syncAll();
+    }
+
+    public function testAnEnvelopeFieldThatIsNotAStringIsSealedNotAbsent(): void
+    {
+        $this->startMockServer();
+
+        $open = new \ReflectionMethod(Client::class, 'openEnvelope');
+
+        $absent = $open->invoke($this->client(), null);
+        $sealed = $open->invoke($this->client(), 12345);
+
+        self::assertInstanceOf(EnvelopeResult::class, $absent);
+        self::assertInstanceOf(EnvelopeResult::class, $sealed);
+        self::assertNull($absent->error, 'a missing envelope is not a failure');
+        self::assertNotNull($sealed->error, 'a malformed envelope field must not read as "no data"');
+    }
+
+    public function testAKeyedMapWhereAListIsExpectedIsAnApiException(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'keyed-body'];
+        $this->startMockServer();
+
+        // A keyed object satisfies is_array() and loops once over its single value, so without a
+        // list check the row validation runs against the wrong container.
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('expected a list of objects');
+
+        $this->client()->getAccounts();
+    }
+
+    public function testANonIntegerTotalIsAnApiExceptionRatherThanZero(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'bad-total'];
+        $this->startMockServer();
+
+        // Coercing it would report a finished, empty page and let the caller's window advance.
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('total is array');
+
+        $this->client()->getTransactions('11111111-1111-4111-8111-111111111111');
+    }
+
+    public function testASessionThatOpensWithoutAUidIsReportedTheSameWayAsAsealedOne(): void
+    {
+        $credentials = Fixtures::load('credentials.json');
+        self::assertIsArray($credentials['encryptionKey']);
+        $key = $credentials['encryptionKey']['privateKey'];
+        self::assertIsString($key);
+
+        $this->useRecipientKey($key);
+
+        // sync() throws for this account, so syncAll() must not quietly leave it out of the run.
+        $this->serverEnvOverrides = [
+            'OBK_ACCOUNTS_MODE' => 'uidless-session',
+            'OBK_UIDLESS_ENC' => $this->seal('{"notauid":"x"}'),
+        ];
+        $this->startMockServer();
+
+        $this->expectException(\OpenBankingIO\OpenBankingException::class);
+        $this->expectExceptionMessage('no usable uid');
+
+        $this->client()->syncAll();
+    }
+
+    public function testATotalPastTheIntegerRangeIsAnApiExceptionRatherThanSaturated(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'huge-total'];
+        $this->startMockServer();
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('out of range');
+
+        $this->client()->getTransactions('11111111-1111-4111-8111-111111111111');
+    }
+
+    public function testAListWhoseEntriesAreNotObjectsIsAnApiException(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'scalar-rows'];
+        $this->startMockServer();
+
+        // The top-level container is a list, so only the per-row check catches this.
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('expected a list of objects');
+
+        $this->client()->getAccounts();
+    }
+
+    public function testATransactionsPageMissingItemsOrTotalIsAnApiException(): void
+    {
+        foreach (['no-total', 'no-items'] as $mode) {
+            $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => $mode];
+            $this->startMockServer();
+
+            try {
+                $this->client()->getTransactions('11111111-1111-4111-8111-111111111111');
+                self::fail("{$mode} should not have produced a page");
+            } catch (ApiException $e) {
+                // Without the presence check this is an undefined-key warning and a TypeError,
+                // neither of which a caller catching ApiException sees.
+                self::assertStringContainsString('expected items and total', $e->getMessage());
+            } finally {
+                $this->stopMockServer();
+            }
+        }
+    }
+
+    public function testEveryUnreadableAccountIsListedEvenWhenIdsRepeatOrAreMissing(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'twin-sealed'];
+        $this->startMockServer();
+
+        try {
+            $this->client()->syncAll();
+            self::fail('nothing was readable, so this should have thrown');
+        } catch (\OpenBankingIO\OpenBankingException $e) {
+            // Keying purely by id would have collapsed four faults into two.
+            self::assertCount(4, array_unique(explode('; ', substr($e->getMessage(), (int) strpos($e->getMessage(), ': ') + 2))));
+            self::assertStringContainsString('(account with no id)', $e->getMessage());
+        }
+    }
+
+    public function testAnAccountSaysWhichOfItsEnvelopesFailed(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'sealed-display-name'];
+        $this->startMockServer();
+
+        $account = $this->client()->getAccounts()[0];
+
+        // Without the label a display-name failure is indistinguishable from the account's own
+        // fields being unreadable, which is what a caller would act on.
+        self::assertTrue($account->isSealed());
+        self::assertStringStartsWith('displayName: ', (string) $account->decryptError);
+    }
+
+    public function testASealReasonSaysWhatWentWrong(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'sealed-session'];
+        $this->startMockServer();
+
+        try {
+            $this->client()->syncAll();
+            self::fail('expected the sealed fleet to throw');
+        } catch (\OpenBankingIO\OpenBankingException $e) {
+            self::assertMatchesRegularExpression('/AES-256-GCM|ephemeral|envelope|base64/i', $e->getMessage());
+        }
+    }
+
+    public function testATotalWithATrailingNewlineIsNotQuietlyCoerced(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'newline-total'];
+        $this->startMockServer();
+
+        // PCRE's $ also matches before a final newline, so this needs the /D anchor.
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('expected an integer');
+
+        $this->client()->getTransactions('11111111-1111-4111-8111-111111111111');
+    }
+
+    public function testTheLargestTotalTheIntegerRangeHoldsIsAccepted(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'edge-total'];
+        $this->startMockServer();
+
+        // Exercises the equal-length comparison, which a length-only check would never reach.
+        self::assertSame(PHP_INT_MAX, $this->client()->getTransactions('11111111-1111-4111-8111-111111111111')->total);
+    }
+
+    public function testATotalOnePastTheIntegerRangeIsRejected(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'over-edge-total'];
+        $this->startMockServer();
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('out of range');
+
+        $this->client()->getTransactions('11111111-1111-4111-8111-111111111111');
+    }
+
+    private function client(): Client
+    {
+        return new Client(
+            $this->baseUrl,
+            $this->credentials['apiKey'],
+            $this->credentials['encryptionKey']['privateKey'],
+        );
+    }
+}

--- a/php/tests/SealsEnvelopes.php
+++ b/php/tests/SealsEnvelopes.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenBankingIO\Tests;
+
+/**
+ * Seals a payload the way the service does, so a test can build an envelope the client will open
+ * rather than asserting against a fixture that cannot be varied.
+ */
+trait SealsEnvelopes
+{
+    private string $recipientPublicPem = '';
+
+    protected function useRecipientKey(string $privateKeyPkcs8B64): void
+    {
+        $private = openssl_pkey_get_private(
+            "-----BEGIN PRIVATE KEY-----\n" // gitleaks:allow
+            . chunk_split($privateKeyPkcs8B64, 64, "\n")
+            . "-----END PRIVATE KEY-----\n",
+        );
+        self::assertNotFalse($private);
+
+        $details = openssl_pkey_get_details($private);
+        self::assertIsArray($details);
+        self::assertIsString($details['key']);
+
+        $this->recipientPublicPem = $details['key'];
+    }
+
+    protected function seal(string $plaintext): string
+    {
+        $ephemeral = openssl_pkey_new([
+            'private_key_type' => OPENSSL_KEYTYPE_EC,
+            'curve_name' => 'prime256v1',
+        ]);
+        self::assertNotFalse($ephemeral);
+
+        $recipient = openssl_pkey_get_public($this->recipientPublicPem);
+        self::assertNotFalse($recipient);
+
+        $shared = openssl_pkey_derive($recipient, $ephemeral);
+        self::assertIsString($shared);
+
+        $key = hash_hkdf('sha256', $shared, 32, 'bank.core.ci/zk/v1', str_repeat("\x00", 32));
+
+        $nonce = random_bytes(12);
+        $tag = '';
+        $ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $nonce, $tag, '', 16);
+        self::assertIsString($ciphertext);
+
+        $details = openssl_pkey_get_details($ephemeral);
+        self::assertIsArray($details);
+        self::assertIsArray($details['ec']);
+        self::assertIsString($details['ec']['x']);
+        self::assertIsString($details['ec']['y']);
+
+        $point = "\x04"
+            . str_pad($details['ec']['x'], 32, "\x00", STR_PAD_LEFT)
+            . str_pad($details['ec']['y'], 32, "\x00", STR_PAD_LEFT);
+
+        return base64_encode("\x01" . $point . $nonce . $tag . $ciphertext);
+    }
+}

--- a/php/tests/mock-server/router.php
+++ b/php/tests/mock-server/router.php
@@ -13,7 +13,22 @@ declare(strict_types=1);
  * OBK_ACCOUNTS_MODE switches payloads for negative-path tests:
  *   'sessionless'  -> the /api/accounts account drops its uidEnc (no active session),
  *   'error-status' -> GET /api/connections returns 503 with a JSON error body,
- *   'bad-json'     -> GET /api/connections returns 200 with an unparseable body.
+ *   'bad-json'     -> GET /api/connections returns 200 with an unparseable body,
+ *   'scalar-body'  -> GET /api/accounts returns 200 with a bare JSON scalar,
+ *   'object-body'  -> GET /api/accounts returns 200 with an object where a list is expected,
+ *   'keyed-body'   -> GET /api/accounts returns 200 with a keyed map of rows,
+ *   'scalar-rows'  -> GET /api/accounts returns a list whose entries are not objects,
+ *   'bad-total'    -> the transactions page returns a non-integer total,
+ *   'sealed-session' -> the /api/accounts account carries a uidEnc nobody can decrypt,
+ *   'mixed-fleet'  -> one account readable, one sealed, one with no session at all,
+ *   'uidless-session' -> the account's session envelope opens but carries no uid,
+ *   'huge-total'   -> the transactions page returns a total past PHP_INT_MAX,
+ *   'no-total'     -> the transactions page omits total, 'no-items' omits items,
+ *   'newline-total' -> total is a digit string with a trailing newline,
+ *   'edge-total'    -> total is exactly PHP_INT_MAX, 'over-edge-total' is one past it,
+ *   'twin-sealed'  -> two accounts share an id and both have unreadable sessions,
+ *   'sealed-display-name' -> only the account's displayNameEnc is unreadable,
+ *   'sync-no-counters' -> POST /api/sync returns 200 without its counters.
  */
 
 $fixtures = getenv('OBK_FIXTURES') ?: '';
@@ -77,7 +92,101 @@ if ($method === 'GET' && $path === '/api/accounts') {
         $existing['userAgent'] = is_string($_SERVER['HTTP_USER_AGENT'] ?? null)
             ? $_SERVER['HTTP_USER_AGENT']
             : '';
+        $existing['apiKeyHeader'] = is_string($_SERVER['HTTP_X_API_KEY'] ?? null)
+            ? $_SERVER['HTTP_X_API_KEY']
+            : '';
+        $existing['callerHeader'] = is_string($_SERVER['HTTP_X_CALLER_TAG'] ?? null)
+            ? $_SERVER['HTTP_X_CALLER_TAG']
+            : '';
         file_put_contents($captureFile, json_encode($existing));
+    }
+    if ($accountsMode === 'scalar-body') {
+        echo '42';
+        return true;
+    }
+    if ($accountsMode === 'object-body') {
+        echo json_encode(['error' => 'rate limited']);
+        return true;
+    }
+    if ($accountsMode === 'scalar-rows') {
+        echo json_encode(['11111111-1111-4111-8111-111111111111', 'another']);
+        return true;
+    }
+    if ($accountsMode === 'keyed-body') {
+        echo json_encode(['unexpected' => ['id' => '11111111-1111-4111-8111-111111111111']]);
+        return true;
+    }
+    if ($accountsMode === 'uidless-session') {
+        $raw = file_get_contents($fixtures . '/api/accounts.json');
+        $decoded = $raw === false ? [] : json_decode($raw, true);
+        $accounts = is_array($decoded) ? $decoded : [];
+        $uidless = getenv('OBK_UIDLESS_ENC') ?: '';
+        foreach ($accounts as &$acct) {
+            if (is_array($acct)) {
+                $acct['uidEnc'] = $uidless;
+            }
+        }
+        unset($acct);
+        echo json_encode($accounts);
+        return true;
+    }
+    if ($accountsMode === 'sealed-display-name') {
+        $raw = file_get_contents($fixtures . '/api/accounts.json');
+        $decoded = $raw === false ? [] : json_decode($raw, true);
+        $accounts = is_array($decoded) ? $decoded : [];
+        foreach ($accounts as &$acct) {
+            if (is_array($acct)) {
+                $acct['displayNameEnc'] = base64_encode("\x01" . str_repeat("\x00", 92) . 'nonsense');
+            }
+        }
+        unset($acct);
+        echo json_encode($accounts);
+        return true;
+    }
+    if ($accountsMode === 'twin-sealed') {
+        $raw = file_get_contents($fixtures . '/api/accounts.json');
+        $decoded = $raw === false ? [] : json_decode($raw, true);
+        $accounts = is_array($decoded) ? $decoded : [];
+        $first = $accounts[0] ?? [];
+        $row = is_array($first) ? $first : [];
+        $row['uidEnc'] = base64_encode("\x01" . str_repeat("\x00", 92) . 'nonsense');
+
+        $twin = $row;
+        unset($twin['id']);
+
+        echo json_encode([$row, $row, $twin, $twin]);
+        return true;
+    }
+    if ($accountsMode === 'mixed-fleet') {
+        $raw = file_get_contents($fixtures . '/api/accounts.json');
+        $decoded = $raw === false ? [] : json_decode($raw, true);
+        $accounts = is_array($decoded) ? $decoded : [];
+        $first = $accounts[0] ?? [];
+        $readable = is_array($first) ? $first : [];
+
+        $torn = $readable;
+        $torn['id'] = '22222222-2222-4222-8222-222222222222';
+        $torn['uidEnc'] = base64_encode("\x01" . str_repeat("\x00", 92) . 'nonsense');
+
+        $unconnected = $readable;
+        $unconnected['id'] = '33333333-3333-4333-8333-333333333333';
+        unset($unconnected['uidEnc']);
+
+        echo json_encode([$readable, $torn, $unconnected]);
+        return true;
+    }
+    if ($accountsMode === 'sealed-session') {
+        $raw = file_get_contents($fixtures . '/api/accounts.json');
+        $decoded = $raw === false ? [] : json_decode($raw, true);
+        $accounts = is_array($decoded) ? $decoded : [];
+        foreach ($accounts as &$acct) {
+            if (is_array($acct)) {
+                $acct['uidEnc'] = base64_encode("\x01" . str_repeat("\x00", 92) . 'nonsense');
+            }
+        }
+        unset($acct);
+        echo json_encode($accounts);
+        return true;
     }
     if ($accountsMode === 'sessionless') {
         $raw = file_get_contents($fixtures . '/api/accounts.json');
@@ -97,6 +206,34 @@ if ($method === 'GET' && $path === '/api/accounts') {
 }
 
 if ($method === 'GET' && $path === "/api/accounts/{$accountId}/transactions") {
+    if ($accountsMode === 'bad-total') {
+        echo json_encode(['items' => [], 'total' => []]);
+        return true;
+    }
+    if ($accountsMode === 'no-total') {
+        echo json_encode(['items' => []]);
+        return true;
+    }
+    if ($accountsMode === 'no-items') {
+        echo json_encode(['total' => 0]);
+        return true;
+    }
+    if ($accountsMode === 'newline-total') {
+        echo '{"items":[],"total":"5\\n"}';
+        return true;
+    }
+    if ($accountsMode === 'edge-total') {
+        echo '{"items":[],"total":"9223372036854775807"}';
+        return true;
+    }
+    if ($accountsMode === 'over-edge-total') {
+        echo '{"items":[],"total":"9223372036854775808"}';
+        return true;
+    }
+    if ($accountsMode === 'huge-total') {
+        echo '{"items":[],"total":"99999999999999999999999999"}';
+        return true;
+    }
     $serve('transactions.json');
     return true;
 }
@@ -122,6 +259,10 @@ if ($method === 'POST' && $path === "/api/accounts/{$accountId}/sync") {
 }
 
 if ($method === 'POST' && $path === '/api/sync') {
+    if ($accountsMode === 'sync-no-counters') {
+        echo json_encode(['ok' => true]);
+        return true;
+    }
     $capture('syncAll');
     $serve('sync-all.json');
     return true;

--- a/python/README.md
+++ b/python/README.md
@@ -26,7 +26,9 @@ with OpenBankingClient.from_credentials("credentials.json") as client:
 
         page = client.get_transactions(account.id, limit=50)
         for t in page.items:
-            print(f"  {t.booking_date}  {t.creditor_name or t.debtor_name}  {t.amount} {t.currency}")
+            print(
+                f"  {t.booking_date}  {t.creditor_name or t.debtor_name}  {t.amount} {t.currency}"
+            )
 
     # Trigger an online sync (decrypts the account uid locally and posts it):
     client.sync(account.id)


### PR DESCRIPTION
## The bug

A sealed envelope was indistinguishable from a genuine zero. `decryptEnc()` swallowed the failure into an empty array and `decimalString()` coerced the missing amount to `'0'`:

```php
private function decryptEnc($enc): array
{
    return $this->envelope->decryptToArray(is_string($enc) ? $enc : null) ?? [];
}

amount: self::decimalString($d['amount'] ?? null),   // null -> '0'
```

For an importer this is the worst possible failure mode. Invoice Ninja, for example, routes any transaction whose direction is not literally `DEBIT` into invoice matching, which creates a `Payment` against a live invoice — so a batch of undecryptable rows books zero-value receipts and marks invoices paid, silently, on HTTP 200.

Separately, `Envelope::decrypt()` threw on any version byte other than `0x01`, and nothing caught it. A single v2 balance envelope on one account took down the entire `getAccounts()` call.

## The fix

`EnvelopeResult` distinguishes the three cases the old code collapsed into one: opened, absent, and sealed. Amounts are nullable, and every envelope-backed model carries the failure reason:

```php
$transaction->amount;        // null when the envelope could not be read
$transaction->isSealed();    // true, with $transaction->decryptError explaining why
```

A caller can now skip the row instead of booking nothing. An unsupported version fails that envelope alone and the exception names the version it found, rather than aborting the batch behind a generic message.

## Verification

Against the live service, not fixtures:

| | before | after |
|---|---|---|
| staging | `getAccounts()` threw `EnvelopeException` | 6 accounts, 414 transactions; the 4 v2 balances and 8 v2 transactions come back sealed, the other 406 decrypt to real amounts |
| production | — | 13 accounts, 33 balances, 1089 transactions; none sealed, none zero |

`vendor/bin/phpunit` 44 passing, PHPStan and php-cs-fixer clean.

The wrong-key test changed shape deliberately: it used to assert an exception escaped `getAccounts()`. It now asserts the safer contract — every field sealed, every amount `null`, never `'0'`.

## Breaking

`Transaction::$amount` and `Balance::$amount` are now `?string`. Callers reading them as `string` need a null check, which is the point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer reporting for unreadable or sealed accounts, balances, and transactions.
  * Added sync completeness tracking, including details about sessions that could not be read.
  * Upgraded the PHP package to version 1.0.0 and PHP 8.2+.

* **Bug Fixes**
  * Improved validation for malformed API responses and encrypted data.
  * Prevented sensitive credentials from appearing in debugging or error output.
  * Refined handling of partial synchronization results.

* **Documentation**
  * Expanded guidance for sealed data, exact monetary values, and release versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->