### PR TITLE
fix(cli): unhang the callback test, and actually run the CLI in CI

### DIFF
--- a/.github/actions/changed-packages/action.yml
+++ b/.github/actions/changed-packages/action.yml
@@ -26,6 +26,9 @@ outputs:
   go:
     description: Whether the go package is affected
     value: ${{ steps.filter.outputs.go }}
+  cli:
+    description: Whether the CLI is affected
+    value: ${{ steps.filter.outputs.cli }}
   ruby:
     description: Whether the ruby package is affected
     value: ${{ steps.filter.outputs.ruby }}
@@ -56,6 +59,8 @@ runs:
           rust: ['rust/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
           java: ['java/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
           go: ['go/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
+          # The CLI depends on the go SDK (via the workspace), so an SDK change must run it too.
+          cli: ['cli/**', 'go/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
           ruby: ['ruby/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
           php: ['php/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']
           beancount: ['beancount/**', 'fixtures/**', '.github/workflows/**', '.github/actions/**']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,29 @@ jobs:
       # always run; -fuzztime adds a brief exploratory pass to catch panics on malformed input.
       - run: go test -run='^$' -fuzz='FuzzDecryptEnvelope$' -fuzztime=20s .
 
+  # The CLI is a separate module from the go SDK and was never covered: the `go` job above is pinned
+  # to working-directory `go`, so a cli/-only change ran no tests at all. A stale expectation in
+  # cli/internal/app then shipped in v0.2.14 as a test that HANGS rather than fails, which nothing
+  # caught until someone ran the package by hand. Hence also the explicit -timeout: a hang here must
+  # end as a red build in a couple of minutes, not occupy a runner for the job's maximum.
+  cli:
+    needs: changes
+    if: needs.changes.outputs.cli == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.25'
+      - run: gofmt -l . | tee /dev/stderr | (! read)
+      - run: go vet ./...
+      - run: go test -race -timeout 120s ./...
+
   java:
     needs: changes
     if: needs.changes.outputs.java == 'true'
@@ -312,7 +335,7 @@ jobs:
   # actually failed or was cancelled (skipped/success both pass).
   ci-gate:
     if: always()
-    needs: [changes, dotnet, node, n8n, python, rust, go, java, ruby, php, beancount, erpnext, zapier]
+    needs: [changes, dotnet, node, n8n, python, rust, go, cli, java, ruby, php, beancount, erpnext, zapier]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job failed

--- a/cli/internal/app/login_logic_test.go
+++ b/cli/internal/app/login_logic_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestTrimTrailingSlash(t *testing.T) {
@@ -45,7 +46,8 @@ func TestCallbackHandlerCapturesCode(t *testing.T) {
 	srv := httptest.NewServer(callbackHandler(ch, "st", "https://app.example"))
 	defer srv.Close()
 
-	resp, err := srv.Client().Get(srv.URL + "/callback?code=abc123")
+	// state is required on the GET fallback too, not just the POST relay.
+	resp, err := srv.Client().Get(srv.URL + "/callback?code=abc123&state=st")
 	if err != nil {
 		t.Fatalf("GET /callback: %v", err)
 	}
@@ -53,8 +55,24 @@ func TestCallbackHandlerCapturesCode(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("status = %d, want 200", resp.StatusCode)
 	}
-	if got := <-ch; got.code != "abc123" || got.privKeyB64 != "" {
+	got := recvCallback(t, ch)
+	if got.code != "abc123" || got.privKeyB64 != "" {
 		t.Errorf("captured = %+v, want code abc123 and no key", got)
+	}
+}
+
+// recvCallback takes a delivered result or fails. A bare `<-ch` turns "the handler rejected this
+// request" into a hang that only surfaces as `go test`'s timeout minutes later, with a panic trace
+// pointing at the receive rather than at the rejection — which is exactly how a stale expectation
+// in this file went unnoticed. Nothing in CI runs this package, so it has to fail loudly here.
+func recvCallback(t *testing.T, ch <-chan callbackResult) callbackResult {
+	t.Helper()
+	select {
+	case got := <-ch:
+		return got
+	case <-time.After(5 * time.Second):
+		t.Fatal("no callback was delivered — the handler rejected the request")
+		return callbackResult{}
 	}
 }
 
@@ -75,7 +93,7 @@ func TestCallbackHandlerRelaysEncryptionKey(t *testing.T) {
 	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://app.example" {
 		t.Errorf("CORS origin = %q, want the app origin", got)
 	}
-	res := <-ch
+	res := recvCallback(t, ch)
 	if res.code != "c1" || res.privKeyB64 != "PK" || res.pubKeyB64 != "PUB" {
 		t.Errorf("relayed result = %+v, want code c1 + key PK/PUB", res)
 	}
@@ -96,7 +114,7 @@ func TestCallbackHandlerAcceptsFormPost(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	res := <-ch
+	res := recvCallback(t, ch)
 	if res.code != "c9" || res.privKeyB64 != "PK" || res.pubKeyB64 != "PUB" {
 		t.Errorf("form relay result = %+v, want code c9 + PK/PUB", res)
 	}

--- a/cli/internal/app/login_test.go
+++ b/cli/internal/app/login_test.go
@@ -325,7 +325,7 @@ func TestCallbackGetRequiresTheStateNonce(t *testing.T) {
 	if res3.StatusCode != http.StatusOK {
 		t.Errorf("status = %d, want 200 for the matching state", res3.StatusCode)
 	}
-	if got := <-resultCh; got.code != "real" {
+	if got := recvCallback(t, resultCh); got.code != "real" {
 		t.Errorf("code = %q, want real", got.code)
 	}
 }


### PR DESCRIPTION
`main` is currently unrunnable: `go test ./...` in `cli/` **hangs** rather than failing.

#162 made the loopback's GET fallback require the `state` nonce, but only updated the stub server in `login_test.go`. `TestCallbackHandlerCapturesCode` in `login_logic_test.go` still GETs a bare `?code=`, which the handler now 403s — and its assertion is an unguarded `<-ch`. So the package doesn't fail, it blocks until `go test`'s timeout and panics. On the default timeout that's ten minutes of nothing, with a trace pointing at the channel receive rather than at the stale expectation.

This shipped in v0.2.14. **The released binary is fine** — the product code was always correct, and the flow works against production. It's purely the test that went stale.

Two changes:

**Unhang it.** Send the `state`, and route every callback receive in the package through a `recvCallback` helper that fails in five seconds with "the handler rejected the request". A stale expectation should read as a failure at the line that's wrong, not a timeout panic somewhere else.

**Run the CLI in CI, which is why this escaped.** There was no `cli` job and no `cli` filter output at all: the `go` job is pinned to `working-directory: go` (the SDK), and `publish-cli.yml` only `go build`s. A `cli/`-only change therefore ran zero tests and still went green — which is exactly what happened on #162. The new job does `gofmt`, `go vet`, and `go test -race -timeout 120s`, and is wired into `ci-gate` so it's required rather than advisory. The explicit `-timeout` is deliberate: a hang must come back as a red build in minutes, not hold a runner for the job maximum. The `cli` filter also watches `go/**`, since the CLI consumes the SDK through the workspace.

Verified on top of current `main`: `gofmt -l` empty, `go vet` clean, `go test -race -timeout 120s ./...` green across all three packages in ~1.6s each — versus hanging before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNQioSHT9fBpCX1BdYGE4s
