### PR TITLE
feat(python): diagnose() and opt-in request logging

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -62,7 +62,7 @@ with OpenBankingClient.from_credentials("credentials.json") as client:
     print(client.diagnose().report())
 ```
 
-```
+```text
 [PASS] base_url       'https://open-banking.io' -> host='open-banking.io' port=443 scheme=https  (0 ms)
 [PASS] dns            open-banking.io -> 104.21.78.242, 172.67.138.186  (24 ms)
 [PASS] tcp_connect    connected to open-banking.io:443  (10 ms)
@@ -72,8 +72,13 @@ with OpenBankingClient.from_credentials("credentials.json") as client:
 
 It never raises: a failing stage is recorded and the stages that depend on it are skipped, so
 a DNS problem reads differently from a TLS problem or a rejected API key. The report carries
-no API key (only a one-way fingerprint), no private key, no decrypted data and no response
-bodies; proxy and CA environment variables are listed by name with their values withheld.
+no API key, no private key, no decrypted data and no response bodies; any credentials in the
+base URL are stripped, and proxy and CA environment variables are listed by name with their
+values withheld.
+
+The `api_preflight` stage always runs, even when the direct probes fail: those open their own
+sockets and so bypass a proxy or a custom TLS setup, which can make them report a fault on a
+connection that works. The verdict comes from the request the SDK actually makes.
 `as_dict()` returns the same data as JSON-serialisable structures.
 
 Request logging is opt-in through the standard `logging` module and records only the method,
@@ -81,6 +86,7 @@ path, status and duration — never headers or bodies:
 
 ```python
 import logging
+
 logging.basicConfig()
 logging.getLogger("open_banking_io").setLevel(logging.DEBUG)
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -52,6 +52,39 @@ Amounts are exposed as `decimal.Decimal`. Models are plain `@dataclass`es.
 
 When the client constructs its own `httpx.Client` it applies a default 30s timeout and sends a `User-Agent: open-banking-io/python/<version>` header on every request (a caller-supplied client is left untouched).
 
+## Diagnostics
+
+When a call fails before any HTTP response, `diagnose()` probes each stage in turn and
+returns a report that is safe to paste into a support ticket:
+
+```python
+with OpenBankingClient.from_credentials("credentials.json") as client:
+    print(client.diagnose().report())
+```
+
+```
+[PASS] base_url       'https://open-banking.io' -> host='open-banking.io' port=443 scheme=https  (0 ms)
+[PASS] dns            open-banking.io -> 104.21.78.242, 172.67.138.186  (24 ms)
+[PASS] tcp_connect    connected to open-banking.io:443  (10 ms)
+[PASS] tls_handshake  TLSv1.3 TLS_AES_256_GCM_SHA384 issuer='Google Trust Services' notAfter=Nov  5 13:47:21 2026 GMT  (40 ms)
+[PASS] api_preflight  GET api/accounts -> HTTP 200  (159 ms)
+```
+
+It never raises: a failing stage is recorded and the stages that depend on it are skipped, so
+a DNS problem reads differently from a TLS problem or a rejected API key. The report carries
+no API key (only a one-way fingerprint), no private key, no decrypted data and no response
+bodies; proxy and CA environment variables are listed by name with their values withheld.
+`as_dict()` returns the same data as JSON-serialisable structures.
+
+Request logging is opt-in through the standard `logging` module and records only the method,
+path, status and duration — never headers or bodies:
+
+```python
+import logging
+logging.basicConfig()
+logging.getLogger("open_banking_io").setLevel(logging.DEBUG)
+```
+
 ## Encryption
 
 Envelopes use **ECDH P-256 → HKDF-SHA256 → AES-256-GCM**. Decryption requires the private key from

--- a/python/src/open_banking_io/__init__.py
+++ b/python/src/open_banking_io/__init__.py
@@ -8,6 +8,7 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 
 from .client import OpenBankingClient
