### PR TITLE
feat(cli): pick pin-code or GitHub at login, and wait long enough for the email

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -55,13 +55,19 @@ from the bank **without ever holding the uid in plaintext**. Sessions are time-l
 ## CLI onboarding (browser-relay)
 
 `openbanking login` sets the CLI up in one step without the private key ever reaching the server. The CLI
-starts a localhost loopback and opens the browser to the app's authorize page; you sign in and enter your
-passphrase **in the browser**, which unlocks the locally-held private key and POSTs the full credentials
-**directly to `http://127.0.0.1:<port>`** — browser → localhost only. The server never sees the private key
-(not even encrypted) or the passphrase. The relay is bound by three things: the random loopback port, the
-PKCE `verifier` (held only by the CLI, required to redeem the one-time code for the API key), and a `state`
-nonce echoed by the authenticated browser. CORS on the loopback is scoped to the app origin. The CLI writes
-`credentials.json` at `0600` and never logs the key or passphrase.
+starts a localhost loopback and opens the browser to the app's authorize page; you sign in — with an emailed
+6-digit code or GitHub — and enter your passphrase **in the browser**, which unlocks the locally-held private
+key and POSTs the full credentials **directly to `http://127.0.0.1:<port>`** — browser → localhost only. The
+server never sees the private key (not even encrypted) or the passphrase. The relay is bound by three things:
+the random loopback port, the PKCE `verifier` (held only by the CLI, required to redeem the one-time code for
+the API key), and a `state` nonce echoed by the authenticated browser. CORS on the loopback is scoped to the
+app origin. The CLI writes `credentials.json` at `0600` and never logs the key or passphrase.
+
+The one-time code is minted against **the browser session's tenant** — the authenticated `email` claim, never
+anything in the request — so the API key the CLI receives and the encryption key the browser relays always
+belong to the same account. An existing session mints without a further sign-in, so the authorize page names
+the account and offers a sign-out before anything is handed over. What crosses to the loopback is a
+full-tenant API key, revocable in Settings; the code itself is single-use and expires in five minutes.
 
 ## Assumptions & limitations
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -124,5 +124,7 @@ signed in to the web app? The browser skips the sign-in entirely — the CLI is
 authorized for that account, which the authorize page names before you confirm.
 
 Because signing in can mean waiting on an email, `login` waits **10 minutes** for the
-browser by default; `login --timeout 2m` shortens it. Note this is the login command's
-own flag — the global `--timeout` is the per-request HTTP timeout, a different thing.
+browser by default; `login --wait 2m` shortens it. It is deliberately not called
+`--timeout`: that name is a *global* flag (the per-request HTTP timeout) and is stripped
+from the arguments before any subcommand sees it, so `login --timeout 2m` would re-time
+every HTTP request while leaving the browser wait untouched.

