### PR TITLE
chore: bump packages with unreleased changes to 1.0.0

### DIFF
--- a/erpnext/erpnext_open_banking/__init__.py
+++ b/erpnext/erpnext_open_banking/__init__.py
@@ -2,4 +2,4 @@
 # Author: open-banking.io
 # Licence: MIT
 
-__version__ = "0.1.3"
+__version__ = "1.0.0"

--- a/erpnext/pyproject.toml
+++ b/erpnext/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "erpnext-open-banking"
-version = "0.1.3"
+version = "1.0.0"
 description = "Connect your bank accounts to ERPNext via open-banking.io — no eIDAS certificates required."
 readme = "README.md"
 license = { text = "MIT" }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.open-banking</groupId>
   <artifactId>open-banking-io-client</artifactId>
-  <version>0.3.0</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <name>open-banking.io client</name>

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-banking-io/client",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-banking-io/client",
-      "version": "0.3.1",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-banking-io/client",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "description": "Server-to-server client for open-banking.io: API-key auth + client-side decryption of the zero-knowledge data envelopes with your exported private key.",
   "type": "module",
   "license": "MIT",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-banking-io"
-version = "0.3.0"
+version = "1.0.0"
 description = "Server-to-server client for open-banking.io with local zero-knowledge envelope decryption."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    open-banking-io (0.3.0)
+    open-banking-io (1.0.0)
       base64 (>= 0.1)
       bigdecimal (>= 3.0)
 
@@ -105,7 +105,7 @@ CHECKSUMS
   json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
   language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
-  open-banking-io (0.3.0)
+  open-banking-io (1.0.0)
   parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
   parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85

--- a/ruby/lib/open_banking_io/version.rb
+++ b/ruby/lib/open_banking_io/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenBankingIO
-  VERSION = "0.3.0"
+  VERSION = "1.0.0"
 end

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -607,7 +607,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open-banking-io"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-banking-io"
-version = "0.3.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.74"
 description = "Server-to-server client for open-banking.io with local zero-knowledge envelope decryption."


### PR DESCRIPTION
Bumps every package that has unreleased commits on `main` to 1.0.0, leaving the ones with nothing pending alone.

| Package | From | To | What was unreleased |
|---|---|---|---|
| rust | 0.3.0 | 1.0.0 | runtime dep bumps (ureq 3.3.0→3.4.0, serde, serde_json, thiserror) |
| node | 0.3.1 | 1.0.0 | dev-only (eslint, typescript-eslint) |
| java | 0.3.0 | 1.0.0 | dev-only (junit, maven-jar-plugin) |
| ruby | 0.3.0 | 1.0.0 | dev-only (standard) |
| python | 0.3.0 | 1.0.0 | README only |
| erpnext | 0.1.3 | 1.0.0 | docs only (PUBLISHING.md) |

Untouched because nothing is unreleased: go, php, dotnet, n8n, beancount, cli.

**zapier is excluded** — it is already at 1.0.1, so 1.0.0 would be a downgrade. Its one unreleased commit is a CHANGELOG addition. It needs its own decision (1.0.2, or leave it).

Worth being explicit about what this version number claims: apart from rust's runtime dependency bumps, the diffs behind these releases are dev-tooling and prose. 1.0.0 is a public API-stability commitment carried by the number here, not by the code.

Lockfile self-versions are updated in the same commit. `Cargo.lock` went through cargo; `node/package-lock.json` was edited by hand rather than regenerated, so the platform-specific optional `@emnapi` deps stay exactly as CI expects.

User-agent strings derive from package metadata in all six (`CARGO_PKG_VERSION`, `package.json`, etc.), so they pick up 1.0.0 with no separate change.

Merging this publishes nothing — SDK publishing is tag-driven (`push: tags: ['<pkg>/v*'])` or a manual `release.yml` dispatch. The tags are a separate, deliberate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqBk7U7NyD8GAhEKYCepJJ