### PR TITLE
feat(node): connect module for Partner Connect (1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,19 @@ All notable changes to the open-banking.io client SDKs are documented here.
 This is a monorepo of independently versioned packages, each released under its own
 `<package>/vX.Y.Z` git tag and following [Semantic Versioning](https://semver.org/):
 
-| Package | Tag prefix | Registry |
-| ------- | ---------- | -------- |
-| .NET    | `dotnet/v` | NuGet |
-| Node    | `node/v`   | npm |
-| Python  | `python/v` | PyPI |
-| Rust    | `rust/v`   | crates.io |
-| Go      | `go/v`     | Go modules |
-| Java    | `java/v`   | Maven Central |
-| Ruby    | `ruby/v`   | RubyGems |
-| PHP     | `php/v`    | Packagist |
-| CLI     | `cli/v`    | GitHub Releases + Homebrew |
-| n8n     | `n8n/v`    | npm |
-| Beancount | `beancount/v` | PyPI |
+| Package   | Tag prefix    | Registry                   |
+| --------- | ------------- | -------------------------- |
+| .NET      | `dotnet/v`    | NuGet                      |
+| Node      | `node/v`      | npm                        |
+| Python    | `python/v`    | PyPI                       |
+| Rust      | `rust/v`      | crates.io                  |
+| Go        | `go/v`        | Go modules                 |
+| Java      | `java/v`      | Maven Central              |
+| Ruby      | `ruby/v`      | RubyGems                   |
+| PHP       | `php/v`       | Packagist                  |
+| CLI       | `cli/v`       | GitHub Releases + Homebrew |
+| n8n       | `n8n/v`       | npm                        |
+| Beancount | `beancount/v` | PyPI                       |
 
 ## Per-release notes
 
@@ -26,6 +26,14 @@ Detailed, auto-generated notes for every release live on the
 `<package>/vX.Y.Z` tag. The release process is documented in [`RELEASING.md`](RELEASING.md).
 
 ## Notable cross-cutting changes
+
+### 2026-08
+
+- Node 1.1.0: a `connect` module for Partner Connect — PKCE and state helpers, `buildAuthorizeUrl`,
+  `parseRelay` (constant-time `state`/`iss` checks, RFC error surfacing), `exchangeCode`,
+  `revokeToken`, `userinfo`, `discover` and `OpenBankingClient.fromTokenResponse`. The flow is plain
+  OAuth 2.0 with PKCE and `form_post`; other SDKs can use any client library that supports those, and
+  the CLI's Go `pkce.go`/relay parser is the template for a Go port.
 
 ### 2026-06
 

--- a/node/README.md
+++ b/node/README.md
@@ -98,7 +98,7 @@ app.get("/connect", async (req, res) => {
 app.post("/callback", express.urlencoded({ extended: false }), async (req, res) => {
   const { issuer } = await discover(ISSUER);
   const flow = await flows.take(req.body.state);
-  if (!flow) return res.status(400).send("unknown or expired state");
+  if (!flow || flow.expiresAt < Date.now()) return res.status(400).send("unknown or expired state");
   let relay;
   try {
     relay = parseRelay(req.body, { expectedState: flow.state, issuer });

--- a/node/README.md
+++ b/node/README.md
@@ -63,6 +63,7 @@ import {
   exchangeCode,
   parseRelay,
   OpenBankingClient,
+  RelayError,
 } from "@open-banking-io/client";
 
 const ISSUER = "https://open-banking.io";
@@ -71,7 +72,7 @@ const ISSUER = "https://open-banking.io";
 app.get("/connect", async (req, res) => {
   const pkce = createPkce();
   const state = createState();
-  await flows.put(state, { verifier: pkce.verifier, sessionId: req.session.id });
+  await flows.put(state, { state, verifier: pkce.verifier, sessionId: req.session.id });
   res.redirect(
     buildAuthorizeUrl({
       issuer: ISSUER,
@@ -84,11 +85,20 @@ app.get("/connect", async (req, res) => {
   );
 });
 
-// 2. Callback: the consent page form-posts code, state, iss, privateKey and publicKey.
-app.post("/callback", async (req, res) => {
+// 2. Callback: the consent page form-posts code, state, iss, privateKey and publicKey — or
+//    error=access_denied when the user went back to you. Consume the flow by state first, so a
+//    cancel consumes it too; the lookup is what binds the POST to the session that started it.
+app.post("/callback", express.urlencoded({ extended: false }), async (req, res) => {
   const { issuer } = await discover(ISSUER);
   const flow = await flows.take(req.body.state);
-  const relay = parseRelay(req.body, { expectedState: flow?.state ?? "", issuer });
+  if (!flow) return res.status(400).send("unknown or expired state");
+  let relay;
+  try {
+    relay = parseRelay(req.body, { expectedState: flow.state, issuer });
+  } catch (e) {
+    if (e instanceof RelayError && e.code === "access_denied") return res.render("cancelled");
+    throw e;
+  }
   const token = await exchangeCode({
     issuer,
     clientId: CLIENT_ID,
@@ -106,8 +116,8 @@ const client = OpenBankingClient.fromTokenResponse(token, privateKey);
 const accounts = await client.getAccounts();
 ```
 
-`parseRelay` throws a `RelayError` (`oauth_error`, `state_mismatch`, `issuer_mismatch`,
-`missing_code`, `missing_private_key`) and compares `state` and `iss` in constant time;
+`parseRelay` throws a `RelayError` (`access_denied` — the user cancelled, a normal outcome —
+`oauth_error`, `state_mismatch`, `issuer_mismatch`, `missing_code`, `missing_private_key`) and compares `state` and `iss` in constant time;
 `exchangeCode`, `revokeToken` and `userinfo` throw an `OAuthError` carrying the RFC 6749 `error`
 and `error_description`. An `invalid_grant` is terminal for that code — restart the flow.
 

--- a/node/README.md
+++ b/node/README.md
@@ -72,7 +72,14 @@ const ISSUER = "https://open-banking.io";
 app.get("/connect", async (req, res) => {
   const pkce = createPkce();
   const state = createState();
-  await flows.put(state, { state, verifier: pkce.verifier, sessionId: req.session.id });
+  const mode = req.query.mode === "redirect" ? "redirect" : "popup";
+  await flows.put(state, {
+    state,
+    verifier: pkce.verifier,
+    sessionId: req.session.id,
+    mode,
+    expiresAt: Date.now() + 600_000,
+  });
   res.redirect(
     buildAuthorizeUrl({
       issuer: ISSUER,
@@ -80,7 +87,7 @@ app.get("/connect", async (req, res) => {
       redirectUri: `${SELF_URL}/callback`,
       state,
       codeChallenge: pkce.challenge,
-      challenge: "pin_code", // popup mode; omit for a redirect flow
+      ...(mode === "popup" && { challenge: "pin_code" }),
     }),
   );
 });
@@ -96,7 +103,8 @@ app.post("/callback", express.urlencoded({ extended: false }), async (req, res) 
   try {
     relay = parseRelay(req.body, { expectedState: flow.state, issuer });
   } catch (e) {
-    if (e instanceof RelayError && e.code === "access_denied") return res.render("cancelled");
+    if (e instanceof RelayError && e.code === "access_denied")
+      return finish(res, flow, "cancelled");
     throw e;
   }
   const token = await exchangeCode({
@@ -108,10 +116,22 @@ app.post("/callback", express.urlencoded({ extended: false }), async (req, res) 
     redirectUri: `${SELF_URL}/callback`,
   });
   await bundles.put(flow.sessionId, { token, privateKey: relay.privateKey });
-  res.render("close");
+  finish(res, flow, "connected");
 });
 
-// 3. Read: the token plus the relayed private key is a complete credentials bundle.
+// A redirect-mode flow lands back on your page; a popup signals its opener and closes.
+const finish = (res, flow, outcome) =>
+  flow.mode === "redirect"
+    ? res.redirect(302, `/?connect=${outcome}`)
+    : res.send(closePage(outcome));
+const closePage = (
+  outcome,
+) => `<!doctype html><p>${outcome === "connected" ? "Connected — you can close this window." : "Cancelled."}</p>
+<script>try{new BroadcastChannel("bank-connect").postMessage(${JSON.stringify(outcome)})}catch{}setTimeout(()=>window.close(),300)</script>`;
+
+// 3. Read (inside any handler that has the stored pair): the token plus the relayed private key
+//    is a complete credentials bundle.
+const { token, privateKey } = await bundles.get(req.session.id);
 const client = OpenBankingClient.fromTokenResponse(token, privateKey);
 const accounts = await client.getAccounts();
 ```

--- a/node/README.md
+++ b/node/README.md
@@ -47,6 +47,70 @@ const client = new OpenBankingClient({ apiBaseUrl, apiKey, privateKeyPkcs8 });
 Every request carries a `User-Agent: open-banking-io/node/<version>` header and a default 30s timeout
 (override via the `timeoutMs` option) so a hung connection can't block forever.
 
+## Partner Connect (OAuth 2.0 + PKCE)
+
+Partners let their users connect banks through open-banking.io and receive a delegated key plus the
+user's private key — a standard authorization-code flow with PKCE and `form_post`, documented at
+[open-banking.io/en/docs/partners](https://open-banking.io/en/docs/partners). The `connect` helpers
+cover every step; keep the client secret and the verifier on your server.
+
+```ts
+import {
+  buildAuthorizeUrl,
+  createPkce,
+  createState,
+  discover,
+  exchangeCode,
+  parseRelay,
+  OpenBankingClient,
+} from "@open-banking-io/client";
+
+const ISSUER = "https://open-banking.io";
+
+// 1. Start: keep the verifier server-side, keyed by state, and send the browser to the URL.
+app.get("/connect", async (req, res) => {
+  const pkce = createPkce();
+  const state = createState();
+  await flows.put(state, { verifier: pkce.verifier, sessionId: req.session.id });
+  res.redirect(
+    buildAuthorizeUrl({
+      issuer: ISSUER,
+      clientId: CLIENT_ID,
+      redirectUri: `${SELF_URL}/callback`,
+      state,
+      codeChallenge: pkce.challenge,
+      challenge: "pin_code", // popup mode; omit for a redirect flow
+    }),
+  );
+});
+
+// 2. Callback: the consent page form-posts code, state, iss, privateKey and publicKey.
+app.post("/callback", async (req, res) => {
+  const { issuer } = await discover(ISSUER);
+  const flow = await flows.take(req.body.state);
+  const relay = parseRelay(req.body, { expectedState: flow?.state ?? "", issuer });
+  const token = await exchangeCode({
+    issuer,
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    code: relay.code,
+    codeVerifier: flow.verifier,
+    redirectUri: `${SELF_URL}/callback`,
+  });
+  await bundles.put(flow.sessionId, { token, privateKey: relay.privateKey });
+  res.render("close");
+});
+
+// 3. Read: the token plus the relayed private key is a complete credentials bundle.
+const client = OpenBankingClient.fromTokenResponse(token, privateKey);
+const accounts = await client.getAccounts();
+```
+
+`parseRelay` throws a `RelayError` (`oauth_error`, `state_mismatch`, `issuer_mismatch`,
+`missing_code`, `missing_private_key`) and compares `state` and `iss` in constant time;
+`exchangeCode`, `revokeToken` and `userinfo` throw an `OAuthError` carrying the RFC 6749 `error`
+and `error_description`. An `invalid_grant` is terminal for that code — restart the flow.
+
 ## Money
 
 Amounts (`balance.amount`, `transaction.amount`, `transaction.balanceAfterTransaction`) are exposed

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-banking-io/client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-banking-io/client",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-banking-io/client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Server-to-server client for open-banking.io: API-key auth + client-side decryption of the zero-knowledge data envelopes with your exported private key.",
   "type": "module",
   "license": "MIT",

--- a/node/src/client.ts
+++ b/node/src/client.ts
@@ -1,3 +1,4 @@
+import { bundleFromToken, type TokenResponse } from "./connect.js";
 import { readFileSync } from "node:fs";
 import { decryptTo, importPrivateKey, type CryptoKey } from "./envelope.js";
 import { USER_AGENT } from "./version.js";
@@ -86,6 +87,18 @@ export class OpenBankingClient {
       timeoutMs: overrides.timeoutMs,
       fetch: overrides.fetch,
     });
+  }
+
+  /**
+   * Builds a client from a Partner Connect token response and the private key the consent page
+   * relayed — see {@link exchangeCode} and {@link parseRelay}.
+   */
+  static fromTokenResponse(
+    token: TokenResponse,
+    privateKey: string,
+    overrides: Partial<Pick<OpenBankingClientOptions, "fetch" | "timeoutMs">> = {},
+  ): OpenBankingClient {
+    return OpenBankingClient.fromBundle(bundleFromToken(token, privateKey), overrides);
   }
 
   /** Lists the user's accounts with all sensitive fields decrypted. */

--- a/node/src/connect.ts
+++ b/node/src/connect.ts
@@ -78,9 +78,18 @@ export interface ConnectRelay {
 }
 
 export type RelayErrorCode =
-  "oauth_error" | "state_mismatch" | "issuer_mismatch" | "missing_code" | "missing_private_key";
+  | "access_denied"
+  | "oauth_error"
+  | "state_mismatch"
+  | "issuer_mismatch"
+  | "missing_code"
+  | "missing_private_key";
 
-/** Thrown by {@link parseRelay}. `code` says why; for `oauth_error` the server's fields are attached. */
+/**
+ * Thrown by {@link parseRelay}. `code` says why: `access_denied` is the user pressing "Back to the
+ * partner" or declining (a normal outcome), `oauth_error` any other error the server relayed (the
+ * fields are attached), the rest are validation failures on your side.
+ */
 export class RelayError extends Error {
   readonly code: RelayErrorCode;
   readonly error?: string;
@@ -125,10 +134,14 @@ export function parseRelay(input: RelayInput, options: ParseRelayOptions): Conne
   const error = read("error");
   if (error) {
     const description = read("error_description");
-    throw new RelayError("oauth_error", description ? `${error}: ${description}` : error, {
-      error,
-      errorDescription: description || undefined,
-    });
+    throw new RelayError(
+      error === "access_denied" ? "access_denied" : "oauth_error",
+      description ? `${error}: ${description}` : error,
+      {
+        error,
+        errorDescription: description || undefined,
+      },
+    );
   }
 
   if (!options.expectedState || !constantTimeEqual(read("state"), options.expectedState)) {

--- a/node/src/connect.ts
+++ b/node/src/connect.ts
@@ -389,7 +389,9 @@ function endpoint(issuer: string, path: string): string {
 }
 
 function trimSlash(value: string): string {
-  return value.replace(/\/+$/, "");
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") end--;
+  return value.slice(0, end);
 }
 
 function basicAuth(clientId: string, clientSecret: string): string {

--- a/node/src/connect.ts
+++ b/node/src/connect.ts
@@ -125,8 +125,9 @@ export interface ParseRelayOptions {
 export type RelayInput = string | URLSearchParams | FormData | Record<string, unknown>;
 
 /**
- * Validates the form_post relay: an OAuth error becomes a {@link RelayError} (`oauth_error`); then
- * `state` (constant time), `iss`, `code` and `privateKey` are checked in that order.
+ * Validates the form_post relay: `state` (constant time) and `iss` first, so a relayed error is only
+ * honoured for this flow from this issuer; then an OAuth error becomes a {@link RelayError}, and
+ * `code` and `privateKey` are checked.
  */
 export function parseRelay(input: RelayInput, options: ParseRelayOptions): ConnectRelay {
   const fields = toRecord(input);
@@ -134,19 +135,6 @@ export function parseRelay(input: RelayInput, options: ParseRelayOptions): Conne
     const value = fields[name];
     return typeof value === "string" ? value : "";
   };
-
-  const error = read("error");
-  if (error) {
-    const description = read("error_description");
-    throw new RelayError(
-      error === "access_denied" ? "access_denied" : "oauth_error",
-      description ? `${error}: ${description}` : error,
-      {
-        error,
-        errorDescription: description || undefined,
-      },
-    );
-  }
 
   if (!options.expectedState || !constantTimeEqual(read("state"), options.expectedState)) {
     throw new RelayError("state_mismatch", "The relayed state does not match this flow");
@@ -160,6 +148,19 @@ export function parseRelay(input: RelayInput, options: ParseRelayOptions): Conne
     !constantTimeEqual(trimSlash(iss), trimSlash(options.issuer))
   ) {
     throw new RelayError("issuer_mismatch", "The relayed iss is not the expected issuer");
+  }
+
+  const error = read("error");
+  if (error) {
+    const description = read("error_description");
+    throw new RelayError(
+      error === "access_denied" ? "access_denied" : "oauth_error",
+      description ? `${error}: ${description}` : error,
+      {
+        error,
+        errorDescription: description || undefined,
+      },
+    );
   }
 
   const code = read("code");
@@ -185,7 +186,7 @@ export class OAuthError extends Error {
   }
 }
 
-interface HttpOptions {
+export interface HttpOptions {
   /** Custom `fetch`, e.g. for tests. Defaults to the global. */
   fetch?: typeof globalThis.fetch;
   /** Per-request timeout; defaults to 30s. */
@@ -382,11 +383,11 @@ export async function discover(issuer: string, options: HttpOptions = {}): Promi
   if (!response.ok)
     throw new OAuthError(response.status, "discovery_failed", `HTTP ${response.status}`);
   const metadata = (await response.json()) as ServerMetadata;
-  if (trimSlash(metadata.issuer) !== key) {
+  if (typeof metadata.issuer !== "string" || trimSlash(metadata.issuer) !== key) {
     throw new OAuthError(
       response.status,
       "discovery_failed",
-      `Issuer mismatch: ${metadata.issuer}`,
+      `Issuer mismatch: ${String(metadata.issuer)}`,
     );
   }
   discoveryCache.set(key, { metadata, expiresAt: Date.now() + DISCOVERY_TTL_MS });
@@ -465,13 +466,10 @@ async function post(
 
 async function request(url: string, init: RequestInit, options: HttpOptions): Promise<Response> {
   const fetchImpl = options.fetch ?? fetch;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
-  try {
-    return await fetchImpl(url, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timer);
-  }
+  return fetchImpl(url, {
+    ...init,
+    signal: AbortSignal.timeout(options.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+  });
 }
 
 async function throwIfOAuthError(response: Response): Promise<void> {

--- a/node/src/connect.ts
+++ b/node/src/connect.ts
@@ -1,0 +1,473 @@
+// Partner Connect: the OAuth 2.0 authorization-code flow (PKCE, form_post) that hands a partner an
+// API key and the user's private key. Documented at https://open-banking.io/en/docs/partners.
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import type { CredentialsBundle } from "./models.js";
+import { USER_AGENT } from "./version.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** The relay fields the consent page form-posts to a redirect URI, in wire order. */
+export const CONNECT_RELAY_FIELDS = ["code", "state", "iss", "privateKey", "publicKey"] as const;
+
+export interface Pkce {
+  /** The `code_verifier` to keep server-side and send on the token request. */
+  verifier: string;
+  /** The `code_challenge` to send on the authorize request. */
+  challenge: string;
+  method: "S256";
+}
+
+/** A fresh PKCE pair (RFC 7636): 32 random bytes, base64url, S256 challenge. */
+export function createPkce(): Pkce {
+  const verifier = randomBytes(32).toString("base64url");
+  return { verifier, challenge: pkceChallenge(verifier), method: "S256" };
+}
+
+/** The S256 challenge for a verifier — exposed so a stored verifier can be re-checked. */
+export function pkceChallenge(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+/** A fresh opaque `state` (16 random bytes, base64url). */
+export function createState(): string {
+  return randomBytes(16).toString("base64url");
+}
+
+export interface AuthorizeUrlOptions {
+  /** The issuer, e.g. `https://open-banking.io`. */
+  issuer: string;
+  clientId: string;
+  /** One of the client's registered redirect URIs, character for character. */
+  redirectUri: string;
+  state: string;
+  /** From {@link createPkce}. */
+  codeChallenge: string;
+  /** Defaults to `accounts.read`, the only scope. */
+  scope?: string;
+  /** Prefills the email on the login page; never authenticates. */
+  loginHint?: string;
+  /** `pin_code` keeps a popup journey inside the popup (typed emailed code instead of a magic link). */
+  challenge?: "pin_code";
+}
+
+/** The `/oauth/authorize` URL for a top-level browser navigation. */
+export function buildAuthorizeUrl(options: AuthorizeUrlOptions): string {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: options.clientId,
+    redirect_uri: options.redirectUri,
+    scope: options.scope ?? "accounts.read",
+    state: options.state,
+    code_challenge: options.codeChallenge,
+    code_challenge_method: "S256",
+  });
+  if (options.loginHint) params.set("login_hint", options.loginHint);
+  if (options.challenge) params.set("challenge", options.challenge);
+  return `${endpoint(options.issuer, "/oauth/authorize")}?${params.toString()}`;
+}
+
+/** What the consent page relayed to the redirect URI. */
+export interface ConnectRelay {
+  code: string;
+  state: string;
+  /** Present on current servers (RFC 9207); empty string from older ones. */
+  iss: string;
+  /** The user's base64 PKCS#8 private key. A credential: never log it. */
+  privateKey: string;
+  publicKey: string;
+}
+
+export type RelayErrorCode =
+  | "oauth_error"
+  | "state_mismatch"
+  | "issuer_mismatch"
+  | "missing_code"
+  | "missing_private_key";
+
+/** Thrown by {@link parseRelay}. `code` says why; for `oauth_error` the server's fields are attached. */
+export class RelayError extends Error {
+  readonly code: RelayErrorCode;
+  readonly error?: string;
+  readonly errorDescription?: string;
+
+  constructor(
+    code: RelayErrorCode,
+    message: string,
+    oauth?: { error: string; errorDescription?: string },
+  ) {
+    super(message);
+    this.name = "RelayError";
+    this.code = code;
+    this.error = oauth?.error;
+    this.errorDescription = oauth?.errorDescription;
+  }
+}
+
+export interface ParseRelayOptions {
+  /** The `state` this flow was started with. Compared in constant time. */
+  expectedState: string;
+  /** When set, `iss` must equal it (trailing slashes ignored). */
+  issuer?: string;
+  /** Require `iss` to be present even when `issuer` is not checked. Default: only when `issuer` is set. */
+  requireIss?: boolean;
+}
+
+/** A form body, `URLSearchParams`, parsed body object, or JSON string. */
+export type RelayInput = string | URLSearchParams | FormData | Record<string, unknown>;
+
+/**
+ * Validates the form_post relay: an OAuth error becomes a {@link RelayError} (`oauth_error`); then
+ * `state` (constant time), `iss`, `code` and `privateKey` are checked in that order.
+ */
+export function parseRelay(input: RelayInput, options: ParseRelayOptions): ConnectRelay {
+  const fields = toRecord(input);
+  const read = (name: string): string => {
+    const value = fields[name];
+    return typeof value === "string" ? value : "";
+  };
+
+  const error = read("error");
+  if (error) {
+    const description = read("error_description");
+    throw new RelayError("oauth_error", description ? `${error}: ${description}` : error, {
+      error,
+      errorDescription: description || undefined,
+    });
+  }
+
+  if (!options.expectedState || !constantTimeEqual(read("state"), options.expectedState)) {
+    throw new RelayError("state_mismatch", "The relayed state does not match this flow");
+  }
+
+  const iss = read("iss");
+  const wantIss = options.issuer !== undefined || options.requireIss === true;
+  if (wantIss && !iss) throw new RelayError("issuer_mismatch", "The relay carries no iss");
+  if (
+    options.issuer !== undefined &&
+    !constantTimeEqual(trimSlash(iss), trimSlash(options.issuer))
+  ) {
+    throw new RelayError("issuer_mismatch", "The relayed iss is not the expected issuer");
+  }
+
+  const code = read("code");
+  if (!code) throw new RelayError("missing_code", "The relay carries no authorization code");
+  const privateKey = read("privateKey");
+  if (!privateKey) throw new RelayError("missing_private_key", "The relay carries no private key");
+
+  return { code, state: read("state"), iss, privateKey, publicKey: read("publicKey") };
+}
+
+/** An RFC 6749 §5.2 error body from the token or revocation endpoint. */
+export class OAuthError extends Error {
+  readonly status: number;
+  readonly error: string;
+  readonly errorDescription?: string;
+
+  constructor(status: number, error: string, errorDescription?: string) {
+    super(errorDescription ? `${error}: ${errorDescription}` : error);
+    this.name = "OAuthError";
+    this.status = status;
+    this.error = error;
+    this.errorDescription = errorDescription;
+  }
+}
+
+interface HttpOptions {
+  /** Custom `fetch`, e.g. for tests. Defaults to the global. */
+  fetch?: typeof globalThis.fetch;
+  /** Per-request timeout; defaults to 30s. */
+  timeoutMs?: number;
+}
+
+export interface ExchangeCodeOptions extends HttpOptions {
+  issuer: string;
+  clientId: string;
+  clientSecret: string;
+  /** From the relay. */
+  code: string;
+  /** From {@link createPkce}, kept server-side. */
+  codeVerifier: string;
+  /** The redirect URI used on the authorize request; sent when given and must match. */
+  redirectUri?: string;
+}
+
+/** The token endpoint's response. `accessToken` and `apiKey` are the same key. */
+export interface TokenResponse {
+  accessToken: string;
+  tokenType: string;
+  expiresIn: number;
+  scope: string;
+  apiKey: string;
+  apiBaseUrl: string;
+  /** The tenant subject the key reads for. */
+  user: string;
+}
+
+interface TokenResponseWire {
+  access_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  scope?: string;
+  apiKey?: string;
+  apiBaseUrl?: string;
+  user?: string;
+}
+
+/** Exchanges the relayed code for the key, server to server, with HTTP Basic client authentication. */
+export async function exchangeCode(options: ExchangeCodeOptions): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: options.code,
+    code_verifier: options.codeVerifier,
+  });
+  if (options.redirectUri) body.set("redirect_uri", options.redirectUri);
+
+  const response = await post(
+    endpoint(options.issuer, "/oauth/token"),
+    body,
+    {
+      Authorization: basicAuth(options.clientId, options.clientSecret),
+      Accept: "application/json",
+    },
+    options,
+  );
+  await throwIfOAuthError(response);
+
+  const wire = (await response.json()) as TokenResponseWire;
+  const accessToken = wire.access_token ?? wire.apiKey;
+  if (!accessToken)
+    throw new OAuthError(
+      response.status,
+      "invalid_response",
+      "The token response carries no access token",
+    );
+  return {
+    accessToken,
+    tokenType: wire.token_type ?? "Bearer",
+    expiresIn: wire.expires_in ?? 0,
+    scope: wire.scope ?? "",
+    apiKey: wire.apiKey ?? accessToken,
+    apiBaseUrl: wire.apiBaseUrl ?? trimSlash(options.issuer),
+    user: wire.user ?? "",
+  };
+}
+
+export interface RevokeTokenOptions extends HttpOptions {
+  issuer: string;
+  clientId: string;
+  clientSecret: string;
+  /** The key to revoke. Only keys issued to this client are touched; an unknown key still succeeds. */
+  token: string;
+}
+
+/** RFC 7009 revocation. Resolves on 200; throws {@link OAuthError} on a client-authentication failure. */
+export async function revokeToken(options: RevokeTokenOptions): Promise<void> {
+  const body = new URLSearchParams({ token: options.token, token_type_hint: "access_token" });
+  const response = await post(
+    endpoint(options.issuer, "/oauth/revoke"),
+    body,
+    {
+      Authorization: basicAuth(options.clientId, options.clientSecret),
+    },
+    options,
+  );
+  await throwIfOAuthError(response);
+}
+
+export interface UserinfoOptions extends HttpOptions {
+  issuer: string;
+  accessToken: string;
+}
+
+export interface Userinfo {
+  sub: string;
+  email: string;
+  partnerId: string | null;
+  clientId: string | null;
+  scope: string;
+  expiresAt: string | null;
+}
+
+interface UserinfoWire {
+  sub: string;
+  email: string;
+  partner_id: string | null;
+  client_id: string | null;
+  scope: string;
+  expires_at: string | null;
+}
+
+/** What a key reads for. Throws {@link OAuthError} with status 401 when the key is revoked or expired. */
+export async function userinfo(options: UserinfoOptions): Promise<Userinfo> {
+  const response = await request(
+    endpoint(options.issuer, "/oauth/userinfo"),
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${options.accessToken}`,
+        Accept: "application/json",
+        "User-Agent": USER_AGENT,
+      },
+    },
+    options,
+  );
+  await throwIfOAuthError(response);
+  const wire = (await response.json()) as UserinfoWire;
+  return {
+    sub: wire.sub,
+    email: wire.email,
+    partnerId: wire.partner_id ?? null,
+    clientId: wire.client_id ?? null,
+    scope: wire.scope,
+    expiresAt: wire.expires_at ?? null,
+  };
+}
+
+/** RFC 8414 metadata with the `open_banking_io` extension. */
+export interface ServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  revocation_endpoint: string;
+  scopes_supported: string[];
+  response_types_supported: string[];
+  response_modes_supported: string[];
+  grant_types_supported: string[];
+  token_endpoint_auth_methods_supported: string[];
+  code_challenge_methods_supported: string[];
+  service_documentation?: string;
+  open_banking_io: {
+    userinfo_endpoint: string;
+    api_base_url: string;
+    api_key_header: string;
+    bearer_supported: boolean;
+    key_relay: { response_mode: string; fields: string[] };
+    documentation: string;
+  };
+}
+
+const discoveryCache = new Map<string, { metadata: ServerMetadata; expiresAt: number }>();
+const DISCOVERY_TTL_MS = 60 * 60 * 1000;
+
+/** Fetches `/.well-known/oauth-authorization-server`, cached per issuer for an hour. */
+export async function discover(issuer: string, options: HttpOptions = {}): Promise<ServerMetadata> {
+  const key = trimSlash(issuer);
+  const cached = discoveryCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) return cached.metadata;
+
+  const response = await request(
+    `${key}/.well-known/oauth-authorization-server`,
+    {
+      method: "GET",
+      headers: { Accept: "application/json", "User-Agent": USER_AGENT },
+    },
+    options,
+  );
+  if (!response.ok)
+    throw new OAuthError(response.status, "discovery_failed", `HTTP ${response.status}`);
+  const metadata = (await response.json()) as ServerMetadata;
+  if (trimSlash(metadata.issuer) !== key) {
+    throw new OAuthError(
+      response.status,
+      "discovery_failed",
+      `Issuer mismatch: ${metadata.issuer}`,
+    );
+  }
+  discoveryCache.set(key, { metadata, expiresAt: Date.now() + DISCOVERY_TTL_MS });
+  return metadata;
+}
+
+/** The credentials bundle the data client reads with: the key plus the relayed private key. */
+export function bundleFromToken(token: TokenResponse, privateKey: string): CredentialsBundle {
+  return {
+    service: "open-banking.io",
+    apiBaseUrl: token.apiBaseUrl,
+    user: token.user,
+    apiKey: token.accessToken,
+    encryptionKey: { scheme: "ecdh-p256-hkdf-aes-256-gcm", curve: "P-256", privateKey },
+  };
+}
+
+function endpoint(issuer: string, path: string): string {
+  return trimSlash(issuer) + path;
+}
+
+function trimSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function basicAuth(clientId: string, clientSecret: string): string {
+  const pair = `${encodeURIComponent(clientId)}:${encodeURIComponent(clientSecret)}`;
+  return `Basic ${Buffer.from(pair, "utf8").toString("base64")}`;
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const x = createHash("sha256").update(a, "utf8").digest();
+  const y = createHash("sha256").update(b, "utf8").digest();
+  return timingSafeEqual(x, y) && a.length === b.length;
+}
+
+function toRecord(input: RelayInput): Record<string, unknown> {
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    if (trimmed.startsWith("{")) return JSON.parse(trimmed) as Record<string, unknown>;
+    return Object.fromEntries(new URLSearchParams(trimmed));
+  }
+  if (input instanceof URLSearchParams) return Object.fromEntries(input);
+  if (input instanceof FormData) {
+    const record: Record<string, unknown> = {};
+    input.forEach((value, name) => {
+      if (typeof value === "string") record[name] = value;
+    });
+    return record;
+  }
+  return input;
+}
+
+async function post(
+  url: string,
+  body: URLSearchParams,
+  headers: Record<string, string>,
+  options: HttpOptions,
+): Promise<Response> {
+  return request(
+    url,
+    {
+      method: "POST",
+      headers: {
+        ...headers,
+        "Content-Type": "application/x-www-form-urlencoded",
+        "User-Agent": USER_AGENT,
+      },
+      body: body.toString(),
+    },
+    options,
+  );
+}
+
+async function request(url: string, init: RequestInit, options: HttpOptions): Promise<Response> {
+  const fetchImpl = options.fetch ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    return await fetchImpl(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function throwIfOAuthError(response: Response): Promise<void> {
+  if (response.ok) return;
+  let error = "http_error";
+  let description: string | undefined = `HTTP ${response.status}`;
+  try {
+    const body = (await response.json()) as { error?: string; error_description?: string };
+    if (body.error) {
+      error = body.error;
+      description = body.error_description;
+    }
+  } catch {
+    // A non-JSON error body keeps the HTTP status as the description.
+  }
+  throw new OAuthError(response.status, error, description);
+}

--- a/node/src/connect.ts
+++ b/node/src/connect.ts
@@ -78,11 +78,7 @@ export interface ConnectRelay {
 }
 
 export type RelayErrorCode =
-  | "oauth_error"
-  | "state_mismatch"
-  | "issuer_mismatch"
-  | "missing_code"
-  | "missing_private_key";
+  "oauth_error" | "state_mismatch" | "issuer_mismatch" | "missing_code" | "missing_private_key";
 
 /** Thrown by {@link parseRelay}. `code` says why; for `oauth_error` the server's fields are attached. */
 export class RelayError extends Error {

--- a/node/src/connect.ts
+++ b/node/src/connect.ts
@@ -48,6 +48,8 @@ export interface AuthorizeUrlOptions {
   loginHint?: string;
   /** `pin_code` keeps a popup journey inside the popup (typed emailed code instead of a magic link). */
   challenge?: "pin_code";
+  /** Space-separated locales; the first one the server publishes forces the language of every screen. */
+  uiLocales?: string;
 }
 
 /** The `/oauth/authorize` URL for a top-level browser navigation. */
@@ -60,9 +62,11 @@ export function buildAuthorizeUrl(options: AuthorizeUrlOptions): string {
     state: options.state,
     code_challenge: options.codeChallenge,
     code_challenge_method: "S256",
+    response_mode: "form_post",
   });
   if (options.loginHint) params.set("login_hint", options.loginHint);
   if (options.challenge) params.set("challenge", options.challenge);
+  if (options.uiLocales) params.set("ui_locales", options.uiLocales);
   return `${endpoint(options.issuer, "/oauth/authorize")}?${params.toString()}`;
 }
 
@@ -343,13 +347,16 @@ export interface ServerMetadata {
   response_modes_supported: string[];
   grant_types_supported: string[];
   token_endpoint_auth_methods_supported: string[];
+  revocation_endpoint_auth_methods_supported?: string[];
   code_challenge_methods_supported: string[];
+  authorization_response_iss_parameter_supported?: boolean;
   service_documentation?: string;
   open_banking_io: {
     userinfo_endpoint: string;
     api_base_url: string;
     api_key_header: string;
     bearer_supported: boolean;
+    login_challenges_supported?: string[];
     key_relay: { response_mode: string; fields: string[] };
     documentation: string;
   };

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -19,6 +19,7 @@ export type {
   AuthorizeUrlOptions,
   ConnectRelay,
   ExchangeCodeOptions,
+  HttpOptions,
   ParseRelayOptions,
   Pkce,
   RelayErrorCode,

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -1,5 +1,34 @@
 export { OpenBankingClient } from "./client.js";
 export { decryptEnvelope, decryptTo, importPrivateKey } from "./envelope.js";
+export {
+  buildAuthorizeUrl,
+  bundleFromToken,
+  CONNECT_RELAY_FIELDS,
+  createPkce,
+  createState,
+  discover,
+  exchangeCode,
+  OAuthError,
+  parseRelay,
+  pkceChallenge,
+  RelayError,
+  revokeToken,
+  userinfo,
+} from "./connect.js";
+export type {
+  AuthorizeUrlOptions,
+  ConnectRelay,
+  ExchangeCodeOptions,
+  ParseRelayOptions,
+  Pkce,
+  RelayErrorCode,
+  RelayInput,
+  RevokeTokenOptions,
+  ServerMetadata,
+  TokenResponse,
+  Userinfo,
+  UserinfoOptions,
+} from "./connect.js";
 export type {
   Account,
   Balance,

--- a/node/test/connect.test.ts
+++ b/node/test/connect.test.ts
@@ -179,6 +179,23 @@ describe("parseRelay", () => {
     ).toThrow(/private key/);
   });
 
+  it("names a cancel as access_denied, the normal outcome it is", () => {
+    try {
+      parseRelay(
+        {
+          error: "access_denied",
+          error_description: "the user declined the authorization",
+          state: "s123",
+        },
+        { expectedState: "s123" },
+      );
+      expect.unreachable();
+    } catch (e) {
+      expect((e as RelayError).code).toBe("access_denied");
+      expect((e as RelayError).error).toBe("access_denied");
+    }
+  });
+
   it("surfaces an OAuth error relay before anything else", () => {
     try {
       parseRelay(

--- a/node/test/connect.test.ts
+++ b/node/test/connect.test.ts
@@ -90,6 +90,7 @@ describe("buildAuthorizeUrl", () => {
         codeChallenge: "c456",
         loginHint: "alice@example.com",
         challenge: "pin_code",
+        uiLocales: "da-DK en",
       }),
     );
     expect(url.origin + url.pathname).toBe(ISSUER + "/oauth/authorize");
@@ -101,8 +102,10 @@ describe("buildAuthorizeUrl", () => {
       state: "s123",
       code_challenge: "c456",
       code_challenge_method: "S256",
+      response_mode: "form_post",
       login_hint: "alice@example.com",
       challenge: "pin_code",
+      ui_locales: "da-DK en",
     });
   });
 
@@ -118,6 +121,7 @@ describe("buildAuthorizeUrl", () => {
     );
     expect(url.searchParams.has("login_hint")).toBe(false);
     expect(url.searchParams.has("challenge")).toBe(false);
+    expect(url.searchParams.has("ui_locales")).toBe(false);
   });
 });
 
@@ -398,12 +402,15 @@ describe("discover", () => {
     response_modes_supported: ["form_post"],
     grant_types_supported: ["authorization_code"],
     token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
+    revocation_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
     code_challenge_methods_supported: ["S256"],
+    authorization_response_iss_parameter_supported: true,
     open_banking_io: {
       userinfo_endpoint: ISSUER + "/oauth/userinfo",
       api_base_url: ISSUER,
       api_key_header: "X-Api-Key",
       bearer_supported: true,
+      login_challenges_supported: ["pin_code"],
       key_relay: { response_mode: "form_post", fields: [...CONNECT_RELAY_FIELDS] },
       documentation: "https://open-banking.io/en/docs/partners",
     },

--- a/node/test/connect.test.ts
+++ b/node/test/connect.test.ts
@@ -1,0 +1,443 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildAuthorizeUrl,
+  bundleFromToken,
+  CONNECT_RELAY_FIELDS,
+  createPkce,
+  createState,
+  discover,
+  exchangeCode,
+  OAuthError,
+  OpenBankingClient,
+  parseRelay,
+  pkceChallenge,
+  RelayError,
+  revokeToken,
+  userinfo,
+} from "../src/index.js";
+
+const ISSUER = "https://staging.open-banking.io";
+
+function jsonResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+type Call = { url: string; init: RequestInit };
+function fakeFetch(respond: (call: Call) => Response): {
+  fetch: typeof fetch;
+  calls: Call[];
+  first: () => Call;
+} {
+  const calls: Call[] = [];
+  const impl = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const call = { url, init: init ?? {} };
+    calls.push(call);
+    return Promise.resolve(respond(call));
+  });
+  const first = (): Call => {
+    const call = calls[0];
+    if (!call) throw new Error("fetch was not called");
+    return call;
+  };
+  return { fetch: impl, calls, first };
+}
+
+const fixtures = fileURLToPath(new URL("../../fixtures/", import.meta.url));
+const readJson = <T = unknown>(name: string): T =>
+  JSON.parse(readFileSync(fixtures + name, "utf8")) as T;
+const PRIVATE_KEY = readJson<{ privateKeyPkcs8B64: string }>("keypair.json").privateKeyPkcs8B64;
+
+describe("PKCE and state", () => {
+  it("derives the RFC 7636 appendix B challenge", () => {
+    expect(pkceChallenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")).toBe(
+      "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+    );
+  });
+
+  it("creates a 43-char base64url verifier with a matching S256 challenge", () => {
+    const pkce = createPkce();
+    expect(pkce.verifier).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(pkce.method).toBe("S256");
+    expect(pkce.challenge).toBe(createHash("sha256").update(pkce.verifier).digest("base64url"));
+    expect(createPkce().verifier).not.toBe(pkce.verifier);
+  });
+
+  it("creates unpredictable states", () => {
+    expect(createState()).toMatch(/^[A-Za-z0-9_-]{22}$/);
+    expect(createState()).not.toBe(createState());
+  });
+});
+
+describe("buildAuthorizeUrl", () => {
+  it("builds the exact authorize request", () => {
+    const url = new URL(
+      buildAuthorizeUrl({
+        issuer: ISSUER + "/",
+        clientId: "obc_demo",
+        redirectUri: "https://app.example.com/callback",
+        state: "s123",
+        codeChallenge: "c456",
+        loginHint: "alice@example.com",
+        challenge: "pin_code",
+      }),
+    );
+    expect(url.origin + url.pathname).toBe(ISSUER + "/oauth/authorize");
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      response_type: "code",
+      client_id: "obc_demo",
+      redirect_uri: "https://app.example.com/callback",
+      scope: "accounts.read",
+      state: "s123",
+      code_challenge: "c456",
+      code_challenge_method: "S256",
+      login_hint: "alice@example.com",
+      challenge: "pin_code",
+    });
+  });
+
+  it("omits the optional hints when not given", () => {
+    const url = new URL(
+      buildAuthorizeUrl({
+        issuer: ISSUER,
+        clientId: "c",
+        redirectUri: "https://x/cb",
+        state: "s",
+        codeChallenge: "ch",
+      }),
+    );
+    expect(url.searchParams.has("login_hint")).toBe(false);
+    expect(url.searchParams.has("challenge")).toBe(false);
+  });
+});
+
+describe("parseRelay", () => {
+  const relay = { code: "code1", state: "s123", iss: ISSUER, privateKey: "pk", publicKey: "pub" };
+
+  it("names the wire fields in order", () => {
+    expect([...CONNECT_RELAY_FIELDS]).toEqual(["code", "state", "iss", "privateKey", "publicKey"]);
+  });
+
+  it("accepts a form body, URLSearchParams, a record and JSON", () => {
+    const expected = { ...relay };
+    expect(
+      parseRelay(new URLSearchParams(relay).toString(), { expectedState: "s123", issuer: ISSUER }),
+    ).toEqual(expected);
+    expect(
+      parseRelay(new URLSearchParams(relay), { expectedState: "s123", issuer: ISSUER }),
+    ).toEqual(expected);
+    expect(parseRelay(relay, { expectedState: "s123", issuer: ISSUER })).toEqual(expected);
+    expect(parseRelay(JSON.stringify(relay), { expectedState: "s123", issuer: ISSUER })).toEqual(
+      expected,
+    );
+  });
+
+  it("rejects a state mismatch, including a length mismatch and an empty expectation", () => {
+    expect(() => parseRelay(relay, { expectedState: "s124" })).toThrow(RelayError);
+    expect(() => parseRelay(relay, { expectedState: "s12" })).toThrow(/state/);
+    expect(() => parseRelay(relay, { expectedState: "" })).toThrow(/state/);
+    try {
+      parseRelay(relay, { expectedState: "nope" });
+    } catch (e) {
+      expect((e as RelayError).code).toBe("state_mismatch");
+    }
+  });
+
+  it("checks the issuer when asked, ignoring trailing slashes, and tolerates its absence otherwise", () => {
+    expect(
+      parseRelay({ ...relay, iss: ISSUER + "/" }, { expectedState: "s123", issuer: ISSUER }).iss,
+    ).toBe(ISSUER + "/");
+    expect(() =>
+      parseRelay(
+        { ...relay, iss: "https://evil.example" },
+        { expectedState: "s123", issuer: ISSUER },
+      ),
+    ).toThrow(/issuer/);
+    expect(() =>
+      parseRelay({ ...relay, iss: "" }, { expectedState: "s123", issuer: ISSUER }),
+    ).toThrow(/iss/);
+    expect(() =>
+      parseRelay({ ...relay, iss: "" }, { expectedState: "s123", requireIss: true }),
+    ).toThrow(/iss/);
+    expect(parseRelay({ ...relay, iss: "" }, { expectedState: "s123" }).iss).toBe("");
+  });
+
+  it("requires the code and the private key", () => {
+    expect(() => parseRelay({ ...relay, code: "" }, { expectedState: "s123" })).toThrow(/code/);
+    expect(() =>
+      parseRelay({ ...relay, privateKey: undefined }, { expectedState: "s123" }),
+    ).toThrow(/private key/);
+  });
+
+  it("surfaces an OAuth error relay before anything else", () => {
+    try {
+      parseRelay(
+        { error: "invalid_scope", error_description: "unsupported scope", state: "s123" },
+        { expectedState: "s123" },
+      );
+      expect.unreachable();
+    } catch (e) {
+      const err = e as RelayError;
+      expect(err.code).toBe("oauth_error");
+      expect(err.error).toBe("invalid_scope");
+      expect(err.errorDescription).toBe("unsupported scope");
+      expect(err.message).toBe("invalid_scope: unsupported scope");
+    }
+  });
+});
+
+describe("exchangeCode", () => {
+  const token = {
+    access_token: "ebk_key",
+    token_type: "Bearer",
+    expires_in: 31536000,
+    scope: "accounts.read",
+    apiKey: "ebk_key",
+    apiBaseUrl: ISSUER,
+    user: "wl:p:connect:alice@example.com",
+  };
+
+  it("posts the form-encoded request with HTTP Basic client authentication", async () => {
+    const { fetch, calls, first } = fakeFetch(() => jsonResponse(200, token));
+
+    const result = await exchangeCode({
+      issuer: ISSUER,
+      clientId: "obc_demo",
+      clientSecret: "s3cret:with/odd chars",
+      code: "code1",
+      codeVerifier: "ver",
+      redirectUri: "https://app.example.com/callback",
+      fetch,
+    });
+
+    expect(calls).toHaveLength(1);
+    const call = first();
+    expect(call.url).toBe(ISSUER + "/oauth/token");
+    expect(call.init.method).toBe("POST");
+    const headers = call.init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+    expect(headers.Authorization).toBe(
+      "Basic " + Buffer.from("obc_demo:s3cret%3Awith%2Fodd%20chars").toString("base64"),
+    );
+    expect(headers["User-Agent"]).toMatch(/^open-banking-io\/node\//);
+    expect(call.init.body).toBe(
+      "grant_type=authorization_code&code=code1&code_verifier=ver&redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback",
+    );
+    expect(call.init.signal).toBeInstanceOf(AbortSignal);
+    expect(result).toEqual({
+      accessToken: "ebk_key",
+      tokenType: "Bearer",
+      expiresIn: 31536000,
+      scope: "accounts.read",
+      apiKey: "ebk_key",
+      apiBaseUrl: ISSUER,
+      user: "wl:p:connect:alice@example.com",
+    });
+  });
+
+  it("maps an RFC 6749 error body to OAuthError", async () => {
+    const { fetch } = fakeFetch(() =>
+      jsonResponse(400, {
+        error: "invalid_grant",
+        error_description: "invalid or expired authorization code",
+      }),
+    );
+
+    const promise = exchangeCode({
+      issuer: ISSUER,
+      clientId: "c",
+      clientSecret: "s",
+      code: "x",
+      codeVerifier: "v",
+      fetch,
+    });
+    await expect(promise).rejects.toBeInstanceOf(OAuthError);
+    await expect(promise).rejects.toMatchObject({ status: 400, error: "invalid_grant" });
+  });
+
+  it("reads a first-generation response that only carries apiKey", async () => {
+    const { fetch } = fakeFetch(() =>
+      jsonResponse(200, { apiKey: "ebk_old", apiBaseUrl: ISSUER, user: "u" }),
+    );
+
+    const result = await exchangeCode({
+      issuer: ISSUER,
+      clientId: "c",
+      clientSecret: "s",
+      code: "x",
+      codeVerifier: "v",
+      fetch,
+    });
+
+    expect(result.accessToken).toBe("ebk_old");
+    expect(result.tokenType).toBe("Bearer");
+  });
+
+  it("aborts after the timeout", async () => {
+    const hanging = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_, reject) =>
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted"))),
+        ),
+    );
+
+    await expect(
+      exchangeCode({
+        issuer: ISSUER,
+        clientId: "c",
+        clientSecret: "s",
+        code: "x",
+        codeVerifier: "v",
+        fetch: hanging as unknown as typeof fetch,
+        timeoutMs: 5,
+      }),
+    ).rejects.toThrow(/aborted/);
+  });
+});
+
+describe("revokeToken and userinfo", () => {
+  it("revokes with client authentication and resolves on 200", async () => {
+    const { fetch, first } = fakeFetch(() => new Response(null, { status: 200 }));
+
+    await revokeToken({
+      issuer: ISSUER,
+      clientId: "c",
+      clientSecret: "s",
+      token: "ebk_key",
+      fetch,
+    });
+
+    expect(first().url).toBe(ISSUER + "/oauth/revoke");
+    expect(first().init.body).toBe("token=ebk_key&token_type_hint=access_token");
+    expect((first().init.headers as Record<string, string>).Authorization).toMatch(/^Basic /);
+  });
+
+  it("throws invalid_client on a bad secret", async () => {
+    const { fetch } = fakeFetch(() =>
+      jsonResponse(401, { error: "invalid_client" }, { "WWW-Authenticate": 'Basic realm="oauth"' }),
+    );
+
+    await expect(
+      revokeToken({ issuer: ISSUER, clientId: "c", clientSecret: "bad", token: "t", fetch }),
+    ).rejects.toMatchObject({
+      status: 401,
+      error: "invalid_client",
+    });
+  });
+
+  it("reads userinfo with a Bearer key", async () => {
+    const { fetch, first } = fakeFetch(() =>
+      jsonResponse(200, {
+        sub: "wl:p:connect:a@b",
+        email: "a@b",
+        partner_id: "p",
+        client_id: "c",
+        scope: "accounts.read",
+        expires_at: null,
+      }),
+    );
+
+    const info = await userinfo({ issuer: ISSUER, accessToken: "ebk_key", fetch });
+
+    expect(first().url).toBe(ISSUER + "/oauth/userinfo");
+    expect((first().init.headers as Record<string, string>).Authorization).toBe("Bearer ebk_key");
+    expect(info).toEqual({
+      sub: "wl:p:connect:a@b",
+      email: "a@b",
+      partnerId: "p",
+      clientId: "c",
+      scope: "accounts.read",
+      expiresAt: null,
+    });
+  });
+
+  it("surfaces a revoked key as a 401 OAuthError", async () => {
+    const { fetch } = fakeFetch(() => new Response("", { status: 401 }));
+
+    await expect(
+      userinfo({ issuer: ISSUER, accessToken: "ebk_gone", fetch }),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+describe("discover", () => {
+  const metadata = {
+    issuer: ISSUER,
+    authorization_endpoint: ISSUER + "/oauth/authorize",
+    token_endpoint: ISSUER + "/oauth/token",
+    revocation_endpoint: ISSUER + "/oauth/revoke",
+    scopes_supported: ["accounts.read"],
+    response_types_supported: ["code"],
+    response_modes_supported: ["form_post"],
+    grant_types_supported: ["authorization_code"],
+    token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
+    code_challenge_methods_supported: ["S256"],
+    open_banking_io: {
+      userinfo_endpoint: ISSUER + "/oauth/userinfo",
+      api_base_url: ISSUER,
+      api_key_header: "X-Api-Key",
+      bearer_supported: true,
+      key_relay: { response_mode: "form_post", fields: [...CONNECT_RELAY_FIELDS] },
+      documentation: "https://open-banking.io/en/docs/partners",
+    },
+  };
+
+  it("fetches the well-known document and caches it per issuer", async () => {
+    const { fetch, calls, first } = fakeFetch(() => jsonResponse(200, metadata));
+
+    const one = await discover(ISSUER, { fetch });
+    const two = await discover(ISSUER + "/", { fetch });
+
+    expect(calls).toHaveLength(1);
+    expect(first().url).toBe(ISSUER + "/.well-known/oauth-authorization-server");
+    expect(one.open_banking_io.key_relay.fields).toEqual([...CONNECT_RELAY_FIELDS]);
+    expect(two).toBe(one);
+  });
+
+  it("rejects a document whose issuer does not match", async () => {
+    const { fetch } = fakeFetch(() =>
+      jsonResponse(200, { ...metadata, issuer: "https://evil.example" }),
+    );
+
+    await expect(discover("https://mismatch.example", { fetch })).rejects.toThrow(
+      /Issuer mismatch/,
+    );
+  });
+});
+
+describe("bundleFromToken and OpenBankingClient.fromTokenResponse", () => {
+  const token = {
+    accessToken: "ebk_key",
+    tokenType: "Bearer",
+    expiresIn: 1,
+    scope: "accounts.read",
+    apiKey: "ebk_key",
+    apiBaseUrl: ISSUER,
+    user: "wl:p:connect:a@b",
+  };
+
+  it("builds the credentials bundle the data client reads with", () => {
+    expect(bundleFromToken(token, "pk")).toEqual({
+      service: "open-banking.io",
+      apiBaseUrl: ISSUER,
+      user: "wl:p:connect:a@b",
+      apiKey: "ebk_key",
+      encryptionKey: { scheme: "ecdh-p256-hkdf-aes-256-gcm", curve: "P-256", privateKey: "pk" },
+    });
+  });
+
+  it("constructs a client straight from the token response", () => {
+    const client = OpenBankingClient.fromTokenResponse(token, PRIVATE_KEY);
+    expect(client).toBeInstanceOf(OpenBankingClient);
+  });
+});

--- a/node/test/connect.test.ts
+++ b/node/test/connect.test.ts
@@ -200,6 +200,18 @@ describe("parseRelay", () => {
     }
   });
 
+  it("checks state and iss before honouring a relayed error", () => {
+    expect(() =>
+      parseRelay({ error: "access_denied", state: "other" }, { expectedState: "s123" }),
+    ).toThrow(/state does not match/);
+    expect(() =>
+      parseRelay(
+        { error: "access_denied", state: "s123", iss: "https://evil.example" },
+        { expectedState: "s123", issuer: ISSUER },
+      ),
+    ).toThrow(/not the expected issuer/);
+  });
+
   it("surfaces an OAuth error relay before anything else", () => {
     try {
       parseRelay(
@@ -324,6 +336,31 @@ describe("exchangeCode", () => {
       }),
     ).rejects.toThrow(/aborted/);
   });
+
+  it("keeps the timeout armed while the body is read", async () => {
+    const stalled = vi.fn((_url: string, init?: RequestInit) => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          init?.signal?.addEventListener("abort", () => controller.error(new Error("aborted")));
+        },
+      });
+      return Promise.resolve(
+        new Response(body, { status: 200, headers: { "Content-Type": "application/json" } }),
+      );
+    });
+
+    await expect(
+      exchangeCode({
+        issuer: ISSUER,
+        clientId: "c",
+        clientSecret: "s",
+        code: "x",
+        codeVerifier: "v",
+        fetch: stalled as unknown as typeof fetch,
+        timeoutMs: 5,
+      }),
+    ).rejects.toThrow(/aborted/);
+  });
 });
 
 describe("revokeToken and userinfo", () => {
@@ -435,6 +472,14 @@ describe("discover", () => {
 
     await expect(discover("https://mismatch.example", { fetch })).rejects.toThrow(
       /Issuer mismatch/,
+    );
+  });
+
+  it("rejects a document without an issuer as an OAuthError", async () => {
+    const { fetch } = fakeFetch(() => jsonResponse(200, { ...metadata, issuer: undefined }));
+
+    await expect(discover("https://noissuer.example", { fetch })).rejects.toBeInstanceOf(
+      OAuthError,
     );
   });
 });


### PR DESCRIPTION
Adds a `connect` module to the Node client for the Partner Connect flow (OAuth 2.0 authorization code + PKCE, `form_post` relay): `createPkce`/`createState`, `buildAuthorizeUrl`, `parseRelay` (constant-time `state` and `iss` checks, RFC 6749 error surfacing as `RelayError`), `exchangeCode` (form-encoded, `client_secret_basic`), `revokeToken`, `userinfo`, `discover` (RFC 8414, cached per issuer) and `OpenBankingClient.fromTokenResponse`.

Every request is tested against an injected `fetch` for the exact URL, headers and body; the PKCE vector is the RFC 7636 appendix B one; timeouts abort. Zero new runtime dependencies.

Documented at https://open-banking.io/en/docs/partners (ships with the service PR that adds the standard endpoints). Bumps the package to 1.1.0; tag `node/v1.1.0` via the Release workflow after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Partner Connect OAuth 2.0 authorization with PKCE and `form_post` relay handling.
  * Added authorization URL generation, relay validation, token exchange, revocation, user information, and discovery support.
  * Added client creation from token responses and structured OAuth and relay errors.
* **Documentation**
  * Added Node.js integration guidance and complete authorization-flow examples.
* **Release**
  * Updated the Node package to version 1.1.0 and refreshed release metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->