### PR TITLE
feat(php): sync() can ask for a window, and reports the one it got

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -76,11 +76,36 @@ $client = Client::fromCredentials('credentials.json', ['timeout' => 60]);
 - `getAccounts(): Account[]` — decrypts each account's envelope, display name and balances.
 - `getTransactions(string $accountId, array $opts = []): TransactionPage` — `$opts` keys: `from`, `to`, `limit`, `offset`.
 - `getConnections(): Connection[]`
-- `sync(string $accountId): SyncResult` — decrypts the account uid locally and posts it; throws if the account has no active session.
+- `sync(string $accountId, array $opts = []): SyncResult` — decrypts the account uid locally and posts it; throws if the account has no active session. `$opts` keys: `fromDate` (`YYYY-MM-DD`) to backfill from a given day instead of syncing incrementally. See [Backfilling from a date](#backfilling-from-a-date).
 - `syncAll(): SyncAllResult` — syncs every account whose session it can read; `$result->unreadable` lists the ones it could not, and `isComplete()` is the only proof the run covered everything.
 
 Money/amount fields are exposed as **decimal `string`s** (exact; never a float). Models are
 `final` classes with `readonly` public properties under `OpenBankingIO\Model`.
+
+### Backfilling from a date
+
+By default `sync()` fetches incrementally, continuing from what the service already holds. Pass
+`fromDate` to fetch from a specific day instead — the import is additive, so this only inserts rows
+that are missing, and re-running it is safe:
+
+```php
+$result = $client->sync($accountId, ['fromDate' => '2026-08-01']);
+```
+
+It is also the lever for a slow bank. A sync runs while your request is open, and some banks need
+minutes to serve a wide window — long enough that a proxy in front of the API can close the
+connection first (Cloudflare answers `524` after 100 seconds). A narrow window usually returns in
+seconds. A `524` does not mean the sync failed: the service owns the run once it has started and
+carries it to completion regardless of the caller, and retrying the same account joins the run in
+progress rather than starting a second fetch.
+
+The window you ask for is a request, not a guarantee. A bank caps how far into the past a request
+may reach, and the service negotiates a refused window down rather than failing — so read back what
+was actually served:
+
+```php
+$result->servedFromDate;  // e.g. '2026-05-19', or null when no fromDate was requested
+```
 
 ### A null amount is not zero
 

--- a/php/README.md
+++ b/php/README.md
@@ -76,36 +76,11 @@ $client = Client::fromCredentials('credentials.json', ['timeout' => 60]);
 - `getAccounts(): Account[]` — decrypts each account's envelope, display name and balances.
 - `getTransactions(string $accountId, array $opts = []): TransactionPage` — `$opts` keys: `from`, `to`, `limit`, `offset`.
 - `getConnections(): Connection[]`
-- `sync(string $accountId, array $opts = []): SyncResult` — decrypts the account uid locally and posts it; throws if the account has no active session. `$opts` keys: `fromDate` (`YYYY-MM-DD`) to backfill from a given day instead of syncing incrementally. See [Backfilling from a date](#backfilling-from-a-date).
+- `sync(string $accountId, array $opts = []): SyncResult` — decrypts the account uid locally and posts it; throws if the account has no active session. `$opts` keys: `fromDate` (`YYYY-MM-DD`) to backfill from a given day instead of syncing incrementally.
 - `syncAll(): SyncAllResult` — syncs every account whose session it can read; `$result->unreadable` lists the ones it could not, and `isComplete()` is the only proof the run covered everything.
 
 Money/amount fields are exposed as **decimal `string`s** (exact; never a float). Models are
 `final` classes with `readonly` public properties under `OpenBankingIO\Model`.
-
-### Backfilling from a date
-
-By default `sync()` fetches incrementally, continuing from what the service already holds. Pass
-`fromDate` to fetch from a specific day instead — the import is additive, so this only inserts rows
-that are missing, and re-running it is safe:
-
-```php
-$result = $client->sync($accountId, ['fromDate' => '2026-08-01']);
-```
-
-It is also the lever for a slow bank. A sync runs while your request is open, and some banks need
-minutes to serve a wide window — long enough that a proxy in front of the API can close the
-connection first (Cloudflare answers `524` after 100 seconds). A narrow window usually returns in
-seconds. A `524` does not mean the sync failed: the service owns the run once it has started and
-carries it to completion regardless of the caller, and retrying the same account joins the run in
-progress rather than starting a second fetch.
-
-The window you ask for is a request, not a guarantee. A bank caps how far into the past a request
-may reach, and the service negotiates a refused window down rather than failing — so read back what
-was actually served:
-
-```php
-$result->servedFromDate;  // e.g. '2026-05-19', or null when no fromDate was requested
-```
 
 ### A null amount is not zero
 

--- a/php/src/Client.php
+++ b/php/src/Client.php
@@ -241,9 +241,24 @@ final class Client
      *
      * Decrypts that account's Enable Banking uid and posts it, so the service can
      * fetch fresh data without ever holding the uid in plaintext.
+     *
+     * By default the service fetches incrementally, from what it already holds. Pass a
+     * `fromDate` to backfill from a specific day instead: the import is additive, so this
+     * only ever inserts rows that are missing. It is also the lever for a bank that cannot
+     * serve a wide window inside one request -- a narrow window returns in seconds where the
+     * default may run for minutes and be cut off by a proxy long before it finishes.
+     *
+     * The window is a request, not a guarantee: read `SyncResult::$servedFromDate` for the one
+     * the service actually fetched.
+     *
+     * @param array{fromDate?: string} $opts `fromDate`: backfill start, YYYY-MM-DD.
      */
-    public function sync(string $accountId): SyncResult
+    public function sync(string $accountId, array $opts = []): SyncResult
     {
+        $fromDate = isset($opts['fromDate']) && $opts['fromDate'] !== ''
+            ? self::calendarDate($opts['fromDate'])
+            : null;
+
         $account = null;
         foreach ($this->getAccountWires() as $wire) {
             if (($wire['id'] ?? null) === $accountId) {
@@ -269,12 +284,19 @@ final class Client
             );
         }
 
+        $body = ['uid' => $uid];
+        if ($fromDate !== null) {
+            $body['fromDate'] = $fromDate;
+        }
+
         $path = 'api/accounts/' . rawurlencode($accountId) . '/sync';
-        $result = self::counters($this->postJson($path, ['uid' => $uid]), ['newTransactions', 'totalFetched'], $path);
+        $response = $this->postJson($path, $body);
+        $result = self::counters($response, ['newTransactions', 'totalFetched'], $path);
 
         return new SyncResult(
             newTransactions: $result['newTransactions'],
             totalFetched: $result['totalFetched'],
+            servedFromDate: self::nullableString($response['servedFromDate'] ?? null),
         );
     }
 
@@ -359,6 +381,33 @@ final class Client
         }
 
         return $counters;
+    }
+
+    /**
+     * Refuses anything that is not a plain YYYY-MM-DD calendar day, locally.
+     *
+     * The service answers a bad date with a 400 whose body does not name the offending argument,
+     * and on the sync endpoint that round trip is not free -- it queues behind the account's own
+     * work and can cost minutes at a slow bank. `checkdate` is what rejects 2026-02-31, which
+     * matches the pattern and is still not a day.
+     */
+    private static function calendarDate(mixed $value): string
+    {
+        if (!is_string($value)
+            || preg_match('/^(\d{4})-(\d{2})-(\d{2})$/D', $value, $m) !== 1
+            || !checkdate((int) $m[2], (int) $m[3], (int) $m[1])) {
+            throw new OpenBankingException(
+                'fromDate must be a calendar date as YYYY-MM-DD, got: ' . self::describe($value),
+            );
+        }
+
+        return $value;
+    }
+
+    /** Names a rejected argument without ever stringifying an array or an object. */
+    private static function describe(mixed $value): string
+    {
+        return is_string($value) ? $value : get_debug_type($value);
     }
 
     /**

--- a/php/src/Model/SyncResult.php
+++ b/php/src/Model/SyncResult.php
@@ -7,9 +7,17 @@ namespace OpenBankingIO\Model;
 /** The result of syncing a single account. */
 final class SyncResult
 {
+    /**
+     * @param string|null $servedFromDate The window the service actually fetched from (YYYY-MM-DD),
+     *                                    which is not necessarily the one that was asked for: a bank
+     *                                    caps how far into the past a request may reach, and the
+     *                                    service negotiates a refused window DOWN rather than failing.
+     *                                    Null when no backfill window was requested.
+     */
     public function __construct(
         public readonly int $newTransactions,
         public readonly int $totalFetched,
+        public readonly ?string $servedFromDate = null,
     ) {
     }
 }

