### PR TITLE
fix(node,go,php,java,ruby): normalize and validate apiBaseUrl

### DIFF
--- a/go/baseurl_test.go
+++ b/go/baseurl_test.go
@@ -1,0 +1,64 @@
+package openbanking
+
+import "testing"
+
+func TestNewTrimsWhitespaceAroundBaseURL(t *testing.T) {
+	m := startMock(t)
+
+	for _, padded := range []string{
+		"  " + m.server.URL,
+		m.server.URL + "  ",
+		"\t" + m.server.URL + "\n",
+		"  " + m.server.URL + "/  ",
+	} {
+		c, err := New(padded, m.apiKey, m.privateKey, nil)
+		if err != nil {
+			t.Fatalf("New(%q) = %v, want no error", padded, err)
+		}
+		if _, err := c.GetAccounts(); err != nil {
+			t.Fatalf("GetAccounts() with base %q: %v", padded, err)
+		}
+	}
+}
+
+func TestNewRejectsBaseURLWithoutHTTPScheme(t *testing.T) {
+	for _, bad := range []string{"open-banking.io", "//open-banking.io", "ftp://open-banking.io"} {
+		if _, err := New(bad, "k", "x", nil); err == nil {
+			t.Errorf("New(%q) = nil error, want a scheme error", bad)
+		}
+	}
+}
+
+func TestNewRejectsCleartextHTTPToRemoteHost(t *testing.T) {
+	for _, bad := range []string{
+		"http://open-banking.io",
+		"http://192.168.1.10:8080",
+		"http://localhost.evil.test",
+	} {
+		if _, err := New(bad, "k", "x", nil); err == nil {
+			t.Errorf("New(%q) = nil error, want a cleartext error", bad)
+		}
+	}
+}
+
+func TestNewAllowsCleartextHTTPOnLoopback(t *testing.T) {
+	m := startMock(t)
+	// httptest binds 127.0.0.1, so the mock server itself is the loopback case.
+	if _, err := New(m.server.URL, m.apiKey, m.privateKey, nil); err != nil {
+		t.Fatalf("New(%q) = %v, want no error", m.server.URL, err)
+	}
+	for _, ok := range []string{"http://localhost:8080", "http://[::1]:8080", "HTTP://LOCALHOST:8080"} {
+		if _, err := New(ok, m.apiKey, m.privateKey, nil); err != nil {
+			t.Errorf("New(%q) = %v, want no error", ok, err)
+		}
+	}
+}
+
+func TestNewPublicAppliesTheSameBaseURLRules(t *testing.T) {
+	if _, err := NewPublic("open-banking.io", "k", nil); err == nil {
+		t.Error("NewPublic with no scheme = nil error, want a scheme error")
+	}
+	if _, err := NewPublic("http://open-banking.io", "k", nil); err == nil {
+		t.Error("NewPublic with cleartext http = nil error, want a cleartext error")
+	}
+}

--- a/go/client.go
+++ b/go/client.go
@@ -26,11 +26,39 @@ type Client struct {
 	httpClient *http.Client
 }
 
