### PR TITLE
fix(zapier): override form-data to 4.0.6 (GHSA-hmw2-7cc7-3qxx)

### DIFF
--- a/zapier/package-lock.json
+++ b/zapier/package-lock.json
@@ -676,16 +676,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"

--- a/zapier/package.json
+++ b/zapier/package.json
@@ -35,5 +35,8 @@
     "chai": "^4.5.0",
     "mocha": "^10.8.0",
     "zapier-platform-schema": "19.0.0"
+  },
+  "overrides": {
+    "form-data": "4.0.6"
   }
 }


### PR DESCRIPTION
Scorecard's OSV check reports 16 vulnerabilities. Resolving each advisory to its package and checking it against our lockfiles, **15 are in dev-only tooling and one reaches a shipped artifact** — this PR fixes that one.

`zapier` depends on `zapier-platform-core@19.0.0`, which pins `form-data` to exactly `4.0.5` — vulnerable to CRLF injection via unescaped multipart values (GHSA-hmw2-7cc7-3qxx, HIGH, fixed in 4.0.6). Upstream still pins 4.0.5 on its latest 19.1.0, so bumping the dependency does not clear it; an npm `overrides` entry is the only route to a fixed transitive version.

The lockfile change is exactly `form-data` 4.0.5 → 4.0.6 and nothing else. All 31 zapier tests pass against the override.

### Why the other 15 are not fixed here

| Package | Where | Runtime? |
|---|---|---|
| brace-expansion, nanoid, postcss | node SDK | dev-only — the published SDK has **zero** runtime dependencies |
| brace-expansion, form-data, js-yaml, lodash, nanoid, postcss, uuid | n8n | dev-only |
| brace-expansion, js-yaml, serialize-javascript | zapier | dev-only |
| json (RubyGems) | ruby | dev-only — the gem's runtime deps are `base64` and `bigdecimal` |
| lodash | zapier | runtime, but already at 4.18.1 ≥ the 4.18.0 fix |

None of them ship to users. They are build/test tooling that Scorecard counts because it scans lockfiles indiscriminately, and dependabot moves them on its own schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqBk7U7NyD8GAhEKYCepJJ