### PR TITLE
Set crates.io documentation field (docs.rs link)

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,6 +7,7 @@ description = "Server-to-server client for open-banking.io with local zero-knowl
 license = "MIT"
 repository = "https://github.com/open-banking-io/clients"
 homepage = "https://open-banking.io"
+documentation = "https://docs.rs/open-banking-io"
 keywords = ["open-banking", "psd2", "zero-knowledge", "ecdh", "fintech"]
 categories = ["api-bindings", "cryptography"]
 readme = "README.md"


### PR DESCRIPTION
## What

Adds `documentation = "https://docs.rs/open-banking-io"` to `[package]` in `rust/Cargo.toml`.

## Why

- Surfaces the documentation link on the **crates.io listing page** for the `open-banking-io` crate (the field is currently missing).
- **docs.rs already builds this crate** (docs.rs/open-banking-io/latest), so the link resolves today — no doc-build changes needed.

## Notes

- Verified along the way: `homepage` = https://open-banking.io and `repository` = https://github.com/open-banking-io/clients are already set correctly — unchanged.
- No version bump, no other changes; the field takes effect on the **next crates.io publish** (the publish itself needs the crates.io token, which is a human/maintainer step outside this PR).