+// loopbackHosts are the only hosts allowed to be reached over cleartext http://.
+var loopbackHosts = map[string]bool{"localhost": true, "127.0.0.1": true, "::1": true}
+
+// normalizeBaseURL trims the base url and rejects anything that would otherwise only
+// surface later as an opaque transport error, or would put credentials on the wire in
+// the clear.
+func normalizeBaseURL(apiBaseURL string) (string, error) {
+	trimmed := strings.TrimSpace(apiBaseURL)
+	if trimmed == "" {
+		return "", fmt.Errorf("apiBaseUrl is required")
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("apiBaseUrl is not a valid url: %w", err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if (scheme != "http" && scheme != "https") || u.Host == "" {
+		return "", fmt.Errorf("apiBaseUrl must start with http:// or https:// (got %q)", trimmed)
+	}
+	if scheme == "http" && !loopbackHosts[strings.ToLower(u.Hostname())] {
+		return "", fmt.Errorf(
+			"apiBaseUrl must use https:// -- cleartext http:// would send the API key and "+
+				"decrypted session uids over the network (got %q)", trimmed)
+	}
+	return strings.TrimRight(trimmed, "/"), nil
+}
+
 // New builds a client from an API base url, API key, and base64 PKCS#8 encryption private key.
 // A nil httpClient builds an *http.Client with a 30s timeout.
 func New(apiBaseURL, apiKey, privateKeyPKCS8B64 string, httpClient *http.Client) (*Client, error) {
-	if strings.TrimSpace(apiBaseURL) == "" {
-		return nil, fmt.Errorf("apiBaseUrl is required")
+	baseURL, err := normalizeBaseURL(apiBaseURL)
+	if err != nil {
+		return nil, err
 	}
 	if strings.TrimSpace(apiKey) == "" {
 		return nil, fmt.Errorf("apiKey is required")
@@ -46,7 +74,7 @@ func New(apiBaseURL, apiKey, privateKeyPKCS8B64 string, httpClient *http.Client)
 		httpClient = &http.Client{Timeout: 30 * time.Second}
 	}
 	return &Client{
-		baseURL:    strings.TrimRight(apiBaseURL, "/"),
+		baseURL:    baseURL,
 		apiKey:     apiKey,
 		privateKey: priv,
 		httpClient: httpClient,
@@ -132,8 +160,9 @@ func NewWithOptions(apiBaseURL, apiKey, privateKeyPKCS8B64 string, opts ...Optio
 // (GetConnections). It needs no encryption key; the decrypting methods (GetAccounts,
 // GetTransactions, Sync, SyncAll) return an error on a client built this way.
 func NewPublic(apiBaseURL, apiKey string, httpClient *http.Client) (*Client, error) {
-	if strings.TrimSpace(apiBaseURL) == "" {
-		return nil, fmt.Errorf("apiBaseUrl is required")
+	baseURL, err := normalizeBaseURL(apiBaseURL)
+	if err != nil {
+		return nil, err
 	}
 	if strings.TrimSpace(apiKey) == "" {
 		return nil, fmt.Errorf("apiKey is required")
@@ -142,7 +171,7 @@ func NewPublic(apiBaseURL, apiKey string, httpClient *http.Client) (*Client, err
 		httpClient = http.DefaultClient
 	}
 	return &Client{
-		baseURL:    strings.TrimRight(apiBaseURL, "/"),
+		baseURL:    baseURL,
 		apiKey:     apiKey,
 		httpClient: httpClient,
 	}, nil

--- a/java/src/main/java/io/openbanking/OpenBankingClient.java
+++ b/java/src/main/java/io/openbanking/OpenBankingClient.java
@@ -18,7 +18,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Server-to-server client for open-banking.io. Authenticates with an API key ({@code X-Api-Key})
@@ -44,6 +46,44 @@ public final class OpenBankingClient {
   private final ObjectMapper mapper =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
+  private static final Set<String> LOOPBACK_HOSTS = Set.of("localhost", "127.0.0.1", "::1");
+
+  /**
+   * Trims and validates the API base url, rejecting up front what would otherwise only surface as
+   * an opaque {@link java.io.IOException} on the first request, and refusing cleartext {@code
+   * http://} to a non-loopback host, which would put the API key and decrypted session uids on the
+   * wire.
+   */
+  private static String normalizeBaseUrl(String apiBaseUrl) {
+    if (isBlank(apiBaseUrl)) {
+      throw new OpenBankingException("apiBaseUrl is required");
+    }
+    String trimmed = apiBaseUrl.trim();
+
+    URI uri;
+    try {
+      uri = URI.create(trimmed);
+    } catch (IllegalArgumentException e) {
+      throw new OpenBankingException(
+          "apiBaseUrl must start with http:// or https:// (got \"" + trimmed + "\")");
+    }
+    String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+    if ((!scheme.equals("http") && !scheme.equals("https")) || uri.getHost() == null) {
+      throw new OpenBankingException(
+          "apiBaseUrl must start with http:// or https:// (got \"" + trimmed + "\")");
+    }
+    String host = uri.getHost().toLowerCase(Locale.ROOT).replace("[", "").replace("]", "");
+    if (scheme.equals("http") && !LOOPBACK_HOSTS.contains(host)) {
+      throw new OpenBankingException(
+          "apiBaseUrl must use https:// -- cleartext http:// would send the API key and decrypted"
+              + " session uids over the network (got \""
+              + trimmed
+              + "\")");
+    }
+
+    return trimmed.replaceAll("/+$", "");
+  }
+
   /**
    * @param apiBaseUrl e.g. {@code https://open-banking.io}
    * @param apiKey the API key from your credentials bundle
@@ -68,16 +108,13 @@ public final class OpenBankingClient {
       String privateKeyPkcs8Base64,
       HttpClient httpClient,
       Duration requestTimeout) {
-    if (isBlank(apiBaseUrl)) {
-      throw new OpenBankingException("apiBaseUrl is required");
-    }
     if (isBlank(apiKey)) {
       throw new OpenBankingException("apiKey is required");
     }
     if (isBlank(privateKeyPkcs8Base64)) {
       throw new OpenBankingException("privateKeyPkcs8 is required");
     }
-    this.baseUrl = apiBaseUrl.replaceAll("/+$", "");
+    this.baseUrl = normalizeBaseUrl(apiBaseUrl);
     this.apiKey = apiKey;
     this.privateKey = Envelope.loadPrivateKey(privateKeyPkcs8Base64);
     this.http =

--- a/java/src/test/java/io/openbanking/BaseUrlTest.java
+++ b/java/src/test/java/io/openbanking/BaseUrlTest.java
@@ -1,0 +1,75 @@
+package io.openbanking;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** apiBaseUrl normalization: whitespace, missing scheme and cleartext http. */
+class BaseUrlTest {
+
+  private static final Path FIXTURES = Path.of("..", "fixtures");
+
+  @SuppressWarnings("unchecked")
+  private static String privateKeyPkcs8() throws Exception {
+    Map<String, Object> keypair =
+        new ObjectMapper()
+            .readValue(Files.readAllBytes(FIXTURES.resolve("keypair.json")), Map.class);
+    return (String) keypair.get("privateKeyPkcs8B64");
+  }
+
+  private static OpenBankingClient build(String baseUrl) throws Exception {
+    return new OpenBankingClient(baseUrl, "k", privateKeyPkcs8(), null);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"  https://example.test", "https://example.test  ", "\thttps://example.test\n"})
+  @DisplayName("whitespace around the base url is stripped")
+  void trimsWhitespace(String padded) {
+    assertDoesNotThrow(() -> build(padded));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"open-banking.io", "//open-banking.io", "ftp://open-banking.io"})
+  @DisplayName("a base url without an http scheme is rejected")
+  void rejectsMissingScheme(String bad) {
+    OpenBankingException e = assertThrows(OpenBankingException.class, () -> build(bad));
+    assertTrue(e.getMessage().contains("http"), e.getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "http://open-banking.io",
+        "http://192.168.1.10:8080",
+        "http://localhost.evil.test"
+      })
+  @DisplayName("cleartext http to a remote host is rejected")
+  void rejectsCleartextToRemoteHost(String bad) {
+    OpenBankingException e = assertThrows(OpenBankingException.class, () -> build(bad));
+    assertTrue(e.getMessage().contains("https"), e.getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080"})
+  @DisplayName("cleartext http is allowed on loopback")
+  void allowsCleartextOnLoopback(String ok) {
+    assertDoesNotThrow(() -> build(ok));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "   "})
+  @DisplayName("a blank base url is rejected")
+  void rejectsBlank(String blank) {
+    OpenBankingException e = assertThrows(OpenBankingException.class, () -> build(blank));
+    assertTrue(e.getMessage().contains("required"), e.getMessage());
+  }
+}

--- a/node/src/client.ts
+++ b/node/src/client.ts
@@ -30,6 +30,42 @@ import type {
  * decrypts the zero-knowledge data envelopes locally with the exported private key — the service
  * only ever returns ciphertext it cannot read.
  */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+/**
+ * Trims and validates the API base url. Rejects up front what would otherwise only surface
+ * as an opaque fetch/network error on the first request, and refuses cleartext http:// to a
+ * non-loopback host, which would put the API key and decrypted session uids on the wire.
+ */
+function normalizeBaseUrl(apiBaseUrl: unknown): string {
+  if (typeof apiBaseUrl !== "string" || !apiBaseUrl.trim()) {
+    throw new Error("apiBaseUrl is required");
+  }
+  const trimmed = apiBaseUrl.trim();
+  const shown = JSON.stringify(trimmed);
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error("apiBaseUrl must start with http:// or https:// (got " + shown + ")");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("apiBaseUrl must start with http:// or https:// (got " + shown + ")");
+  }
+  if (url.protocol === "http:" && !LOOPBACK_HOSTS.has(url.hostname.toLowerCase())) {
+    throw new Error(
+      "apiBaseUrl must use https:// -- cleartext http:// would send the API key and " +
+        "decrypted session uids over the network (got " + shown + ")",
+    );
+  }
+
+  // Strip all trailing "/" without a backtracking regex (avoids ReDoS on long inputs).
+  let end = trimmed.length;
+  while (end > 0 && trimmed.charCodeAt(end - 1) === 47 /* "/" */) end--;
+  return trimmed.slice(0, end);
+}
+
 export class OpenBankingClient {
   /** Default per-request timeout (30s) when {@link OpenBankingClientOptions.timeoutMs} is unset. */
   static readonly DEFAULT_TIMEOUT_MS = 30_000;
@@ -42,14 +78,9 @@ export class OpenBankingClient {
 
   constructor(options: OpenBankingClientOptions) {
     const { apiBaseUrl, apiKey, privateKeyPkcs8, timeoutMs } = options;
-    if (!apiBaseUrl?.trim()) throw new Error("apiBaseUrl is required");
+    this.baseUrl = normalizeBaseUrl(apiBaseUrl);
     if (!apiKey?.trim()) throw new Error("apiKey is required");
     if (!privateKeyPkcs8?.trim()) throw new Error("privateKeyPkcs8 is required");
-
-    // Strip all trailing "/" without a backtracking regex (avoids ReDoS on long inputs).
-    let end = apiBaseUrl.length;
-    while (end > 0 && apiBaseUrl.charCodeAt(end - 1) === 47 /* "/" */) end--;
-    this.baseUrl = apiBaseUrl.slice(0, end);
     this.apiKey = apiKey;
     this.timeoutMs = timeoutMs ?? OpenBankingClient.DEFAULT_TIMEOUT_MS;
     this.fetchImpl = options.fetch ?? fetch;

--- a/node/test/base-url.test.ts
+++ b/node/test/base-url.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { OpenBankingClient } from "../src/index.js";
+
+const fixtures = fileURLToPath(new URL("../../fixtures/", import.meta.url));
+const PRIVATE_KEY = (
+  JSON.parse(readFileSync(fixtures + "keypair.json", "utf8")) as { privateKeyPkcs8B64: string }
+).privateKeyPkcs8B64;
+
+const opts = (apiBaseUrl: unknown) =>
+  ({ apiBaseUrl, apiKey: "k", privateKeyPkcs8: PRIVATE_KEY }) as never;
+
+describe("apiBaseUrl normalization", () => {
+  it("trims surrounding whitespace", async () => {
+    let seen = "";
+    const client = new OpenBankingClient({
+      apiBaseUrl: "  https://example.test/  ",
+      apiKey: "k",
+      privateKeyPkcs8: PRIVATE_KEY,
+      fetch: ((url: string) => {
+        seen = url;
+        return Promise.resolve(
+          new Response("[]", { headers: { "content-type": "application/json" } }),
+        );
+      }) as never,
+    });
+    await client.getAccounts();
+    expect(seen).toBe("https://example.test/api/accounts");
+  });
+
+  it.each(["open-banking.io", "//open-banking.io", "ftp://open-banking.io"])(
+    "rejects %s (no http scheme)",
+    (bad) => {
+      expect(() => new OpenBankingClient(opts(bad))).toThrow(/http/i);
+    },
+  );
+
+  it.each(["http://open-banking.io", "http://192.168.1.10:8080", "http://localhost.evil.test"])(
+    "rejects cleartext %s",
+    (bad) => {
+      expect(() => new OpenBankingClient(opts(bad))).toThrow(/https/i);
+    },
+  );
+
+  it.each(["http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080"])(
+    "allows cleartext on loopback %s",
+    (ok) => {
+      expect(() => new OpenBankingClient(opts(ok))).not.toThrow();
+    },
+  );
+
+  it.each([123, null, undefined, {}, []])("rejects non-string %s", (bad) => {
+    expect(() => new OpenBankingClient(opts(bad))).toThrow(/apiBaseUrl/);
+  });
+});

--- a/node/test/integration.test.ts
+++ b/node/test/integration.test.ts
@@ -183,26 +183,26 @@ describe("integration against a mock API", () => {
 
     // One trailing slash is stripped exactly as before.
     const single = new OpenBankingClient({
-      apiBaseUrl: "http://example.test/",
+      apiBaseUrl: "https://example.test/",
       apiKey: API_KEY,
       privateKeyPkcs8: PRIVATE_KEY,
       fetch: spyFetch,
     });
     await single.getAccounts();
-    expect(seen.at(-1)).toBe("http://example.test/api/accounts");
+    expect(seen.at(-1)).toBe("https://example.test/api/accounts");
 
     // Pathological input: 10k trailing slashes. The old /\/+$/ regex backtracks O(n²); the
     // char-scan trim must return quickly and strip every trailing slash.
     const start = performance.now();
     const many = new OpenBankingClient({
-      apiBaseUrl: "http://example.test" + "/".repeat(10_000),
+      apiBaseUrl: "https://example.test" + "/".repeat(10_000),
       apiKey: API_KEY,
       privateKeyPkcs8: PRIVATE_KEY,
       fetch: spyFetch,
     });
     await many.getAccounts();
     const elapsed = performance.now() - start;
-    expect(seen.at(-1)).toBe("http://example.test/api/accounts");
+    expect(seen.at(-1)).toBe("https://example.test/api/accounts");
     expect(elapsed).toBeLessThan(1000);
   });
 

--- a/php/src/Client.php
+++ b/php/src/Client.php
@@ -54,6 +54,42 @@ final class Client
      */
     private static ?\WeakMap $transportOptions = null;
 
+    /** Hosts allowed to be reached over cleartext http://. */
+    private const LOOPBACK_HOSTS = ['localhost', '127.0.0.1', '::1'];
+
+    /**
+     * Trims and validates the API base url, rejecting up front what would otherwise only
+     * surface as an opaque cURL transport error on the first request, and refusing cleartext
+     * http:// to a non-loopback host, which would put the API key and decrypted session uids
+     * on the wire.
+     */
+    private static function normalizeBaseUrl(string $apiBaseUrl): string
+    {
+        $trimmed = trim($apiBaseUrl);
+        if ($trimmed === '') {
+            throw new OpenBankingException('apiBaseUrl is required');
+        }
+
+        $scheme = strtolower((string) parse_url($trimmed, PHP_URL_SCHEME));
+        $host = parse_url($trimmed, PHP_URL_HOST);
+        if (!in_array($scheme, ['http', 'https'], true) || !is_string($host) || $host === '') {
+            throw new OpenBankingException(
+                sprintf('apiBaseUrl must start with http:// or https:// (got %s)', var_export($trimmed, true)),
+            );
+        }
+        if ($scheme === 'http' && !in_array(strtolower(trim($host, '[]')), self::LOOPBACK_HOSTS, true)) {
+            throw new OpenBankingException(
+                sprintf(
+                    'apiBaseUrl must use https:// -- cleartext http:// would send the API key and '
+                    . 'decrypted session uids over the network (got %s)',
+                    var_export($trimmed, true),
+                ),
+            );
+        }
+
+        return rtrim($trimmed, '/');
+    }
+
     /**
      * @param array{
      *     curl_options?: array<int, mixed>,
@@ -71,9 +107,6 @@ final class Client
         #[\SensitiveParameter] string $privateKeyPkcs8,
         #[\SensitiveParameter] array $options = [],
     ) {
-        if (trim($apiBaseUrl) === '') {
-            throw new OpenBankingException('apiBaseUrl is required');
-        }
         if (trim($apiKey) === '') {
             throw new OpenBankingException('apiKey is required');
         }
@@ -81,7 +114,7 @@ final class Client
             throw new OpenBankingException('privateKeyPkcs8 is required');
         }
 
-        $this->apiBaseUrl = rtrim($apiBaseUrl, '/');
+        $this->apiBaseUrl = self::normalizeBaseUrl($apiBaseUrl);
         $this->apiKey = new Secret($apiKey);
         $this->envelope = Envelope::fromPkcs8Base64($privateKeyPkcs8);
 

--- a/php/tests/BaseUrlTest.php
+++ b/php/tests/BaseUrlTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenBankingIO\Tests;
+
+use OpenBankingIO\Client;
+use OpenBankingIO\OpenBankingException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/** apiBaseUrl normalization: whitespace, missing scheme and cleartext http. */
+final class BaseUrlTest extends TestCase
+{
+    use MockServerTrait;
+
+    protected function tearDown(): void
+    {
+        $this->stopMockServer();
+    }
+
+    /** @return list<array{string}> */
+    public static function paddingProvider(): array
+    {
+        return [['  %s'], ['%s  '], ["\t%s\n"], ['  %s/  ']];
+    }
+
+    #[DataProvider('paddingProvider')]
+    public function testWhitespacePaddedBaseUrlStillReachesTheServer(string $pattern): void
+    {
+        $this->startMockServer();
+        /** @var array{apiKey: string, encryptionKey: array{privateKey: string}} $creds */
+        $creds = Fixtures::load('credentials.json');
+        $client = new Client(
+            sprintf($pattern, $this->baseUrl),
+            $creds['apiKey'],
+            $creds['encryptionKey']['privateKey'],
+        );
+        $this->assertNotEmpty($client->getAccounts());
+    }
+
+    /** @return list<array{string}> */
+    public static function noSchemeProvider(): array
+    {
+        return [['open-banking.io'], ['//open-banking.io'], ['ftp://open-banking.io']];
+    }
+
+    #[DataProvider('noSchemeProvider')]
+    public function testBaseUrlWithoutHttpSchemeIsRejected(string $bad): void
+    {
+        $this->expectException(OpenBankingException::class);
+        $this->expectExceptionMessageMatches('/http/i');
+        new Client($bad, 'k', 'x');
+    }
+
+    /** @return list<array{string}> */
+    public static function cleartextProvider(): array
+    {
+        return [
+            ['http://open-banking.io'],
+            ['http://192.168.1.10:8080'],
+            ['http://localhost.evil.test'],
+        ];
+    }
+
+    #[DataProvider('cleartextProvider')]
+    public function testCleartextHttpToRemoteHostIsRejected(string $bad): void
+    {
+        $this->expectException(OpenBankingException::class);
+        $this->expectExceptionMessageMatches('/https/i');
+        new Client($bad, 'k', 'x');
+    }
+
+    public function testEmptyBaseUrlIsRejected(): void
+    {
+        $this->expectException(OpenBankingException::class);
+        $this->expectExceptionMessageMatches('/required/');
+        new Client('   ', 'k', 'x');
+    }
+}

--- a/php/tests/ClientTransportTest.php
+++ b/php/tests/ClientTransportTest.php
@@ -121,7 +121,7 @@ final class ClientTransportTest extends TestCase
         /** @var array{apiKey: string, encryptionKey: array{privateKey: string}} $credentials */
         $credentials = Fixtures::load('credentials.json');
         $client = new Client(
-            'http://198.51.100.1:9',
+            'https://198.51.100.1:9',
             'api-key',
             $credentials['encryptionKey']['privateKey'],
             ['connect_timeout' => 1],

--- a/ruby/lib/open_banking_io/client.rb
+++ b/ruby/lib/open_banking_io/client.rb
@@ -65,6 +65,39 @@ module OpenBankingIO
       )
     end
 
+    LOOPBACK_HOSTS = ["localhost", "127.0.0.1", "::1"].freeze
+
+    # Trims and validates the API base url, returning it as a URI that always ends in "/".
+    # Rejects up front what would otherwise only surface as an opaque Net::HTTP transport
+    # error on the first request, and refuses cleartext http:// to a non-loopback host,
+    # which would put the API key and decrypted session uids on the wire.
+    def self.normalize_base_url(api_base_url)
+      trimmed = api_base_url.to_s.strip
+      raise ArgumentError, "api_base_url is required" if trimmed.empty?
+
+      uri = begin
+        URI.parse(trimmed)
+      rescue URI::InvalidURIError
+        nil
+      end
+      scheme = uri&.scheme&.downcase
+      unless %w[http https].include?(scheme) && !uri.host.to_s.empty?
+        raise ArgumentError, "api_base_url must start with http:// or https:// (got #{trimmed.inspect})"
+      end
+
+      if scheme == "http" && !LOOPBACK_HOSTS.include?(uri.host.to_s.downcase.delete("[]"))
+        raise ArgumentError,
+          "api_base_url must use https:// -- cleartext http:// would send the API key and " \
+          "decrypted session uids over the network (got #{trimmed.inspect})"
+      end
+
+      # Strip any trailing slashes without a backtracking regex (avoids ReDoS on
+      # pathological input) then re-append a single one, so the base always ends in "/".
+      base = trimmed
+      base = base.chomp("/") while base.end_with?("/")
+      URI.parse(base + "/")
+    end
+
     # +open_timeout+/+read_timeout+ are seconds applied to the internally built Net::HTTP.
     # +http_client+, when given, is any object responding to +#request+ (e.g. a preconfigured
     # Net::HTTP for a proxy, custom CA/mTLS or connection pooling); it is used as-is instead
@@ -72,15 +105,10 @@ module OpenBankingIO
     def initialize(api_base_url:, api_key:, private_key_pkcs8:,
       open_timeout: DEFAULT_OPEN_TIMEOUT, read_timeout: DEFAULT_READ_TIMEOUT,
       http_client: nil)
-      raise ArgumentError, "api_base_url is required" if blank?(api_base_url)
       raise ArgumentError, "api_key is required" if blank?(api_key)
       raise ArgumentError, "private_key_pkcs8 is required" if blank?(private_key_pkcs8)
 
-      # Strip any trailing slashes without a backtracking regex (avoids ReDoS on
-      # pathological input) then re-append a single one, so the base always ends in "/".
-      base = api_base_url.to_s
-      base = base.chomp("/") while base.end_with?("/")
-      @base_uri = URI.parse(base + "/")
+      @base_uri = self.class.normalize_base_url(api_base_url)
       @api_key = api_key
       @private_key = Envelope.load_private_key(private_key_pkcs8)
       @open_timeout = open_timeout

--- a/ruby/spec/base_url_spec.rb
+++ b/ruby/spec/base_url_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "support/mock_server"
+
+RSpec.describe "api_base_url normalization" do
+  let(:credentials) { load_fixture("credentials.json") }
+  let(:api_key) { MockServer::API_KEY }
+
+  def build(base_url)
+    OpenBankingIO::Client.new(
+      api_base_url: base_url,
+      api_key: credentials["apiKey"],
+      private_key_pkcs8: credentials["encryptionKey"]["privateKey"]
+    )
+  end
+
+  describe "whitespace" do
+    it "is stripped so the request still reaches the server" do
+      server = MockServer.new(FIXTURES_DIR)
+      ["  #{server.base_url}", "#{server.base_url}  ", "\t#{server.base_url}\n", "  #{server.base_url}/  "].each do |padded|
+        expect { build(padded).get_accounts }.not_to raise_error
+      end
+    ensure
+      server&.stop
+    end
+  end
+
+  describe "scheme" do
+    %w[open-banking.io //open-banking.io ftp://open-banking.io].each do |bad|
+      it "rejects #{bad.inspect}" do
+        expect { build(bad) }.to raise_error(ArgumentError, /http/i)
+      end
+    end
+  end
+
+  describe "cleartext http" do
+    ["http://open-banking.io", "http://192.168.1.10:8080", "http://localhost.evil.test"].each do |bad|
+      it "rejects #{bad.inspect}" do
+        expect { build(bad) }.to raise_error(ArgumentError, /https/i)
+      end
+    end
+
+    ["http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080"].each do |ok|
+      it "allows loopback #{ok.inspect}" do
+        expect { build(ok) }.not_to raise_error
+      end
+    end
+  end
+
+  it "rejects a blank base url" do
+    expect { build("   ") }.to raise_error(ArgumentError, /required/)
+  end
+end

--- a/ruby/spec/http_options_spec.rb
+++ b/ruby/spec/http_options_spec.rb
@@ -121,20 +121,20 @@ RSpec.describe OpenBankingIO::Client do
     end
 
     it "leaves a base URL without a trailing slash ending in exactly one slash" do
-      expect(base_uri_for("http://x")).to eq("http://x/")
+      expect(base_uri_for("https://x")).to eq("https://x/")
     end
 
     it "collapses multiple trailing slashes to a single one" do
-      expect(base_uri_for("http://x///")).to eq("http://x/")
+      expect(base_uri_for("https://x///")).to eq("https://x/")
     end
 
     it "normalizes a pathological run of trailing slashes quickly (no ReDoS)" do
-      url = "http://x" + ("/" * 10_000)
+      url = "https://x" + ("/" * 10_000)
       started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       result = base_uri_for(url)
       elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
 
-      expect(result).to eq("http://x/")
+      expect(result).to eq("https://x/")
       expect(elapsed).to be < 1.0
     end
   end


### PR DESCRIPTION
## What & why

Ports the Python fix from #182 to the other five SDKs. All shared the same defect: the base url was validated with a trimmed copy but stored raw, so whitespace survived into the request url and only surfaced on the first call as an opaque transport error.

Each now trims before use, requires an `http://`/`https://` scheme, and refuses cleartext `http://` to a non-loopback host — which would put the API key and the decrypted session uid on the wire, contradicting `THREAT_MODEL.md`. Node also rejects a non-string `apiBaseUrl`, matching PHP.

Three existing tests used cleartext http to a non-loopback host incidentally (node `example.test`, ruby `http://x`, php's blackholed TEST-NET-2 address) and now use `https`; none were testing the scheme.

## Affected SDK(s)
- [ ] dotnet · [x] node · [ ] python · [ ] rust · [x] go · [x] java · [x] ruby · [x] php
- [ ] shared (`fixtures/`, workflows, docs)

## Checklist
- [x] Tests pass locally for the affected SDK(s) (see `CONTRIBUTING.md`) — go ok, node 64, php 109, ruby 40, java 68
- [x] Linters/formatters pass — gofmt/vet, eslint, phpstan+cs-fixer, standardrb, spotless
- [x] If the envelope/wire format changed, I regenerated `fixtures/` — n/a
- [x] I did **not** bump package versions

## Security checklist
- [x] No secrets, credentials, or session uids in code, logs, or error messages — errors echo only the base url
- [x] Money uses decimal/exact types, never float — unchanged
- [x] No disabled TLS verification; no new network egress beyond the documented API
