### PR TITLE
release: bump dotnet + node to 0.3.1 (publish metadata fix)

### DIFF
--- a/dotnet/src/OpenBankingIO.Client/OpenBankingIO.Client.csproj
+++ b/dotnet/src/OpenBankingIO.Client/OpenBankingIO.Client.csproj
@@ -17,7 +17,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
     <PackageId>OpenBankingIO.Client</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <Authors>open-banking.io</Authors>
     <Description>Server-to-server client for open-banking.io: API-key auth + client-side decryption of the zero-knowledge data envelopes with your exported private key.</Description>
     <PackageTags>open-banking;psd2;zero-knowledge;encryption;fintech</PackageTags>

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-banking-io/client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-banking-io/client",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-banking-io/client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Server-to-server client for open-banking.io: API-key auth + client-side decryption of the zero-knowledge data envelopes with your exported private key.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Bumps OpenBankingIO.Client (.csproj) and @open-banking-io/client (package.json + lockfile) from 0.3.0 to 0.3.1.

This publishes the package-registry metadata fix from #153 so that the PackageProjectUrl (NuGet) and homepage (npm) pointing at https://open-banking.io land on a published version — creating the do-follow backlinks from nuget.org and npmjs.com.

Changes are version-only (4 lines): no logic touched.

After merge: tag dotnet/v0.3.1 and node/v0.3.1 to trigger publish-dotnet.yml / publish-node.yml via CI.

Ref: tasks 255, 256.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the .NET client package version to 0.3.1.
  * Updated the Node.js package version to 0.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->