--- a/php/tests/ClientNegativeTest.php
+++ b/php/tests/ClientNegativeTest.php
@@ -7,6 +7,7 @@ namespace OpenBankingIO\Tests;
 use OpenBankingIO\ApiException;
 use OpenBankingIO\Client;
 use OpenBankingIO\OpenBankingException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -98,6 +99,50 @@ final class ClientNegativeTest extends TestCase
         $this->expectException(OpenBankingException::class);
         $this->expectExceptionMessage('no active session');
         $this->client()->sync(self::ACCOUNT_ID);
+    }
+
+    /**
+     * A malformed window is refused locally, before the account lookup and before any bank work:
+     * the service answers a bad fromDate with a 400 whose body says nothing about which argument
+     * was wrong, and on this endpoint a round trip can cost minutes at a slow bank.
+     */
+    #[DataProvider('malformedWindows')]
+    public function testSyncRefusesAMalformedBackfillWindow(string $fromDate): void
+    {
+        $this->startMockServer();
+
+        $this->expectException(OpenBankingException::class);
+        $this->expectExceptionMessage('fromDate must be a calendar date');
+        $this->client()->sync(self::ACCOUNT_ID, ['fromDate' => $fromDate]);
+    }
+
+    /**
+     * A non-string window has to arrive as an OpenBankingException too. `$opts` is a plain array,
+     * so nothing stops a caller passing a DateTime or an integer date, and a raw TypeError out of
+     * the SDK reaches their generic handler where it looks like a transport fault.
+     */
+    public function testSyncRefusesANonStringBackfillWindow(): void
+    {
+        $this->startMockServer();
+
+        $this->expectException(OpenBankingException::class);
+        $this->expectExceptionMessage('got: DateTimeImmutable');
+        /** @phpstan-ignore argument.type */
+        $this->client()->sync(self::ACCOUNT_ID, ['fromDate' => new \DateTimeImmutable('2026-08-01')]);
+    }
+
+    /** @return array<string, array{string}> */
+    public static function malformedWindows(): array
+    {
+        return [
+            'not a date' => ['last tuesday'],
+            'wrong order' => ['01-08-2026'],
+            'no zero padding' => ['2026-8-1'],
+            'day out of range' => ['2026-02-31'],
+            'month out of range' => ['2026-13-01'],
+            'timestamp' => ['2026-08-01T00:00:00Z'],
+            'trailing newline' => ["2026-08-01\n"],
+        ];
     }
 
     public function testSyncAllSkipsSessionlessAccounts(): void

