### PR TITLE
fix(cli): prompt before `key import` blocks on a terminal stdin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       rust: ${{ steps.cp.outputs.rust }}
       java: ${{ steps.cp.outputs.java }}
       go: ${{ steps.cp.outputs.go }}
+      cli: ${{ steps.cp.outputs.cli }}
       ruby: ${{ steps.cp.outputs.ruby }}
       php: ${{ steps.cp.outputs.php }}
       beancount: ${{ steps.cp.outputs.beancount }}

--- a/cli/internal/app/key.go
+++ b/cli/internal/app/key.go
@@ -38,8 +38,7 @@ func (a *App) keyImport(args []string) error {
 	var raw []byte
 	var err error
 	if fs.NArg() == 0 || fs.Arg(0) == "-" {
-		// Stdin on a terminal never reaches EOF by itself, so say what we want and how to end it —
-		// an unannounced blocking read is indistinguishable from the CLI having hung.
+		// A terminal never reaches EOF on its own, so an unannounced read just looks like a hang.
 		if env := a.ui(); env.Interactive() {
 			fmt.Fprintln(a.stderr(), env.Color("Paste your encryption key or credentials bundle, then press Ctrl-D:", ui.StyleHeader))
 			fmt.Fprintln(a.stderr(), env.Color("(Ctrl-C to cancel, or re-run as `openbanking key import <file>`)", ui.StyleMuted))

--- a/cli/internal/app/key.go
+++ b/cli/internal/app/key.go
@@ -38,7 +38,6 @@ func (a *App) keyImport(args []string) error {
 	var raw []byte
 	var err error
 	if fs.NArg() == 0 || fs.Arg(0) == "-" {
-		// A terminal never reaches EOF on its own, so an unannounced read just looks like a hang.
 		if env := a.ui(); env.Interactive() {
 			fmt.Fprintln(a.stderr(), env.Color("Paste your encryption key or credentials bundle, then press Ctrl-D:", ui.StyleHeader))
 			fmt.Fprintln(a.stderr(), env.Color("(Ctrl-C to cancel, or re-run as `openbanking key import <file>`)", ui.StyleMuted))

--- a/cli/internal/app/key.go
+++ b/cli/internal/app/key.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/open-banking-io/clients/cli/internal/config"
+	"github.com/open-banking-io/clients/cli/internal/ui"
 	openbanking "github.com/open-banking-io/clients/go"
 )
 
@@ -37,6 +38,12 @@ func (a *App) keyImport(args []string) error {
 	var raw []byte
 	var err error
 	if fs.NArg() == 0 || fs.Arg(0) == "-" {
+		// Stdin on a terminal never reaches EOF by itself, so say what we want and how to end it —
+		// an unannounced blocking read is indistinguishable from the CLI having hung.
+		if env := a.ui(); env.Interactive() {
+			fmt.Fprintln(a.stderr(), env.Color("Paste your encryption key or credentials bundle, then press Ctrl-D:", ui.StyleHeader))
+			fmt.Fprintln(a.stderr(), env.Color("(Ctrl-C to cancel, or re-run as `openbanking key import <file>`)", ui.StyleMuted))
+		}
 		raw, err = io.ReadAll(a.stdin())
 	} else {
 		raw, err = os.ReadFile(fs.Arg(0))

--- a/cli/internal/app/key_test.go
+++ b/cli/internal/app/key_test.go
@@ -108,18 +108,22 @@ func TestKeyImportPromptsWhenStdinIsATerminal(t *testing.T) {
 
 func TestKeyImportDoesNotPromptWhenPiped(t *testing.T) {
 	rawKey := fixtureBundle(t).EncryptionKey.PrivateKey
-	cfg := filepath.Join(t.TempDir(), "credentials.json")
 
-	var out, errOut bytes.Buffer
-	stdin := strings.NewReader(rawKey)
-	app := &App{Stdin: stdin, Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
-	app.env = ui.Custom(stdin, &out, &errOut, ui.FormatTable, false, false)
+	for _, args := range [][]string{{"key", "import"}, {"key", "import", "-"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			cfg := filepath.Join(t.TempDir(), "credentials.json")
+			var out, errOut bytes.Buffer
+			stdin := strings.NewReader(rawKey)
+			app := &App{Stdin: stdin, Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
+			app.env = ui.Custom(stdin, &out, &errOut, ui.FormatTable, false, false)
 
-	if err := app.Run([]string{"key", "import"}); err != nil {
-		t.Fatalf("key import: %v\nstderr: %s", err, errOut.String())
-	}
-	if errOut.Len() != 0 {
-		t.Errorf("piped import wrote to stderr: %q", errOut.String())
+			if err := app.Run(args); err != nil {
+				t.Fatalf("key import: %v\nstderr: %s", err, errOut.String())
+			}
+			if errOut.Len() != 0 {
+				t.Errorf("piped import wrote to stderr: %q", errOut.String())
+			}
+		})
 	}
 }
 

--- a/cli/internal/app/key_test.go
+++ b/cli/internal/app/key_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/open-banking-io/clients/cli/internal/config"
+	"github.com/open-banking-io/clients/cli/internal/ui"
 )
 
 func TestKeyImportFromRawPkcs8(t *testing.T) {
@@ -74,6 +75,77 @@ func TestKeyImportRejectsInvalidKey(t *testing.T) {
 	}
 	if _, statErr := os.Stat(cfg); statErr == nil {
 		t.Error("config should not be written when the key is invalid")
+	}
+}
+
+// A terminal never sends EOF on its own, so reading stdin with no prompt is indistinguishable from a
+// hang: the user gets a blank line and no idea the CLI is waiting on them.
+func TestKeyImportPromptsWhenStdinIsATerminal(t *testing.T) {
+	rawKey := fixtureBundle(t).EncryptionKey.PrivateKey
+
+	// "-" is the explicit spelling of the same thing, and blocks just as silently.
+	for _, args := range [][]string{{"key", "import"}, {"key", "import", "-"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			cfg := filepath.Join(t.TempDir(), "credentials.json")
+			var out, errOut bytes.Buffer
+			stdin := strings.NewReader(rawKey)
+			app := &App{Stdin: stdin, Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
+			app.env = ui.Custom(stdin, &out, &errOut, ui.FormatTable, false, true)
+
+			if err := app.Run(args); err != nil {
+				t.Fatalf("key import: %v\nstderr: %s", err, errOut.String())
+			}
+			if !strings.Contains(errOut.String(), "Ctrl-D") {
+				t.Errorf("prompt does not say how to end the input; stderr = %q", errOut.String())
+			}
+			got, err := config.Load(cfg)
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if got.EncryptionKey.PrivateKey != rawKey {
+				t.Error("prompting broke the import itself")
+			}
+		})
+	}
+}
+
+// Piped and scripted input must stay silent — nothing is waiting on a human, and the prompt would
+// otherwise land in every CI log that imports a key.
+func TestKeyImportDoesNotPromptWhenPiped(t *testing.T) {
+	rawKey := fixtureBundle(t).EncryptionKey.PrivateKey
+	cfg := filepath.Join(t.TempDir(), "credentials.json")
+
+	var out, errOut bytes.Buffer
+	stdin := strings.NewReader(rawKey)
+	app := &App{Stdin: stdin, Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
+	app.env = ui.Custom(stdin, &out, &errOut, ui.FormatTable, false, false)
+
+	if err := app.Run([]string{"key", "import"}); err != nil {
+		t.Fatalf("key import: %v\nstderr: %s", err, errOut.String())
+	}
+	if errOut.Len() != 0 {
+		t.Errorf("piped import wrote to stderr: %q", errOut.String())
+	}
+}
+
+// A file argument never blocks on stdin, so there is nothing to prompt for even on a terminal.
+func TestKeyImportFromFileDoesNotPrompt(t *testing.T) {
+	bundle := fixtureBundle(t)
+	keyFile := filepath.Join(t.TempDir(), "key.txt")
+	if err := os.WriteFile(keyFile, []byte(bundle.EncryptionKey.PrivateKey), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := filepath.Join(t.TempDir(), "credentials.json")
+
+	var out, errOut bytes.Buffer
+	app := &App{Stdout: &out, Stderr: &errOut, ConfigPath: cfg}
+	app.env = ui.Custom(nil, &out, &errOut, ui.FormatTable, false, true)
+
+	if err := app.Run([]string{"key", "import", keyFile}); err != nil {
+		t.Fatalf("key import: %v\nstderr: %s", err, errOut.String())
+	}
+	if errOut.Len() != 0 {
+		t.Errorf("prompted despite reading a file: %q", errOut.String())
 	}
 }
 

--- a/cli/internal/app/key_test.go
+++ b/cli/internal/app/key_test.go
@@ -78,12 +78,9 @@ func TestKeyImportRejectsInvalidKey(t *testing.T) {
 	}
 }
 
-// A terminal never sends EOF on its own, so reading stdin with no prompt is indistinguishable from a
-// hang: the user gets a blank line and no idea the CLI is waiting on them.
 func TestKeyImportPromptsWhenStdinIsATerminal(t *testing.T) {
 	rawKey := fixtureBundle(t).EncryptionKey.PrivateKey
 
-	// "-" is the explicit spelling of the same thing, and blocks just as silently.
 	for _, args := range [][]string{{"key", "import"}, {"key", "import", "-"}} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			cfg := filepath.Join(t.TempDir(), "credentials.json")
@@ -109,8 +106,6 @@ func TestKeyImportPromptsWhenStdinIsATerminal(t *testing.T) {
 	}
 }
 
-// Piped and scripted input must stay silent — nothing is waiting on a human, and the prompt would
-// otherwise land in every CI log that imports a key.
 func TestKeyImportDoesNotPromptWhenPiped(t *testing.T) {
 	rawKey := fixtureBundle(t).EncryptionKey.PrivateKey
 	cfg := filepath.Join(t.TempDir(), "credentials.json")
@@ -128,7 +123,6 @@ func TestKeyImportDoesNotPromptWhenPiped(t *testing.T) {
 	}
 }
 
-// A file argument never blocks on stdin, so there is nothing to prompt for even on a terminal.
 func TestKeyImportFromFileDoesNotPrompt(t *testing.T) {
 	bundle := fixtureBundle(t)
 	keyFile := filepath.Join(t.TempDir(), "key.txt")


### PR DESCRIPTION
`openbanking key import` with no file argument reads stdin to EOF. A terminal never sends EOF on its own and nothing was printed first, so the command just sat there on a blank line — indistinguishable from a hang. It is the only blocking stdin read in the CLI.

The fix prints the prompt to stderr when stdin is a terminal, following the convention already documented on `ui.Select`. Piped input, file arguments and the `-` spelling behave exactly as before, so scripts and CI logs stay clean.

Tests came first: two cases assert the prompt on an interactive stdin (bare and `-`), two assert stderr stays empty when piped or reading a file. Also verified against a real pty — the old binary prints nothing, the new one prompts.

Second commit fixes CI. The `changes` job never re-exported the `cli` output from the changed-packages action, so `needs.changes.outputs.cli` was always empty and the `cli` job skipped on every PR since it was added — including this one, whose tests therefore did not run. The action's filter was computing `cli = true` correctly the whole time; only the plumbing between it and the job was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqBk7U7NyD8GAhEKYCepJJ
