### PR TITLE
fix(python): strip and validate api_base_url scheme

### DIFF
--- a/python/src/open_banking_io/client.py
+++ b/python/src/open_banking_io/client.py
@@ -63,6 +63,41 @@ def _parse_decimal_nullable(value: str | None) -> Decimal | None:
     return Decimal(value)
 
 
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+
+
+def _normalize_base_url(api_base_url: object) -> str:
+    """Strips, validates and returns the base URL, rejecting anything that would only
+    surface later as an opaque httpx transport error."""
+    if not isinstance(api_base_url, str):
+        if api_base_url is None:
+            raise ValueError("api_base_url is required")
+        raise ValueError(f"api_base_url must be a string (got {type(api_base_url).__name__})")
+
+    url = api_base_url.strip()
+    if not url:
+        raise ValueError("api_base_url is required")
+
+    scheme, _, rest = url.partition("://")
+    scheme = scheme.lower()
+    if not rest or scheme not in ("http", "https"):
+        raise ValueError(f"api_base_url must start with http:// or https:// (got {url!r})")
+
+    if scheme == "http":
+        host = rest.split("/", 1)[0].rsplit("@", 1)[-1]
+        if not host.startswith("["):
+            host = host.split(":", 1)[0]
+        elif "]" in host:
+            host = host[: host.index("]") + 1]
+        if host.lower() not in _LOOPBACK_HOSTS:
+            raise ValueError(
+                "api_base_url must use https:// -- cleartext http:// would send the API key "
+                f"and decrypted session uids over the network (got {url!r})"
+            )
+
+    return url
+
+
 class OpenBankingClient:
     """Decrypting client for the open-banking.io API."""
 
@@ -74,13 +109,7 @@ class OpenBankingClient:
         http_client: httpx.Client | None = None,
         timeout: float | None = None,
     ) -> None:
-        api_base_url = (api_base_url or "").strip()
-        if not api_base_url:
-            raise ValueError("api_base_url is required")
-        if not api_base_url.lower().startswith(("http://", "https://")):
-            raise ValueError(
-                f"api_base_url must start with http:// or https:// (got {api_base_url!r})"
-            )
+        api_base_url = _normalize_base_url(api_base_url)
         if not api_key or not api_key.strip():
             raise ValueError("api_key is required")
         if not private_key_pkcs8 or not private_key_pkcs8.strip():

--- a/python/src/open_banking_io/client.py
+++ b/python/src/open_banking_io/client.py
@@ -74,8 +74,13 @@ class OpenBankingClient:
         http_client: httpx.Client | None = None,
         timeout: float | None = None,
     ) -> None:
-        if not api_base_url or not api_base_url.strip():
+        api_base_url = (api_base_url or "").strip()
+        if not api_base_url:
             raise ValueError("api_base_url is required")
+        if not api_base_url.lower().startswith(("http://", "https://")):
+            raise ValueError(
+                f"api_base_url must start with http:// or https:// (got {api_base_url!r})"
+            )
         if not api_key or not api_key.strip():
             raise ValueError("api_key is required")
         if not private_key_pkcs8 or not private_key_pkcs8.strip():

--- a/python/tests/test_base_url.py
+++ b/python/tests/test_base_url.py
@@ -1,0 +1,73 @@
+"""api_base_url normalization: whitespace and a missing scheme must not surface as
+transport errors on the first request."""
+
+import httpx
+import pytest
+
+from open_banking_io import OpenBankingClient
+
+API_KEY = "obk_test_3f8b9c2e1a7d4655b0e9f2c1a8d7e6f5"
+
+
+def _client(base_url, credentials):
+    return OpenBankingClient(
+        api_base_url=base_url,
+        api_key=credentials["apiKey"],
+        private_key_pkcs8=credentials["encryptionKey"]["privateKey"],
+    )
+
+
+@pytest.mark.parametrize(
+    "padded",
+    [
+        "  {url}",
+        "{url}  ",
+        "\t{url}\n",
+        "\n{url}",
+        "  {url}/  ",
+    ],
+)
+def test_whitespace_padded_base_url_still_reaches_the_server(httpserver, credentials, padded):
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json([])
+
+    base = httpserver.url_for("").rstrip("/")
+    with _client(padded.format(url=base), credentials) as client:
+        assert client.get_accounts() == []
+
+
+def test_whitespace_is_stripped_from_base_url(credentials):
+    with _client("  https://open-banking.io  ", credentials) as client:
+        assert str(client._http.base_url) == "https://open-banking.io/"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["open-banking.io", "//open-banking.io", "ftp://open-banking.io"],
+)
+def test_base_url_without_http_scheme_is_rejected_at_construction(credentials, bad):
+    with pytest.raises(ValueError, match="http"):
+        _client(bad, credentials)
+
+
+def test_scheme_error_is_not_deferred_to_a_transport_error(credentials):
+    """Regression: a scheme-less base URL used to raise httpx.UnsupportedProtocol -- a
+    TransportError -- from the first call, long after the bad value was accepted."""
+    try:
+        _client("open-banking.io", credentials)
+    except ValueError:
+        return
+    except httpx.TransportError as exc:  # pragma: no cover
+        pytest.fail(f"bad base URL deferred to a transport error: {exc!r}")
+    pytest.fail("a scheme-less base URL was accepted")
+
+
+def test_from_credentials_strips_a_padded_api_base_url(credentials, tmp_path):
+    import json
+
+    bundle = dict(credentials)
+    bundle["apiBaseUrl"] = " https://open-banking.io\n"
+    path = tmp_path / "bundle.json"
+    path.write_text(json.dumps(bundle))
+
+    with OpenBankingClient.from_credentials(str(path)) as client:
+        assert str(client._http.base_url) == "https://open-banking.io/"