--- a/php/tests/IntegrationTest.php
+++ b/php/tests/IntegrationTest.php
@@ -103,6 +103,24 @@ final class IntegrationTest extends TestCase
         self::assertSame(['uid' => 'c5d93aa7-5e23-4da0-ba88-42b9a584492c'], $body);
     }
 
+    public function testSyncSendsTheRequestedBackfillWindow(): void
+    {
+        $result = $this->client()->sync(self::ACCOUNT_ID, ['fromDate' => '2026-08-01']);
+
+        self::assertSame(1, $result->totalFetched);
+        $body = $this->captured('sync');
+        self::assertSame(
+            ['uid' => 'c5d93aa7-5e23-4da0-ba88-42b9a584492c', 'fromDate' => '2026-08-01'],
+            $body,
+        );
+    }
+
+    /** No window asked for, no window served — the field stays null rather than guessing. */
+    public function testSyncWithoutBackfillHasNoServedWindow(): void
+    {
+        self::assertNull($this->client()->sync(self::ACCOUNT_ID)->servedFromDate);
+    }
+
     public function testSyncAllPostsDecryptedUids(): void
     {
         $result = $this->client()->syncAll();

--- a/php/tests/ResponseShapeTest.php
+++ b/php/tests/ResponseShapeTest.php
@@ -57,6 +57,24 @@ final class ResponseShapeTest extends TestCase
         $this->client()->syncAll();
     }
 