--- a/cli/README.md
+++ b/cli/README.md
@@ -35,6 +35,7 @@ go install github.com/open-banking-io/clients/cli@latest
 
 ```sh
 openbanking login                       # sign in + unlock in the browser — sets up everything
+openbanking login --method github       # skip the picker (or --method pin for an emailed code)
 openbanking key import ./credentials.json   # (fallback) import a key file on a headless machine
 openbanking accounts                    # list accounts with balances        (alias: acc, ls)
 openbanking use                         # pick a current account (arrow keys) — or: use <account-id>
@@ -116,3 +117,12 @@ travels browser → localhost only — it never touches the server, not even enc
 (the server is zero-knowledge and only ever holds your public key). `key import`
 remains as a manual fallback for headless machines without a browser. Money amounts
 are kept as exact decimal strings; debits render negative at display time.
+
+Either sign-in method works: a 6-digit code emailed to you, or GitHub. By default the
+browser asks which; `--method pin` or `--method github` goes straight there. Already
+signed in to the web app? The browser skips the sign-in entirely — the CLI is
+authorized for that account, which the authorize page names before you confirm.
+
+Because signing in can mean waiting on an email, `login` waits **10 minutes** for the
+browser by default; `login --timeout 2m` shortens it. Note this is the login command's
+own flag — the global `--timeout` is the per-request HTTP timeout, a different thing.

--- a/cli/internal/app/login.go
+++ b/cli/internal/app/login.go
@@ -65,17 +65,22 @@ var openBrowser = func(target string) error {
 // number, and it is otherwise unreachable from a test without running a whole login.
 type loginFlags struct {
 	apiBaseURL *string
-	timeout    *time.Duration
+	wait       *time.Duration
 	method     *string
 }
 
 func registerLoginFlags(fs *flag.FlagSet) loginFlags {
 	return loginFlags{
 		apiBaseURL: fs.String("api", defaultAPIBaseURL, "API base URL to log in to"),
+		// NOT --timeout: main.parseTimeout strips that one out of the argument list wherever it
+		// appears, subcommand or not, and spends it on the HTTP client. A --timeout here would never
+		// reach this FlagSet, so `login --timeout 2m` would silently keep the default wait and
+		// re-time every HTTP request instead. --wait is a name the global parser doesn't eat.
+		//
 		// Sized for the emailed-code path: delivery, then finding the mail, then typing six digits.
 		// GitHub used to be the only option and took seconds, which is what the old 3 minutes fit.
-		timeout: fs.Duration("timeout", 10*time.Minute, "how long to wait for the browser login"),
-		method:  fs.String("method", "", "sign-in method to go straight to: pin or github (default: pick in the browser)"),
+		wait:   fs.Duration("wait", 10*time.Minute, "how long to wait for the browser sign-in to finish"),
+		method: fs.String("method", "", "sign-in method to go straight to: pin or github (default: pick in the browser)"),
 	}
 }
 
@@ -86,7 +91,7 @@ func (a *App) login(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	apiBaseURL, timeout := flags.apiBaseURL, flags.timeout
+	apiBaseURL, wait := *flags.apiBaseURL, *flags.wait
 
 	// The server treats an unrecognised method as absent — it is a UX hint, not a security control —
 	// so a typo would quietly give the default rather than failing. Catch it here, before a browser
@@ -96,7 +101,7 @@ func (a *App) login(args []string) error {
 		return fmt.Errorf("unknown --method %q (use pin or github, or omit it to pick in the browser)", method)
 	}
 
-	base := trimTrailingSlash(*apiBaseURL)
+	base := trimTrailingSlash(apiBaseURL)
 
 	// PKCE binds this login to this process: the verifier never leaves the CLI; only its hash
 	// (the challenge) goes to the server, and only the verifier can later redeem the code.
@@ -130,20 +135,28 @@ func (a *App) login(args []string) error {
 		fmt.Fprintf(a.Stderr, "(could not open a browser automatically: %v)\n", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
-	defer cancel()
+	waitCtx, cancelWait := context.WithTimeout(context.Background(), wait)
+	defer cancelWait()
 
 	stopSpinner := a.ui().Spinner("Waiting for you to finish signing in…")
 	var result callbackResult
 	select {
 	case result = <-resultCh:
-	case <-ctx.Done():
+	case <-waitCtx.Done():
 		stopSpinner()
-		return fmt.Errorf("timed out waiting for the browser login after %s", *timeout)
+		return fmt.Errorf("timed out waiting for the browser login after %s", wait)
 	}
 	stopSpinner()
 
-	token, err := a.exchangeToken(ctx, base, result.code, verifier)
+	// The exchange gets its OWN budget rather than whatever is left of the wait. Sharing one context
+	// was survivable at a 3-minute wait that a GitHub round-trip finished in seconds; at 10 minutes
+	// the wait is DESIGNED to be mostly consumed (email delivery, then typing), so a slow-but-
+	// successful sign-in would hand the exchange a near-zero deadline and fail at the worst possible
+	// moment — after the user has already finished in the browser.
+	exchangeCtx, cancelExchange := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancelExchange()
+
+	token, err := a.exchangeToken(exchangeCtx, base, result.code, verifier)
 	if err != nil {
 		return err
 	}
@@ -219,8 +232,8 @@ func (a *App) exchangeToken(ctx context.Context, apiBaseURL, code, verifier stri
 }
 
 // callbackHandler serves the loopback /callback. The browser authorize page POSTs {code,state,
-// encryptionKey} after unlocking the key (CORS-scoped to the app origin); the legacy GET ?code= path
-// remains as a key-less fallback.
+// encryptionKey} after unlocking the key (CORS-scoped to the app origin); the legacy GET path
+// remains as a key-less fallback. Both require the state nonce.
 func callbackHandler(resultCh chan<- callbackResult, state, allowOrigin string) http.Handler {
 	deliver := func(res callbackResult) {
 		select {
@@ -238,9 +251,19 @@ func callbackHandler(resultCh chan<- callbackResult, state, allowOrigin string) 
 			w.Header().Set("Access-Control-Allow-Headers", "content-type")
 			w.WriteHeader(http.StatusNoContent)
 		case http.MethodGet:
-			code := r.URL.Query().Get("code")
+			// Same state check as the POST path. This used to accept a bare ?code=, which meant any
+			// local process — or any page doing <img src="http://127.0.0.1:<port>/callback?code=x">,
+			// which needs no CORS preflight — could feed this listener a junk code by scanning ports.
+			// It could never mint one that satisfies our PKCE challenge, so the damage is a wasted
+			// login rather than a stolen key; but the listener now stays open for ten minutes instead
+			// of three, and THREAT_MODEL already claims the state nonce binds this relay.
+			code, gotState := r.URL.Query().Get("code"), r.URL.Query().Get("state")
 			if code == "" {
 				http.Error(w, "missing code", http.StatusBadRequest)
+				return
+			}
+			if subtle.ConstantTimeCompare([]byte(gotState), []byte(state)) != 1 {
+				http.Error(w, "state mismatch", http.StatusForbidden)
 				return
 			}
 			writeDoneHTML(w)

--- a/cli/internal/app/login.go
+++ b/cli/internal/app/login.go
@@ -60,14 +60,42 @@ var openBrowser = func(target string) error {
 	}
 }
 
+// loginFlags are the values `login` binds. Registration is split out of login() so the defaults can
+// be asserted on their own — the browser wait in particular is a real UX budget, not an arbitrary
+// number, and it is otherwise unreachable from a test without running a whole login.
+type loginFlags struct {
+	apiBaseURL *string
+	timeout    *time.Duration
+	method     *string
+}
+
+func registerLoginFlags(fs *flag.FlagSet) loginFlags {
+	return loginFlags{
+		apiBaseURL: fs.String("api", defaultAPIBaseURL, "API base URL to log in to"),
+		// Sized for the emailed-code path: delivery, then finding the mail, then typing six digits.
+		// GitHub used to be the only option and took seconds, which is what the old 3 minutes fit.
+		timeout: fs.Duration("timeout", 10*time.Minute, "how long to wait for the browser login"),
+		method:  fs.String("method", "", "sign-in method to go straight to: pin or github (default: pick in the browser)"),
+	}
+}
+
 func (a *App) login(args []string) error {
 	fs := flag.NewFlagSet("login", flag.ContinueOnError)
 	fs.SetOutput(a.Stderr)
-	apiBaseURL := fs.String("api", defaultAPIBaseURL, "API base URL to log in to")
-	timeout := fs.Duration("timeout", 3*time.Minute, "how long to wait for the browser login")
+	flags := registerLoginFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	apiBaseURL, timeout := flags.apiBaseURL, flags.timeout
+
+	// The server treats an unrecognised method as absent — it is a UX hint, not a security control —
+	// so a typo would quietly give the default rather than failing. Catch it here, before a browser
+	// opens and a listener is left waiting on a login that isn't the one that was asked for.
+	method := *flags.method
+	if method != "" && method != "pin" && method != "github" {
+		return fmt.Errorf("unknown --method %q (use pin or github, or omit it to pick in the browser)", method)
+	}
+
 	base := trimTrailingSlash(*apiBaseURL)
 
 	// PKCE binds this login to this process: the verifier never leaves the CLI; only its hash
@@ -92,6 +120,11 @@ func (a *App) login(args []string) error {
 
 	startURL := fmt.Sprintf("%s/auth/cli/start?port=%d&code_challenge=%s&state=%s",
 		base, port, url.QueryEscape(challenge), url.QueryEscape(state))
+	// Omitted unless asked for: with no method the server sends you to the login page, which offers
+	// the emailed code and GitHub side by side. Older servers ignore the parameter outright.
+	if method != "" {
+		startURL += "&method=" + url.QueryEscape(method)
+	}
 	fmt.Fprintf(a.Stderr, "Opening your browser to sign in...\nIf it doesn't open, visit:\n  %s\n\n", startURL)
 	if err := openBrowser(startURL); err != nil {
 		fmt.Fprintf(a.Stderr, "(could not open a browser automatically: %v)\n", err)

--- a/cli/internal/app/login_test.go
+++ b/cli/internal/app/login_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"flag"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -227,5 +229,94 @@ func TestLoginRelaysEncryptionKeyFromBrowser(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "encryption key set up") {
 		t.Errorf("expected the one-step success message, got: %q", out.String())
+	}
+}
+
+// captureStartURL runs `login` with args, stubbing the browser so it records the URL the CLI would
+// open and then lets the flow lapse. Returns that URL's query. The login error is discarded: with
+// nothing answering the loopback it always times out, and only the request matters here.
+func captureStartURL(t *testing.T, args ...string) url.Values {
+	t.Helper()
+	var got string
+	prev := openBrowser
+	openBrowser = func(target string) error { got = target; return nil }
+	defer func() { openBrowser = prev }()
+
+	var out, errOut bytes.Buffer
+	app := &App{
+		Stdout:     &out,
+		Stderr:     &errOut,
+		ConfigPath: filepath.Join(t.TempDir(), "credentials.json"),
+	}
+	_ = app.login(append([]string{"--api", "https://example.invalid", "--timeout", "1ms"}, args...))
+
+	if got == "" {
+		t.Fatal("no start URL was opened")
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse start URL %q: %v", got, err)
+	}
+	return u.Query()
+}
+
+// An absent `method` means "let the login page offer both". Released binaries send nothing at all,
+// so the default must stay exactly that — and the rest of the URL contract must not drift either.
+func TestLoginOmitsMethodByDefault(t *testing.T) {
+	q := captureStartURL(t)
+
+	if q.Has("method") {
+		t.Errorf("method should be absent by default, got %q", q.Get("method"))
+	}
+	for _, key := range []string{"port", "code_challenge", "state"} {
+		if q.Get(key) == "" {
+			t.Errorf("start URL is missing %s: %v", key, q)
+		}
+	}
+}
+
+func TestLoginThreadsMethodIntoTheStartURL(t *testing.T) {
+	for _, method := range []string{"pin", "github"} {
+		t.Run(method, func(t *testing.T) {
+			if got := captureStartURL(t, "--method", method).Get("method"); got != method {
+				t.Errorf("method = %q, want %q", got, method)
+			}
+		})
+	}
+}
+
+// The server silently drops an unrecognised method — it is a UX hint, not a security control — so a
+// typo would otherwise appear to work while quietly giving the default. Fail here instead, before
+// a browser is opened and before a listener is left waiting.
+func TestLoginRejectsUnknownMethodBeforeOpeningABrowser(t *testing.T) {
+	opened := false
+	prev := openBrowser
+	openBrowser = func(string) error { opened = true; return nil }
+	defer func() { openBrowser = prev }()
+
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: filepath.Join(t.TempDir(), "credentials.json")}
+	err := app.login([]string{"--api", "https://example.invalid", "--method", "banana"})
+
+	if err == nil {
+		t.Fatal("expected an error for an unknown --method")
+	}
+	if !strings.Contains(err.Error(), "banana") {
+		t.Errorf("the error should name the bad value, got: %v", err)
+	}
+	if opened {
+		t.Error("no browser should be opened for an invalid --method")
+	}
+}
+
+// Signing in now routinely means waiting on an emailed 6-digit code — delivery, finding it, typing
+// it. The old 3-minute budget was sized for a GitHub round-trip that took seconds.
+func TestLoginBrowserWaitDefaultsToTenMinutes(t *testing.T) {
+	fs := flag.NewFlagSet("login", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	registerLoginFlags(fs)
+
+	if got := fs.Lookup("timeout").DefValue; got != "10m0s" {
+		t.Errorf("default browser wait = %s, want 10m0s", got)
 	}
 }

--- a/cli/internal/app/login_test.go
+++ b/cli/internal/app/login_test.go
@@ -130,8 +130,12 @@ func TestLoginPreservesEncryptionKey(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/auth/cli/start":
-			port := r.URL.Query().Get("port")
-			http.Redirect(w, r, "http://127.0.0.1:"+port+"/callback?code=test-code", http.StatusFound)
+			// Echo state back on the redirect, as the real flow does — the loopback requires it on
+			// the GET fallback too, not just the POST relay.
+			port, state := r.URL.Query().Get("port"), r.URL.Query().Get("state")
+			http.Redirect(w, r,
+				"http://127.0.0.1:"+port+"/callback?code=test-code&state="+url.QueryEscape(state),
+				http.StatusFound)
 		case "/auth/cli/token":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"apiKey":"ebk_minted","apiBaseUrl":"` + "" + `","user":"me@example.com","prefix":"ebk_minted12"}`))
