### PR TITLE
chore(php): 1.1.0

### DIFF
--- a/php/src/Client.php
+++ b/php/src/Client.php
@@ -27,7 +27,7 @@ final class Client
      * Client version, sent as the User-Agent. Tracks the published release tag
      * (PHP has no build manifest -- Packagist is tag-based), so bump this when tagging.
      */
-    public const VERSION = '1.0.0';
+    public const VERSION = '1.1.0';
 
     /** Total request timeout, in seconds. */
     private const TIMEOUT_SECONDS = 30;


### PR DESCRIPTION
Step 1 of the PHP 1.1.0 release: `Client::VERSION` → `1.1.0`. `publish-php.yml` refuses a tag that disagrees with the constant, so it has to land on `main` before the tag is cut.

Everything in this release is #168: `sync()` takes an optional `fromDate`, and `SyncResult` carries `servedFromDate` so a window the service negotiated down is visible rather than silent. Both are additive — a new optional `$opts` argument and a constructor parameter with a default — so nothing on 1.0.0 breaks. That is the only PHP change since `php/v1.0.0`.

Step 2 (Actions → Release, package `php`, version `1.1.0`) follows once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kc7Wi2yeAYE5MrsLzr6she