+    /**
+     * The service negotiates a window the bank refuses DOWN rather than failing outright, so the
+     * served window is the only proof of what a backfill actually covered. A caller that asked for
+     * two years and silently received ninety days has to be able to see that.
+     */
+    public function testSyncSurfacesTheWindowTheServiceActuallyServed(): void
+    {
+        $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'sync-narrowed-window'];
+        $this->startMockServer();
+
+        $result = $this->client()->sync(
+            '11111111-1111-4111-8111-111111111111',
+            ['fromDate' => '2024-01-01'],
+        );
+
+        self::assertSame('2026-05-19', $result->servedFromDate);
+    }
+
     public function testAFleetWithOneTornSessionSyncsTheRestAndNamesTheCasualty(): void
     {
         $this->serverEnvOverrides = ['OBK_ACCOUNTS_MODE' => 'mixed-fleet'];

--- a/php/tests/mock-server/router.php
+++ b/php/tests/mock-server/router.php
@@ -28,7 +28,9 @@ declare(strict_types=1);
  *   'edge-total'    -> total is exactly PHP_INT_MAX, 'over-edge-total' is one past it,
  *   'twin-sealed'  -> two accounts share an id and both have unreadable sessions,
  *   'sealed-display-name' -> only the account's displayNameEnc is unreadable,
- *   'sync-no-counters' -> POST /api/sync returns 200 without its counters.
+ *   'sync-no-counters' -> POST /api/sync returns 200 without its counters,
+ *   'sync-narrowed-window' -> the single-account sync answers with a servedFromDate
+ *                             narrower than any window a test would ask for.
  */
 
 $fixtures = getenv('OBK_FIXTURES') ?: '';
@@ -254,6 +256,10 @@ if ($method === 'GET' && $path === '/api/connections') {
 
 if ($method === 'POST' && $path === "/api/accounts/{$accountId}/sync") {
     $capture('sync');
+    if ($accountsMode === 'sync-narrowed-window') {
+        echo json_encode(['newTransactions' => 0, 'totalFetched' => 1, 'servedFromDate' => '2026-05-19']);
+        return true;
+    }
     $serve('sync.json');
     return true;
 }


### PR DESCRIPTION
A user integrating over the PHP SDK hit a wall: `POST /api/accounts/{id}/sync` consistently returned 524 for one account, while the same account synced fine from the web app when a start date was picked. The API has always accepted an optional `fromDate` on that endpoint — it is exactly what the web app sends — but `Client::sync()` posted only the uid, and with no raw-request escape hatch and no public accessor for the decrypted uid, a caller could not reach the field at all.

The account behind the report is at a Spanish bank that burns ~125s serving the default window; the proxy in front of the API gives up at 100s. The same account answered in 11s for a narrow window. `fromDate` is the difference between an integration that works and one that cannot.

`sync()` now takes `$opts` with `fromDate`, mirroring `getTransactions()`. The window is a request rather than a guarantee — the service negotiates one the bank refuses down instead of failing — so `SyncResult` carries `servedFromDate`, otherwise a caller who asks for two years and receives ninety days has no way to tell. A malformed date is refused locally, before the account lookup and any bank work: the service answers a bad date with a 400 that does not name the offending argument, and a round trip on this endpoint is not cheap.

Tests: the posted body with and without a window, the served window surfaced from a narrowed response (new `sync-narrowed-window` router mode), a null served window when none was asked for, and seven malformed shapes plus a non-string one. 98 tests green, phpstan and php-cs-fixer clean.

The other SDKs have the same gap; this is PHP first because that is where the report came from.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional backfill support to synchronization requests using a start date.
  * Sync results now show the date range actually provided by the service.
  * Added validation for invalid backfill dates and values.

* **Documentation**
  * Updated PHP API guidance for backfills, retries, timeouts, `524` responses, and negotiated service windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->