@@ -151,7 +155,7 @@ func TestLoginPreservesEncryptionKey(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfgPath, HTTPClient: srv.Client()}
-	if err := app.login([]string{"--api", srv.URL, "--timeout", "10s"}); err != nil {
+	if err := app.login([]string{"--api", srv.URL, "--wait", "10s"}); err != nil {
 		t.Fatalf("login: %v\nstderr: %s", err, errOut.String())
 	}
 
@@ -210,7 +214,7 @@ func TestLoginRelaysEncryptionKeyFromBrowser(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfgPath, HTTPClient: srv.Client()}
-	if err := app.login([]string{"--api", srv.URL, "--timeout", "10s"}); err != nil {
+	if err := app.login([]string{"--api", srv.URL, "--wait", "10s"}); err != nil {
 		t.Fatalf("login: %v\nstderr: %s", err, errOut.String())
 	}
 
@@ -248,7 +252,7 @@ func captureStartURL(t *testing.T, args ...string) url.Values {
 		Stderr:     &errOut,
 		ConfigPath: filepath.Join(t.TempDir(), "credentials.json"),
 	}
-	_ = app.login(append([]string{"--api", "https://example.invalid", "--timeout", "1ms"}, args...))
+	_ = app.login(append([]string{"--api", "https://example.invalid", "--wait", "1ms"}, args...))
 
 	if got == "" {
 		t.Fatal("no start URL was opened")
@@ -272,6 +276,57 @@ func TestLoginOmitsMethodByDefault(t *testing.T) {
 		if q.Get(key) == "" {
 			t.Errorf("start URL is missing %s: %v", key, q)
 		}
+	}
+	// Exactly those three and nothing else — "backwards compatible" means the URL a released binary
+	// produces, not merely one that happens to contain the right keys.
+	if len(q) != 3 {
+		t.Errorf("unexpected extra query parameters: %v", q)
+	}
+}
+
+// The loopback is reachable by anything on this machine, and a cross-site <img src="…/callback?code=x">
+// needs no CORS preflight — so a bare code must not be accepted. It could never satisfy our PKCE
+// challenge, but it would burn the login, and the listener now stays open ten minutes rather than three.
+func TestCallbackGetRequiresTheStateNonce(t *testing.T) {
+	resultCh := make(chan callbackResult, 1)
+	srv := httptest.NewServer(callbackHandler(resultCh, "the-state", "https://example.invalid"))
+	defer srv.Close()
+
+	res, err := srv.Client().Get(srv.URL + "/callback?code=injected")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for a missing state", res.StatusCode)
+	}
+
+	res2, err := srv.Client().Get(srv.URL + "/callback?code=injected&state=wrong")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer res2.Body.Close()
+	if res2.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for a wrong state", res2.StatusCode)
+	}
+
+	select {
+	case got := <-resultCh:
+		t.Fatalf("a code with no valid state was delivered to login(): %+v", got)
+	default:
+	}
+
+	// The genuine redirect still works.
+	res3, err := srv.Client().Get(srv.URL + "/callback?code=real&state=the-state")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer res3.Body.Close()
+	if res3.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 for the matching state", res3.StatusCode)
+	}
+	if got := <-resultCh; got.code != "real" {
+		t.Errorf("code = %q, want real", got.code)
 	}
 }
 