--- a/python/tests/test_base_url.py
+++ b/python/tests/test_base_url.py
@@ -71,3 +71,52 @@ def test_from_credentials_strips_a_padded_api_base_url(credentials, tmp_path):
 
     with OpenBankingClient.from_credentials(str(path)) as client:
         assert str(client._http.base_url) == "https://open-banking.io/"
+
+
+# -- Cleartext and non-string base URLs ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "loopback",
+    [
+        "http://localhost:8080",
+        "http://127.0.0.1:8080",
+        "http://[::1]:8080",
+        "HTTP://LOCALHOST:8080",
+    ],
+)
+def test_cleartext_http_is_allowed_on_loopback(credentials, loopback):
+    with _client(loopback, credentials) as client:
+        assert client._http.base_url.scheme == "http"
+
+
+@pytest.mark.parametrize(
+    "remote",
+    [
+        "http://open-banking.io",
+        "http://192.168.1.10:8080",
+        "http://localhost.evil.test",
+    ],
+)
+def test_cleartext_http_to_a_remote_host_is_rejected(credentials, remote):
+    """X-Api-Key and decrypted session uids must never cross the network in the clear."""
+    with pytest.raises(ValueError, match="https"):
+        _client(remote, credentials)
+
+
+@pytest.mark.parametrize("bad", [123, 12.5, True, [], {}, object()])
+def test_non_string_api_base_url_raises_value_error(credentials, bad):
+    with pytest.raises(ValueError, match="api_base_url"):
+        _client(bad, credentials)
+
+
+def test_from_credentials_rejects_a_non_string_api_base_url(credentials, tmp_path):
+    import json
+
+    bundle = dict(credentials)
+    bundle["apiBaseUrl"] = 1234
+    path = tmp_path / "bundle.json"
+    path.write_text(json.dumps(bundle))
+
+    with pytest.raises(ValueError, match="api_base_url"):
+        OpenBankingClient.from_credentials(str(path))


### PR DESCRIPTION
## What & why

`__init__` validated `api_base_url` with `.strip()` but normalized the raw value with `.rstrip("/")`, so a padded or scheme-less URL was accepted at construction and only failed on the first request — as an `httpx.TransportError`, with nothing pointing back at the base URL. Now stripped and validated up front.

Also: reject a non-string `apiBaseUrl` from the JSON bundle (PHP already does), and reject cleartext `http://` to non-loopback hosts, which would expose `X-Api-Key` and decrypted session uids.

## Affected SDK(s)
- [x] dotnet · [ ] node · [x] python · [ ] rust · [ ] go · [ ] java · [ ] ruby · [ ] php
- [x] shared (`fixtures/`, workflows, docs)

## Checklist
- [x] Tests pass locally for the affected SDK(s) (see `CONTRIBUTING.md`) — 80 passed, 14 new
- [x] Linters/formatters pass
- [x] If the envelope/wire format changed, I regenerated `fixtures/` — n/a
- [x] I did **not** bump package versions

## Security checklist
- [x] No secrets, credentials, or session uids in code, logs, or error messages
- [x] Money uses decimal/exact types, never float
- [x] No disabled TLS verification; no new network egress beyond the documented API