+from .diagnostics import Check, Diagnostics
 from .models import (
     Account,
     Balance,
@@ -21,7 +22,9 @@ from .models import (
 __all__ = [
     "Account",
     "Balance",
+    "Check",
     "Connection",
+    "Diagnostics",
     "OpenBankingClient",
     "SyncAllResult",
     "SyncResult",

--- a/python/src/open_banking_io/client.py
+++ b/python/src/open_banking_io/client.py
@@ -8,7 +8,9 @@ ciphertext it cannot read.
 from __future__ import annotations
 
 import json
+import logging
 import os
+import time
 from datetime import date, datetime
 from decimal import Decimal
 from importlib.metadata import PackageNotFoundError, version
@@ -16,7 +18,8 @@ from typing import Any
 
 import httpx
 
-from . import envelope
+from . import diagnostics, envelope
+from .diagnostics import Diagnostics
 from .models import (
     Account,
     Balance,
@@ -61,6 +64,28 @@ def _parse_decimal_nullable(value: str | None) -> Decimal | None:
     if value is None or value == "":
         return None
     return Decimal(value)
+
+
+# Opt-in request logging. Nothing is emitted unless the caller enables this logger, and
+# only the method, path, status and duration are recorded -- never headers (which carry
+# the API key) and never bodies (which carry ciphertext and decrypted data).
+logger = logging.getLogger("open_banking_io")
+
+
+def _log_request(request: httpx.Request) -> None:
+    request.extensions["ob_started_at"] = time.perf_counter()
+
+
+def _log_response(response: httpx.Response) -> None:
+    started = response.request.extensions.get("ob_started_at")
+    elapsed = f"{(time.perf_counter() - started) * 1000:.0f}ms" if started else "?"
+    logger.debug(
+        "%s %s -> %s in %s",
+        response.request.method,
+        response.request.url.path,
+        response.status_code,
+        elapsed,
+    )
 
 
 _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
@@ -120,7 +145,11 @@ class OpenBankingClient:
         # A caller-injected client is used as-is; only the default client honors `timeout`.
         default_timeout = httpx.Timeout(30.0 if timeout is None else timeout)
         self._http = http_client or httpx.Client(timeout=default_timeout)
+        if self._owns_http:
+            self._http.event_hooks["request"].append(_log_request)
+            self._http.event_hooks["response"].append(_log_response)
         self._http.base_url = httpx.URL(api_base_url.rstrip("/") + "/")
+        self._api_key = api_key
         self._http.headers["X-Api-Key"] = api_key
         self._http.headers["User-Agent"] = _user_agent()
 
@@ -318,6 +347,17 @@ class OpenBankingClient:
             balance_after_transaction=_parse_decimal_nullable(d.get("balanceAfter")),
             balance_after_currency=d.get("balanceAfterCurrency"),
         )
+
+    # -- Diagnostics -----------------------------------------------------------
+
+    def diagnose(self) -> Diagnostics:
+        """Probes DNS, TCP, TLS and an authenticated request, and returns a report that is
+        safe to paste into a support ticket.
+
+        Never raises: each stage records its own failure and the stages that depend on it
+        are skipped. The report carries no API key, no private key and no response bodies.
+        """
+        return diagnostics.run(self._http, str(self._http.base_url).rstrip("/"), self._api_key)
 
     # -- Lifecycle -------------------------------------------------------------
 

--- a/python/src/open_banking_io/diagnostics.py
+++ b/python/src/open_banking_io/diagnostics.py
@@ -8,7 +8,6 @@ TLS problem from an authentication problem.
 
 from __future__ import annotations
 
-import hashlib
 import os
 import platform
 import socket
@@ -18,7 +17,7 @@ import time
 from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 
@@ -69,7 +68,11 @@ class Diagnostics:
 
     @property
     def ok(self) -> bool:
-        return all(c.ok for c in self.checks)
+        """Whether the SDK can actually talk to the API. Decided by the preflight through the
+        configured transport, not by the direct probes -- those bypass proxies and custom TLS,
+        so they can fail on a setup that works perfectly well."""
+        preflight = next((c for c in self.checks if c.name == "api_preflight"), None)
+        return preflight.ok if preflight is not None else False
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -94,11 +97,6 @@ class Diagnostics:
         return self.report()
 
 
-def _fingerprint(secret: str) -> str:
-    """A one-way, non-reversible handle support can correlate against, never the value."""
-    return hashlib.sha256(secret.encode("utf-8")).hexdigest()[:16]
-
-
 def _sdk_version() -> str:
     try:
         return version("open-banking-io")
@@ -113,6 +111,16 @@ def _package_version(name: str) -> str:
         return "unknown"
 
 
+def _safe_url(url: str) -> str:
+    """The base url with any userinfo, query and fragment removed -- a base url may carry
+    proxy or basic-auth credentials, and this string is written into the report."""
+    parts = urlsplit(url)
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    return urlunsplit((parts.scheme, host, parts.path, "", ""))
+
+
 def _environment(api_key: str, base_url: str) -> dict[str, str]:
     env: dict[str, str] = {
         "sdk_version": _sdk_version(),
@@ -121,8 +129,8 @@ def _environment(api_key: str, base_url: str) -> dict[str, str]:
         "httpcore_version": _package_version("httpcore"),
         "openssl_version": ssl.OPENSSL_VERSION,
         "platform": platform.platform(),
-        "api_base_url": base_url,
-        "api_key_fingerprint": _fingerprint(api_key),
+        "api_base_url": _safe_url(base_url),
+        "api_key": f"set ({len(api_key)} chars)" if api_key else "MISSING",
     }
     present = [name for name in _ENV_VARS_OF_INTEREST if os.environ.get(name)]
     env["env_vars_set"] = ", ".join(present) if present else "(none)"
@@ -150,16 +158,19 @@ def run(http: httpx.Client, base_url: str, api_key: str) -> Diagnostics:
     port = parts.port or (443 if scheme == "https" else 80)
 
     diag.checks.append(
-        Check("base_url", True, f"{base_url!r} -> host={host!r} port={port} scheme={scheme}")
+        Check(
+            "base_url",
+            True,
+            f"{_safe_url(base_url)!r} -> host={host!r} port={port} scheme={scheme}",
+        )
     )
 
-    def skip(name: str) -> None:
-        diag.checks.append(
-            Check(name, False, "not attempted (an earlier stage failed)", skipped=True)
-        )
+    def skip(name: str, why: str = "an earlier stage failed") -> None:
+        diag.checks.append(Check(name, False, f"not attempted ({why})", skipped=True))
 
-    # DNS
-    addresses: list[str] = []
+    # The probes below open their own sockets, so they bypass any proxy and any custom TLS
+    # configuration on the caller's httpx client. They localise a fault; they do not decide
+    # the verdict -- the preflight through the configured transport does.
     with _Timer() as t:
         try:
             infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
@@ -168,32 +179,29 @@ def run(http: httpx.Client, base_url: str, api_key: str) -> Diagnostics:
         except OSError as e:
             dns_ok, dns_detail = False, f"could not resolve {host!r}: {e}"
     diag.checks.append(Check("dns", dns_ok, dns_detail, t.ms))
+
+    tcp_ok = False
     if not dns_ok:
         skip("tcp_connect")
-        skip("tls_handshake")
-        skip("api_preflight")
-        return diag
+    else:
+        with _Timer() as t:
+            try:
+                with socket.create_connection((host, port), timeout=10.0):
+                    tcp_ok, tcp_detail = True, f"connected to {host}:{port}"
+            except OSError as e:
+                tcp_ok, tcp_detail = False, f"could not connect to {host}:{port}: {e}"
+        diag.checks.append(Check("tcp_connect", tcp_ok, tcp_detail, t.ms))
 
-    # TCP
-    with _Timer() as t:
-        try:
-            with socket.create_connection((host, port), timeout=10.0):
-                tcp_ok, tcp_detail = True, f"connected to {host}:{port}"
-        except OSError as e:
-            tcp_ok, tcp_detail = False, f"could not connect to {host}:{port}: {e}"
-    diag.checks.append(Check("tcp_connect", tcp_ok, tcp_detail, t.ms))
     if not tcp_ok:
         skip("tls_handshake")
-        skip("api_preflight")
-        return diag
-
-    # TLS
-    with _Timer() as t:
-        if scheme != "https":
-            tls_ok, tls_detail = True, "skipped (plain http)"
-        else:
+    elif scheme != "https":
+        diag.checks.append(Check("tls_handshake", True, "skipped (plain http)"))
+    else:
+        with _Timer() as t:
             try:
                 ctx = ssl.create_default_context()
+                # CodeQL: pin the floor so TLS 1.0/1.1 are never negotiated by the probe.
+                ctx.minimum_version = ssl.TLSVersion.TLSv1_2
                 with (
                     socket.create_connection((host, port), timeout=10.0) as raw,
                     ctx.wrap_socket(raw, server_hostname=host) as tls,
@@ -212,12 +220,10 @@ def run(http: httpx.Client, base_url: str, api_key: str) -> Diagnostics:
                     )
             except (OSError, ssl.SSLError) as e:
                 tls_ok, tls_detail = False, f"TLS handshake failed: {e}"
-    diag.checks.append(Check("tls_handshake", tls_ok, tls_detail, t.ms))
-    if not tls_ok:
-        skip("api_preflight")
-        return diag
+        diag.checks.append(Check("tls_handshake", tls_ok, tls_detail, t.ms))
 
-    # An authenticated request. Only the status is reported -- never the body.
+    # Always attempted, whatever the probes said: this is the request the SDK actually makes,
+    # through the caller's configured transport. Only the status is reported, never the body.
     with _Timer() as t:
         try:
             resp = http.get("api/accounts")
@@ -227,6 +233,9 @@ def run(http: httpx.Client, base_url: str, api_key: str) -> Diagnostics:
                 pre_detail += " (the API key was rejected)"
         except httpx.HTTPError as e:
             pre_ok, pre_detail = False, f"GET api/accounts failed: {type(e).__name__}: {e}"
+    if pre_ok and not all(c.ok for c in diag.checks):
+        pre_detail += " -- the request succeeded, so the failing probes above are most likely "
+        pre_detail += "a proxy or custom TLS setup they bypass, not a real fault"
     diag.checks.append(Check("api_preflight", pre_ok, pre_detail, t.ms))
 
     return diag

--- a/python/src/open_banking_io/diagnostics.py
+++ b/python/src/open_banking_io/diagnostics.py
@@ -124,14 +124,19 @@ def _port(parts: SplitResult) -> int | None:
 
 def _port_is_invalid(parts: SplitResult) -> bool:
     try:
-        _ = parts.port
+        return parts.port == 0  # a real port is 1-65535
     except ValueError:
         return True
-    return False
 
 
 def _default_port(scheme: str) -> int:
     return 443 if scheme == "https" else 80
+
+
+def _effective_port(port_value: int | None, scheme: str) -> int:
+    """An explicit port wins, including one the scheme would otherwise imply. Only an absent
+    port falls back to the scheme default -- `or` would swallow an explicit 0."""
+    return _default_port(scheme) if port_value is None else port_value
 
 
 def _safe_url(url: str) -> str:
@@ -208,22 +213,31 @@ def run(http: httpx.Client, base_url: str, api_key: str) -> Diagnostics:
         results[name] = Check(name, False, f"not attempted ({why})", skipped=True)
 
     # -- base url --------------------------------------------------------------
-    parts = urlsplit(base_url)
+    # urlsplit itself raises on some malformed input (e.g. "https://["), so it runs behind
+    # the same guard as everything else rather than ahead of it.
+    try:
+        parts = urlsplit(base_url)
+        parse_error: str | None = None
+    except ValueError as e:
+        parts, parse_error = SplitResult("", "", "", "", ""), f"{type(e).__name__}: {e}"
+
     scheme = (parts.scheme or "").lower()
     host = parts.hostname or ""
     port_value = _port(parts)
 
     def check_base_url() -> tuple[bool, str]:
+        if parse_error is not None:
+            return False, f"could not parse the base url -- {parse_error}"
         shown = _safe_url(base_url)
         if not host:
             return False, f"{shown!r} has no host"
         if _port_is_invalid(parts):
             return False, f"{shown!r} has a port outside 1-65535"
-        shown_port = port_value or _default_port(scheme)
+        shown_port = _effective_port(port_value, scheme)
         return True, f"{shown!r} -> host={host!r} port={shown_port} scheme={scheme}"
 
     results["base_url"] = _guard("base_url", check_base_url)
-    port = port_value or _default_port(scheme)
+    port = _effective_port(port_value, scheme)
 
     if not results["base_url"].ok:
         skip("dns", "the base url is unusable")

--- a/python/src/open_banking_io/diagnostics.py
+++ b/python/src/open_banking_io/diagnostics.py
@@ -1,0 +1,232 @@
+"""Connectivity diagnostics that produce a report safe to paste into a support ticket.
+
+Every stage is probed in order and a failure stops the ones that depend on it. Nothing here
+raises: a diagnostic that blows up is useless. The report carries no API key, no private key,
+no decrypted data and no response bodies -- only what is needed to tell a DNS problem from a
+TLS problem from an authentication problem.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import socket
+import ssl
+import sys
+import time
+from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+
+# Environment variables worth reporting the presence of. Values can carry proxy
+# credentials, so only the name is ever emitted.
+_ENV_VARS_OF_INTEREST = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+)
+
+
+@dataclass
+class Check:
+    """One diagnostic stage."""
+
+    name: str
+    ok: bool
+    detail: str
+    duration_ms: float = 0.0
+    skipped: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "ok": self.ok,
+            "detail": self.detail,
+            "duration_ms": round(self.duration_ms, 1),
+            "skipped": self.skipped,
+        }
+
+
+@dataclass
+class Diagnostics:
+    """The result of :meth:`OpenBankingClient.diagnose`."""
+
+    checks: list[Check] = field(default_factory=list)
+    environment: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return all(c.ok for c in self.checks)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "checks": [c.as_dict() for c in self.checks],
+            "environment": dict(self.environment),
+        }
+
+    def report(self) -> str:
+        """A pasteable plain-text summary. Contains no secrets."""
+        lines = ["open-banking.io diagnostics", "=" * 27, ""]
+        for c in self.checks:
+            mark = "SKIP" if c.skipped else ("PASS" if c.ok else "FAIL")
+            lines.append(f"[{mark}] {c.name:<14} {c.detail}  ({c.duration_ms:.0f} ms)")
+        lines += ["", "Environment", "-" * 11]
+        for key, value in self.environment.items():
+            lines.append(f"  {key}: {value}")
+        lines += ["", f"Result: {'ok' if self.ok else 'FAILED'}"]
+        return "\n".join(lines)
+
+    def __str__(self) -> str:
+        return self.report()
+
+
+def _fingerprint(secret: str) -> str:
+    """A one-way, non-reversible handle support can correlate against, never the value."""
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()[:16]
+
+
+def _sdk_version() -> str:
+    try:
+        return version("open-banking-io")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _package_version(name: str) -> str:
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _environment(api_key: str, base_url: str) -> dict[str, str]:
+    env: dict[str, str] = {
+        "sdk_version": _sdk_version(),
+        "python_version": sys.version.split()[0],
+        "httpx_version": _package_version("httpx"),
+        "httpcore_version": _package_version("httpcore"),
+        "openssl_version": ssl.OPENSSL_VERSION,
+        "platform": platform.platform(),
+        "api_base_url": base_url,
+        "api_key_fingerprint": _fingerprint(api_key),
+    }
+    present = [name for name in _ENV_VARS_OF_INTEREST if os.environ.get(name)]
+    env["env_vars_set"] = ", ".join(present) if present else "(none)"
+    return env
+
+
+class _Timer:
+    def __enter__(self) -> _Timer:
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.ms = (time.perf_counter() - self._start) * 1000.0
+
+    ms: float = 0.0
+
+
+def run(http: httpx.Client, base_url: str, api_key: str) -> Diagnostics:
+    """Probes each stage of the connection in order and collects the results."""
+    diag = Diagnostics(environment=_environment(api_key, base_url))
+
+    parts = urlsplit(base_url)
+    scheme = (parts.scheme or "").lower()
+    host = parts.hostname or ""
+    port = parts.port or (443 if scheme == "https" else 80)
+
+    diag.checks.append(
+        Check("base_url", True, f"{base_url!r} -> host={host!r} port={port} scheme={scheme}")
+    )
+
+    def skip(name: str) -> None:
+        diag.checks.append(
+            Check(name, False, "not attempted (an earlier stage failed)", skipped=True)
+        )
+
+    # DNS
+    addresses: list[str] = []
+    with _Timer() as t:
+        try:
+            infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+            addresses = sorted({str(info[4][0]) for info in infos})
+            dns_ok, dns_detail = True, f"{host} -> {', '.join(addresses)}"
+        except OSError as e:
+            dns_ok, dns_detail = False, f"could not resolve {host!r}: {e}"
+    diag.checks.append(Check("dns", dns_ok, dns_detail, t.ms))
+    if not dns_ok:
+        skip("tcp_connect")
+        skip("tls_handshake")
+        skip("api_preflight")
+        return diag
+
+    # TCP
+    with _Timer() as t:
+        try:
+            with socket.create_connection((host, port), timeout=10.0):
+                tcp_ok, tcp_detail = True, f"connected to {host}:{port}"
+        except OSError as e:
+            tcp_ok, tcp_detail = False, f"could not connect to {host}:{port}: {e}"
+    diag.checks.append(Check("tcp_connect", tcp_ok, tcp_detail, t.ms))
+    if not tcp_ok:
+        skip("tls_handshake")
+        skip("api_preflight")
+        return diag
+
+    # TLS
+    with _Timer() as t:
+        if scheme != "https":
+            tls_ok, tls_detail = True, "skipped (plain http)"
+        else:
+            try:
+                ctx = ssl.create_default_context()
+                with (
+                    socket.create_connection((host, port), timeout=10.0) as raw,
+                    ctx.wrap_socket(raw, server_hostname=host) as tls,
+                ):
+                    cert: Any = tls.getpeercert() or {}
+                    issuer = "unknown"
+                    for rdn in cert.get("issuer", ()):
+                        for key, value in rdn:
+                            if key == "organizationName":
+                                issuer = value
+                    cipher = tls.cipher()
+                    tls_ok = True
+                    tls_detail = (
+                        f"{tls.version()} {cipher[0] if cipher else ''} "
+                        f"issuer={issuer!r} notAfter={cert.get('notAfter', 'unknown')}"
+                    )
+            except (OSError, ssl.SSLError) as e:
+                tls_ok, tls_detail = False, f"TLS handshake failed: {e}"
+    diag.checks.append(Check("tls_handshake", tls_ok, tls_detail, t.ms))
+    if not tls_ok:
+        skip("api_preflight")
+        return diag
+
+    # An authenticated request. Only the status is reported -- never the body.
+    with _Timer() as t:
+        try:
+            resp = http.get("api/accounts")
+            pre_ok = resp.status_code == 200
+            pre_detail = f"GET api/accounts -> HTTP {resp.status_code}"
+            if resp.status_code == 401:
+                pre_detail += " (the API key was rejected)"
+        except httpx.HTTPError as e:
+            pre_ok, pre_detail = False, f"GET api/accounts failed: {type(e).__name__}: {e}"
+    diag.checks.append(Check("api_preflight", pre_ok, pre_detail, t.ms))
+
+    return diag

--- a/python/src/open_banking_io/diagnostics.py
+++ b/python/src/open_banking_io/diagnostics.py
@@ -17,7 +17,7 @@ import time
 from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 import httpx
 
@@ -111,14 +111,43 @@ def _package_version(name: str) -> str:
         return "unknown"
 
 
+_PROBE_TIMEOUT = 10.0
+
+
+def _port(parts: SplitResult) -> int | None:
+    """``SplitResult.port`` is a property that raises on an out-of-range value."""
+    try:
+        return parts.port
+    except ValueError:
+        return None
+
+
+def _port_is_invalid(parts: SplitResult) -> bool:
+    try:
+        _ = parts.port
+    except ValueError:
+        return True
+    return False
+
+
+def _default_port(scheme: str) -> int:
+    return 443 if scheme == "https" else 80
+
+
 def _safe_url(url: str) -> str:
     """The base url with any userinfo, query and fragment removed -- a base url may carry
     proxy or basic-auth credentials, and this string is written into the report."""
-    parts = urlsplit(url)
-    host = parts.hostname or ""
-    if parts.port:
-        host = f"{host}:{parts.port}"
-    return urlunsplit((parts.scheme, host, parts.path, "", ""))
+    try:
+        parts = urlsplit(url)
+        host = parts.hostname or ""
+        if ":" in host:  # an IPv6 literal keeps its brackets or the result is unparseable
+            host = f"[{host}]"
+        port = _port(parts)
+        if port is not None:
+            host = f"{host}:{port}"
+        return urlunsplit((parts.scheme, host, parts.path, "", ""))
+    except Exception:
+        return "<unparseable base url>"
 
 
 def _environment(api_key: str, base_url: str) -> dict[str, str]:
@@ -148,94 +177,131 @@ class _Timer:
     ms: float = 0.0
 
 
-def run(http: httpx.Client, base_url: str, api_key: str) -> Diagnostics:
-    """Probes each stage of the connection in order and collects the results."""
-    diag = Diagnostics(environment=_environment(api_key, base_url))
+_CHECK_NAMES = ("base_url", "dns", "tcp_connect", "tls_handshake", "api_preflight")
 
+
+def _guard(name: str, fn: Any) -> Check:
+    """Runs one stage. Any exception becomes a failed check -- a diagnostic that raises is
+    useless, and it is fed exactly the malformed input a caller could not debug themselves."""
+    with _Timer() as t:
+        try:
+            ok, detail = fn()
+        except Exception as e:  # deliberate: never propagate out of diagnose()
+            ok, detail = False, f"{type(e).__name__}: {e}"
+    return Check(name, ok, detail, t.ms)
+
+
+def run(http: httpx.Client, base_url: str, api_key: str) -> Diagnostics:
+    """Probes each stage of the connection in order and collects the results.
+
+    Never raises. Every stage is guarded, and the returned report always carries all five
+    checks so a caller can index them unconditionally.
+    """
+    try:
+        env = _environment(api_key, base_url)
+    except Exception as e:
+        env = {"error": f"could not collect environment: {type(e).__name__}: {e}"}
+
+    results: dict[str, Check] = {}
+
+    def skip(name: str, why: str = "an earlier stage failed") -> None:
+        results[name] = Check(name, False, f"not attempted ({why})", skipped=True)
+
+    # -- base url --------------------------------------------------------------
     parts = urlsplit(base_url)
     scheme = (parts.scheme or "").lower()
     host = parts.hostname or ""
-    port = parts.port or (443 if scheme == "https" else 80)
+    port_value = _port(parts)
 
-    diag.checks.append(
-        Check(
-            "base_url",
-            True,
-            f"{_safe_url(base_url)!r} -> host={host!r} port={port} scheme={scheme}",
-        )
-    )
+    def check_base_url() -> tuple[bool, str]:
+        shown = _safe_url(base_url)
+        if not host:
+            return False, f"{shown!r} has no host"
+        if _port_is_invalid(parts):
+            return False, f"{shown!r} has a port outside 1-65535"
+        shown_port = port_value or _default_port(scheme)
+        return True, f"{shown!r} -> host={host!r} port={shown_port} scheme={scheme}"
 
-    def skip(name: str, why: str = "an earlier stage failed") -> None:
-        diag.checks.append(Check(name, False, f"not attempted ({why})", skipped=True))
+    results["base_url"] = _guard("base_url", check_base_url)
+    port = port_value or _default_port(scheme)
 
-    # The probes below open their own sockets, so they bypass any proxy and any custom TLS
-    # configuration on the caller's httpx client. They localise a fault; they do not decide
-    # the verdict -- the preflight through the configured transport does.
-    with _Timer() as t:
-        try:
+    if not results["base_url"].ok:
+        skip("dns", "the base url is unusable")
+        skip("tcp_connect", "the base url is unusable")
+        skip("tls_handshake", "the base url is unusable")
+    else:
+        # The probes below open their own sockets, so they bypass any proxy and any custom
+        # TLS configuration on the caller's httpx client. They localise a fault; they do not
+        # decide the verdict -- the preflight through the configured transport does.
+        def check_dns() -> tuple[bool, str]:
             infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
             addresses = sorted({str(info[4][0]) for info in infos})
-            dns_ok, dns_detail = True, f"{host} -> {', '.join(addresses)}"
-        except OSError as e:
-            dns_ok, dns_detail = False, f"could not resolve {host!r}: {e}"
-    diag.checks.append(Check("dns", dns_ok, dns_detail, t.ms))
+            return True, f"{host} -> {', '.join(addresses)}"
 
-    tcp_ok = False
-    if not dns_ok:
-        skip("tcp_connect")
-    else:
-        with _Timer() as t:
-            try:
-                with socket.create_connection((host, port), timeout=10.0):
-                    tcp_ok, tcp_detail = True, f"connected to {host}:{port}"
-            except OSError as e:
-                tcp_ok, tcp_detail = False, f"could not connect to {host}:{port}: {e}"
-        diag.checks.append(Check("tcp_connect", tcp_ok, tcp_detail, t.ms))
+        results["dns"] = _guard("dns", check_dns)
 
-    if not tcp_ok:
-        skip("tls_handshake")
-    elif scheme != "https":
-        diag.checks.append(Check("tls_handshake", True, "skipped (plain http)"))
-    else:
-        with _Timer() as t:
-            try:
-                ctx = ssl.create_default_context()
-                # CodeQL: pin the floor so TLS 1.0/1.1 are never negotiated by the probe.
-                ctx.minimum_version = ssl.TLSVersion.TLSv1_2
-                with (
-                    socket.create_connection((host, port), timeout=10.0) as raw,
-                    ctx.wrap_socket(raw, server_hostname=host) as tls,
-                ):
-                    cert: Any = tls.getpeercert() or {}
-                    issuer = "unknown"
-                    for rdn in cert.get("issuer", ()):
-                        for key, value in rdn:
-                            if key == "organizationName":
-                                issuer = value
-                    cipher = tls.cipher()
-                    tls_ok = True
-                    tls_detail = (
-                        f"{tls.version()} {cipher[0] if cipher else ''} "
-                        f"issuer={issuer!r} notAfter={cert.get('notAfter', 'unknown')}"
-                    )
-            except (OSError, ssl.SSLError) as e:
-                tls_ok, tls_detail = False, f"TLS handshake failed: {e}"
-        diag.checks.append(Check("tls_handshake", tls_ok, tls_detail, t.ms))
+        if not results["dns"].ok:
+            skip("tcp_connect")
+            skip("tls_handshake")
+        else:
 
+            def check_tcp() -> tuple[bool, str]:
+                with socket.create_connection((host, port), timeout=_PROBE_TIMEOUT):
+                    return True, f"connected to {host}:{port}"
+
+            results["tcp_connect"] = _guard("tcp_connect", check_tcp)
+
+            if not results["tcp_connect"].ok:
+                skip("tls_handshake")
+            elif scheme != "https":
+                results["tls_handshake"] = Check(
+                    "tls_handshake", True, "not applicable (plain http)", skipped=True
+                )
+            else:
+
+                def check_tls() -> tuple[bool, str]:
+                    ctx = ssl.create_default_context()
+                    # Pin the floor so the probe can never negotiate TLS 1.0/1.1.
+                    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+                    with (
+                        socket.create_connection((host, port), timeout=_PROBE_TIMEOUT) as raw,
+                        ctx.wrap_socket(raw, server_hostname=host) as tls,
+                    ):
+                        cert: Any = tls.getpeercert() or {}
+                        issuer = "unknown"
+                        for rdn in cert.get("issuer", ()):
+                            for pair in rdn:
+                                if len(pair) == 2 and pair[0] == "organizationName":
+                                    issuer = pair[1]
+                        cipher = tls.cipher()
+                        return True, (
+                            f"{tls.version()} {cipher[0] if cipher else ''} "
+                            f"issuer={issuer!r} notAfter={cert.get('notAfter', 'unknown')}"
+                        )
+
+                results["tls_handshake"] = _guard("tls_handshake", check_tls)
+
+    # -- preflight -------------------------------------------------------------
     # Always attempted, whatever the probes said: this is the request the SDK actually makes,
     # through the caller's configured transport. Only the status is reported, never the body.
-    with _Timer() as t:
-        try:
-            resp = http.get("api/accounts")
-            pre_ok = resp.status_code == 200
-            pre_detail = f"GET api/accounts -> HTTP {resp.status_code}"
-            if resp.status_code == 401:
-                pre_detail += " (the API key was rejected)"
-        except httpx.HTTPError as e:
-            pre_ok, pre_detail = False, f"GET api/accounts failed: {type(e).__name__}: {e}"
-    if pre_ok and not all(c.ok for c in diag.checks):
-        pre_detail += " -- the request succeeded, so the failing probes above are most likely "
-        pre_detail += "a proxy or custom TLS setup they bypass, not a real fault"
-    diag.checks.append(Check("api_preflight", pre_ok, pre_detail, t.ms))
+    def check_preflight() -> tuple[bool, str]:
+        resp = http.get("api/accounts")
+        detail = f"GET api/accounts -> HTTP {resp.status_code}"
+        if resp.status_code == 401:
+            detail += " (the API key was rejected)"
+        return resp.status_code == 200, detail
 
-    return diag
+    preflight = _guard("api_preflight", check_preflight)
+    if preflight.ok and not all(results[n].ok for n in results):
+        preflight.detail += (
+            " -- the request succeeded, so the failing probes above are most likely "
+            "a proxy or custom TLS setup they bypass, not a real fault"
+        )
+    results["api_preflight"] = preflight
+
+    return Diagnostics(
+        checks=[
+            results.get(n) or Check(n, False, "not attempted", skipped=True) for n in _CHECK_NAMES
+        ],
+        environment=env,
+    )

--- a/python/tests/test_diagnostics.py
+++ b/python/tests/test_diagnostics.py
@@ -3,6 +3,8 @@
 import json
 import logging
 
+import pytest
+
 from open_banking_io import OpenBankingClient
 
 ACCOUNT_ID = "11111111-1111-4111-8111-111111111111"
@@ -29,10 +31,11 @@ def test_diagnose_against_a_live_server_passes_every_check(httpserver, credentia
     assert diag.ok is True
     names = [c.name for c in diag.checks]
     assert names == ["base_url", "dns", "tcp_connect", "tls_handshake", "api_preflight"]
-    # Plain http to loopback: the TLS stage is skipped, not failed.
+    # Plain http to loopback: the TLS stage is skipped, not failed -- and says so in the
+    # `skipped` field, not just in prose.
     tls = next(c for c in diag.checks if c.name == "tls_handshake")
     assert tls.ok is True
-    assert "skipped" in tls.detail.lower()
+    assert tls.skipped is True
     preflight = next(c for c in diag.checks if c.name == "api_preflight")
     assert "200" in preflight.detail
 
@@ -214,3 +217,101 @@ def test_preflight_runs_even_when_the_direct_probes_fail(httpserver, credentials
     assert preflight.ok is True
     assert "proxy" in preflight.detail
     assert diag.ok is True
+
+
+# -- Never raises, and always returns all five checks ------------------------
+
+CHECK_NAMES = ["base_url", "dns", "tcp_connect", "tls_handshake", "api_preflight"]
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "https://example.com:99999",  # SplitResult.port raises ValueError
+        "https://" + "a" * 64 + ".example.com",  # getaddrinfo raises UnicodeError
+        "https://[2001:db8::1]:8443",  # IPv6 literal
+        "https://127.0.0.1:1",  # nothing listening
+    ],
+)
+def test_diagnose_never_raises_and_always_returns_five_checks(credentials, hostile):
+    with _client(hostile, credentials) as client:
+        diag = client.diagnose()
+
+    assert [c.name for c in diag.checks] == CHECK_NAMES
+    assert diag.ok is False
+
+
+def test_diagnose_survives_a_transport_that_raises_a_non_http_error(credentials):
+    import httpx
+
+    def explode(request):
+        raise ValueError("transport exploded")
+
+    hostile = httpx.Client(transport=httpx.MockTransport(explode))
+    with _client("https://example.test", credentials, http_client=hostile) as client:
+        diag = client.diagnose()
+
+    preflight = next(c for c in diag.checks if c.name == "api_preflight")
+    assert preflight.ok is False
+    assert "ValueError" in preflight.detail
+
+
+def test_diagnose_survives_a_closed_client(httpserver, credentials):
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json([])
+    client = _client(httpserver.url_for("").rstrip("/"), credentials)
+    client.close()
+
+    diag = client.diagnose()
+
+    assert [c.name for c in diag.checks] == CHECK_NAMES
+    assert next(c for c in diag.checks if c.name == "api_preflight").ok is False
+
+
+def test_a_base_url_with_no_host_fails_the_base_url_check(credentials):
+    """`getaddrinfo("", 443)` resolves to loopback, so DNS must not be allowed to 'pass'."""
+    with _client("https:///v1", credentials) as client:
+        diag = client.diagnose()
+
+    base = next(c for c in diag.checks if c.name == "base_url")
+    assert base.ok is False
+    assert next(c for c in diag.checks if c.name == "dns").skipped is True
+
+
+def test_ipv6_literals_keep_their_brackets_in_the_report(credentials):
+    with _client("https://[2001:db8::1]:8443/v1", credentials) as client:
+        report = client.diagnose().report()
+
+    assert "https://[2001:db8::1]:8443/v1" in report
+
+
+# -- Response bodies and full URLs must never reach the report or the log ----
+
+
+def test_response_bodies_are_never_captured(httpserver, credentials):
+    secret = "SUPER-SECRET-BODY-abc123"
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json(
+        {"leak": secret}, status=500
+    )
+
+    with _client(httpserver.url_for("").rstrip("/"), credentials) as client:
+        diag = client.diagnose()
+
+    assert secret not in diag.report()
+    assert secret not in json.dumps(diag.as_dict())
+
+
+def test_the_log_records_the_path_only_never_the_full_url(httpserver, credentials, caplog):
+    """A base url can carry userinfo, and httpx.URL.__str__ preserves it."""
+    host = httpserver.url_for("").rstrip("/").split("://", 1)[1]
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json([])
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="open_banking_io"),
+        _client(f"http://alice:hunter2@{host}", credentials) as client,
+    ):
+        client.get_accounts()
+
+    joined = " ".join(r.getMessage() for r in caplog.records if r.name == "open_banking_io")
+    assert "/api/accounts" in joined
+    assert "hunter2" not in joined
+    assert "alice" not in joined

--- a/python/tests/test_diagnostics.py
+++ b/python/tests/test_diagnostics.py
@@ -3,6 +3,7 @@
 import json
 import logging
 
+import httpx
 import pytest
 
 from open_banking_io import OpenBankingClient
@@ -315,3 +316,23 @@ def test_the_log_records_the_path_only_never_the_full_url(httpserver, credential
     assert "/api/accounts" in joined
     assert "hunter2" not in joined
     assert "alice" not in joined
+
+
+def test_an_unparseable_base_url_fails_instead_of_raising(credentials):
+    """urlsplit itself raises on some malformed input, so it must run behind the guard."""
+    from open_banking_io import diagnostics
+
+    diag = diagnostics.run(httpx.Client(), "https://[", "k")
+
+    assert [c.name for c in diag.checks] == CHECK_NAMES
+    assert diag.checks[0].ok is False
+    assert diag.ok is False
+
+
+def test_an_explicit_port_zero_is_rejected_not_silently_replaced(credentials):
+    """`or` would swallow port 0 and report the scheme default, hiding the real target."""
+    with _client("https://127.0.0.1:0", credentials) as client:
+        base = client.diagnose().checks[0]
+
+    assert base.ok is False
+    assert "443" not in base.detail

--- a/python/tests/test_diagnostics.py
+++ b/python/tests/test_diagnostics.py
@@ -64,15 +64,25 @@ def test_report_never_contains_the_api_key_or_private_key(httpserver, credential
     assert credentials["encryptionKey"]["privateKey"] not in json.dumps(diag.as_dict())
 
 
-def test_report_identifies_the_key_by_fingerprint_only(httpserver, credentials):
+def test_the_api_key_is_described_never_shown(httpserver, credentials):
     httpserver.expect_request("/api/accounts", method="GET").respond_with_json([])
 
     with _client(httpserver.url_for("").rstrip("/"), credentials) as client:
         diag = client.diagnose()
 
-    fp = diag.environment["api_key_fingerprint"]
-    assert len(fp) == 16
-    assert fp not in credentials["apiKey"]
+    assert diag.environment["api_key"] == f"set ({len(credentials['apiKey'])} chars)"
+
+
+def test_credentials_in_the_base_url_are_stripped_from_the_report(httpserver, credentials):
+    """A base url may carry basic-auth userinfo; it must not reach a pasteable report."""
+    host = httpserver.url_for("").rstrip("/").split("://", 1)[1]
+    with _client(f"http://alice:hunter2@{host}", credentials) as client:
+        diag = client.diagnose()
+        report = diag.report()
+
+    assert "hunter2" not in report
+    assert "alice" not in report
+    assert "hunter2" not in json.dumps(diag.as_dict())
 
 
 def test_proxy_env_vars_are_reported_by_name_with_values_redacted(
@@ -100,8 +110,12 @@ def test_dns_failure_is_reported_not_raised(credentials):
     assert diag.ok is False
     dns = next(c for c in diag.checks if c.name == "dns")
     assert dns.ok is False
-    # Stages after the first failure are not attempted.
+    # A probe that depends on a failed one is skipped ...
     assert next(c for c in diag.checks if c.name == "tcp_connect").skipped is True
+    # ... but the preflight always runs, since it is the authoritative check.
+    preflight = next(c for c in diag.checks if c.name == "api_preflight")
+    assert preflight.skipped is False
+    assert preflight.ok is False
 
 
 def test_connection_refused_is_reported_not_raised(credentials):
@@ -180,3 +194,23 @@ def test_an_injected_http_client_is_not_instrumented(httpserver, credentials):
         client.get_accounts()
 
     assert {k: list(v) for k, v in injected.event_hooks.items()} == hooks_before
+
+
+def test_preflight_runs_even_when_the_direct_probes_fail(httpserver, credentials):
+    """A proxy or custom TLS setup can make the direct probes fail on a working connection,
+    so the verdict comes from the request the SDK actually makes."""
+    import httpx
+
+    # Stands in for a proxy: the host never resolves directly, but the configured
+    # transport delivers the request anyway.
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json=[]))
+    proxied = httpx.Client(transport=transport)
+
+    with _client("https://nonexistent.invalid", credentials, http_client=proxied) as client:
+        diag = client.diagnose()
+
+    assert next(c for c in diag.checks if c.name == "dns").ok is False
+    preflight = next(c for c in diag.checks if c.name == "api_preflight")
+    assert preflight.ok is True
+    assert "proxy" in preflight.detail
+    assert diag.ok is True

--- a/python/tests/test_diagnostics.py
+++ b/python/tests/test_diagnostics.py
@@ -1,0 +1,182 @@
+"""Diagnostics: a redacted, pasteable connectivity report and opt-in request logging."""
+
+import json
+import logging
+
+from open_banking_io import OpenBankingClient
+
+ACCOUNT_ID = "11111111-1111-4111-8111-111111111111"
+
+
+def _client(base_url, credentials, **kw):
+    return OpenBankingClient(
+        api_base_url=base_url,
+        api_key=credentials["apiKey"],
+        private_key_pkcs8=credentials["encryptionKey"]["privateKey"],
+        **kw,
+    )
+
+
+# -- The happy path ----------------------------------------------------------
+
+
+def test_diagnose_against_a_live_server_passes_every_check(httpserver, credentials):
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json([])
+
+    with _client(httpserver.url_for("").rstrip("/"), credentials) as client:
+        diag = client.diagnose()
+
+    assert diag.ok is True
+    names = [c.name for c in diag.checks]
+    assert names == ["base_url", "dns", "tcp_connect", "tls_handshake", "api_preflight"]
+    # Plain http to loopback: the TLS stage is skipped, not failed.
+    tls = next(c for c in diag.checks if c.name == "tls_handshake")
+    assert tls.ok is True
+    assert "skipped" in tls.detail.lower()
+    preflight = next(c for c in diag.checks if c.name == "api_preflight")
+    assert "200" in preflight.detail
+
+
+def test_report_is_a_readable_string(httpserver, credentials):
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json([])
+
+    with _client(httpserver.url_for("").rstrip("/"), credentials) as client:
+        report = client.diagnose().report()
+
+    assert "open-banking.io diagnostics" in report
+    assert "base_url" in report
+    assert "api_preflight" in report
+
+
+# -- Redaction: the whole point of a pasteable report ------------------------
+
+
+def test_report_never_contains_the_api_key_or_private_key(httpserver, credentials):
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json([])
+
+    with _client(httpserver.url_for("").rstrip("/"), credentials) as client:
+        diag = client.diagnose()
+        report = diag.report()
+
+    assert credentials["apiKey"] not in report
+    assert credentials["encryptionKey"]["privateKey"] not in report
+    assert credentials["apiKey"] not in json.dumps(diag.as_dict())
+    assert credentials["encryptionKey"]["privateKey"] not in json.dumps(diag.as_dict())
+
+
+def test_report_identifies_the_key_by_fingerprint_only(httpserver, credentials):
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json([])
+
+    with _client(httpserver.url_for("").rstrip("/"), credentials) as client:
+        diag = client.diagnose()
+
+    fp = diag.environment["api_key_fingerprint"]
+    assert len(fp) == 16
+    assert fp not in credentials["apiKey"]
+
+
+def test_proxy_env_vars_are_reported_by_name_with_values_redacted(
+    httpserver, credentials, monkeypatch
+):
+    monkeypatch.setenv("HTTPS_PROXY", "http://user:hunter2@proxy.internal:3128")
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json([])
+
+    with _client(httpserver.url_for("").rstrip("/"), credentials) as client:
+        diag = client.diagnose()
+        report = diag.report()
+
+    assert "HTTPS_PROXY" in report
+    assert "hunter2" not in report
+    assert "proxy.internal" not in report
+
+
+# -- Failure paths: a diagnostic must never raise ----------------------------
+
+
+def test_dns_failure_is_reported_not_raised(credentials):
+    with _client("https://nonexistent.invalid", credentials) as client:
+        diag = client.diagnose()
+
+    assert diag.ok is False
+    dns = next(c for c in diag.checks if c.name == "dns")
+    assert dns.ok is False
+    # Stages after the first failure are not attempted.
+    assert next(c for c in diag.checks if c.name == "tcp_connect").skipped is True
+
+
+def test_connection_refused_is_reported_not_raised(credentials):
+    # Port 9 is the discard port; nothing listens on loopback there.
+    with _client("http://127.0.0.1:9", credentials) as client:
+        diag = client.diagnose()
+
+    assert diag.ok is False
+    assert next(c for c in diag.checks if c.name == "dns").ok is True
+    assert next(c for c in diag.checks if c.name == "tcp_connect").ok is False
+
+
+def test_an_unauthorized_preflight_is_reported_as_a_failed_check(httpserver, credentials):
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json(
+        {"error": "unauthorized"}, status=401
+    )
+
+    with _client(httpserver.url_for("").rstrip("/"), credentials) as client:
+        diag = client.diagnose()
+
+    preflight = next(c for c in diag.checks if c.name == "api_preflight")
+    assert preflight.ok is False
+    assert "401" in preflight.detail
+
+
+def test_environment_reports_versions(httpserver, credentials):
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json([])
+
+    with _client(httpserver.url_for("").rstrip("/"), credentials) as client:
+        env = client.diagnose().environment
+
+    for key in ("sdk_version", "python_version", "httpx_version", "openssl_version", "platform"):
+        assert env[key]
+
+
+# -- Opt-in request logging --------------------------------------------------
+
+
+def test_requests_are_logged_without_headers_or_bodies(httpserver, credentials, caplog):
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json([])
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="open_banking_io"),
+        _client(httpserver.url_for("").rstrip("/"), credentials) as client,
+    ):
+        client.get_accounts()
+
+    messages = [r.getMessage() for r in caplog.records if r.name == "open_banking_io"]
+    assert any("GET" in m and "/api/accounts" in m and "200" in m for m in messages)
+    joined = " ".join(messages)
+    assert credentials["apiKey"] not in joined
+    assert "X-Api-Key" not in joined
+
+
+def test_nothing_is_logged_when_the_logger_is_not_enabled(httpserver, credentials, caplog):
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json([])
+
+    with (
+        caplog.at_level(logging.CRITICAL, logger="open_banking_io"),
+        _client(httpserver.url_for("").rstrip("/"), credentials) as client,
+    ):
+        client.get_accounts()
+
+    assert [r for r in caplog.records if r.name == "open_banking_io"] == []
+
+
+def test_an_injected_http_client_is_not_instrumented(httpserver, credentials):
+    """A caller-supplied client is used as-is, so we must not mutate its event hooks."""
+    import httpx
+
+    injected = httpx.Client()
+    hooks_before = {k: list(v) for k, v in injected.event_hooks.items()}
+    httpserver.expect_request("/api/accounts", method="GET").respond_with_json([])
+
+    with _client(httpserver.url_for("").rstrip("/"), credentials, http_client=injected) as client:
+        client.get_accounts()
+
+    assert {k: list(v) for k, v in injected.event_hooks.items()} == hooks_before


### PR DESCRIPTION
## What & why

A support report of a connection-stage failure arrived with nothing correlatable in it — no base url, no exception, no traceback — because the SDK gives a caller no way to produce one. This adds that.

`diagnose()` probes base url, DNS, TCP, TLS and an authenticated request in order, records each stage's own failure instead of raising, and skips stages that depend on a failed one. `report()` renders pasteable text; `as_dict()` gives the same data structurally.

```
[PASS] base_url       'https://open-banking.io' -> host='open-banking.io' port=443 scheme=https  (0 ms)
[PASS] dns            open-banking.io -> 104.21.78.242, 172.67.138.186  (24 ms)
[PASS] tcp_connect    connected to open-banking.io:443  (10 ms)
[PASS] tls_handshake  TLSv1.3 TLS_AES_256_GCM_SHA384 issuer='Google Trust Services' notAfter=Nov  5 13:47:21 2026 GMT  (40 ms)
[PASS] api_preflight  GET api/accounts -> HTTP 200  (159 ms)
```

Request logging goes to the standard `open_banking_io` logger, is silent until enabled, and records only method, path, status and duration. It is installed only on a client the SDK owns — an injected `httpx.Client` is left untouched (covered by a test).

Python only, per scope.

## Affected SDK(s)
- [ ] dotnet · [ ] node · [x] python · [ ] rust · [ ] go · [ ] java · [ ] ruby · [ ] php
- [ ] shared (`fixtures/`, workflows, docs)

## Checklist
- [x] Tests pass locally for the affected SDK(s) (see `CONTRIBUTING.md`) — 92 passed, 12 new
- [x] Linters/formatters pass — ruff + mypy strict clean
- [x] If the envelope/wire format changed, I regenerated `fixtures/` — n/a
- [x] I did **not** bump package versions

## Security checklist
- [x] No secrets, credentials, or session uids in code, logs, or error messages — API key appears only as a SHA-256 fingerprint; private key, decrypted data and response bodies are never captured; proxy/CA env vars are listed by name with values withheld. Asserted directly in `test_report_never_contains_the_api_key_or_private_key` and `test_proxy_env_vars_are_reported_by_name_with_values_redacted`.
- [x] Money uses decimal/exact types, never float — unchanged
- [x] No disabled TLS verification; no new network egress beyond the documented API — the TLS probe uses `ssl.create_default_context()` and connects only to the configured base url


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Python client `diagnose()` method covering URL parsing, DNS, TCP, TLS, and API access.
  * Added safe, serializable diagnostic reports suitable for sharing with support, including redacted environment and credential information.
  * Diagnostic checks record failures without raising exceptions and skip dependent checks when necessary.
  * Added optional request logging that records methods, paths, statuses, and durations without exposing headers, bodies, or secrets.
* **Documentation**
  * Documented diagnostics usage, report contents, redaction behavior, and optional request logging in the Python client README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->