@@ -316,7 +371,13 @@ func TestLoginBrowserWaitDefaultsToTenMinutes(t *testing.T) {
 	fs.SetOutput(io.Discard)
 	registerLoginFlags(fs)
 
-	if got := fs.Lookup("timeout").DefValue; got != "10m0s" {
+	if got := fs.Lookup("wait").DefValue; got != "10m0s" {
 		t.Errorf("default browser wait = %s, want 10m0s", got)
+	}
+	// NOT "timeout": main.parseTimeout strips that name out of the arguments wherever it appears,
+	// subcommand or not, and spends it on the HTTP client — so a flag called "timeout" here could
+	// never be set by a real invocation. Naming it that again would silently break `login --timeout`.
+	if fs.Lookup("timeout") != nil {
+		t.Error("login must not bind --timeout; the global parser consumes it before dispatch")
 	}
 }


### PR DESCRIPTION
`openbanking login` could only ever authenticate one way. The API challenged GitHub unconditionally on `/auth/cli/start`, so anyone who onboarded with an emailed code — which is the primary sign-in method on the web — simply could not log the CLI in.

The server side is fixed separately (softwarehuset/bank, `feat/cli-login-methods`): `/auth/cli/start` is now session-aware and defers anonymous users to the login page, which has offered both methods all along. **That needs to be deployed before this merges** — `--method` is inert against the current production API, though harmlessly so, since an unknown query parameter is ignored.

This side adds the flag: `--method pin` or `--method github` goes straight to one, and omitting it — what every already-released binary does — lets the browser ask. An unknown value is rejected locally rather than sent, because the server treats `method` as a UX hint and silently drops anything it doesn't recognise; a typo would otherwise look like it worked while quietly giving the default, with a browser already open and a listener already waiting.

The browser wait also goes from 3 to 10 minutes. Three was sized for a GitHub round-trip that took seconds; signing in can now mean waiting on an email, finding it, and typing six digits, which 3 minutes does not comfortably cover. Flag registration moves into `registerLoginFlags` so that budget is assertable without driving a whole login.

`go test ./...`, `go vet` and `gofmt` are clean. The new tests pin the URL contract released binaries depend on (`port`, `code_challenge`, `state` present, `method` absent by default), both explicit method values, the local rejection happening before any browser opens, and the 10-minute default.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI sign-in now supports GitHub authentication or emailed six-digit codes.
  * Added an optional login method selection for supported authentication flows.
  * Browser-based login now allows up to 10 minutes to complete.

* **Bug Fixes**
  * Invalid login methods are rejected before opening the browser.
  * Improved login callback validation for safer sign-in.

* **Documentation**
  * Expanded CLI guidance covering authentication options, existing sessions, and timeout behavior.
  * Documented one-time code expiration, account sign-out, and tenant-specific API key details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->