### PR TITLE
fix: add package-registry metadata (NuGet PackageProjectUrl + npm homepage)

### DIFF
--- a/dotnet/src/OpenBankingIO.Client/OpenBankingIO.Client.csproj
+++ b/dotnet/src/OpenBankingIO.Client/OpenBankingIO.Client.csproj
@@ -23,6 +23,8 @@
     <PackageTags>open-banking;psd2;zero-knowledge;encryption;fintech</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/open-banking-io/clients</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://open-banking.io</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/node/package.json
+++ b/node/package.json
@@ -54,5 +54,6 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1",
     "vitest": "^4.1.9"
-  }
+  },
+  "homepage": "https://open-banking.io"
 }


### PR DESCRIPTION
## What

Fixes empty package-registry metadata that prevents SEO backlinks from the .NET and Node.js ecosystems.

### NuGet (`OpenBankingIO.Client` v0.3.0)
- **Added** `<PackageProjectUrl>https://open-banking.io</PackageProjectUrl>` — the "Project website" link on nuget.org (currently empty).
- **Added** `<RepositoryType>git</RepositoryType>` — NuGet best practice to pair with `<RepositoryUrl>`.

### npm (`@open-banking-io/client` v0.3.0)
- **Added** `"homepage": "https://open-banking.io"` to `package.json` — the npm registry homepage link (currently absent; npm falls back to the GitHub readme).

## Why
Both package registries are high-DA do-follow backlink sources. Without `PackageProjectUrl` / `homepage`, the nuget.org and npmjs.com listing pages link only to GitHub, not to open-banking.io. Adding these fields creates free organic backlinks from two major developer ecosystems.

## After merge
- Publish NuGet 0.3.1: `dotnet pack` + `dotnet nuget push`
- Publish npm 0.3.1: `npm version patch && npm publish`

Related tasks: #255, #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project homepage and source repository information to package metadata.
  * Improved discoverability of project resources across .NET and Node.js packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->