### PR TITLE
chore(python): 1.2.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-banking-io"
-version = "1.1.0"
+version = "1.2.0"
 description = "Server-to-server client for open-banking.io with local zero-knowledge envelope decryption."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## What & why

Version bump for `diagnose()` and opt-in request logging (#185). Minor: new public API (`diagnose()`, `Diagnostics`, `Check`, the `open_banking_io` logger), no breaking changes.

## Affected SDK(s)
- [ ] dotnet · [ ] node · [x] python · [ ] rust · [ ] go · [ ] java · [ ] ruby · [ ] php
- [ ] shared (`fixtures/`, workflows, docs)

## Checklist
- [x] Tests pass locally for the affected SDK(s) (see `CONTRIBUTING.md`)
- [x] Linters/formatters pass
- [x] If the envelope/wire format changed, I regenerated `fixtures/` — n/a
- [ ] I did **not** bump package versions — this PR *is* the bump (step 1 of `RELEASING.md`)

## Security checklist
- [x] No secrets, credentials, or session uids in code, logs, or error messages
- [x] Money uses decimal/exact types, never float
- [x] No disabled TLS verification; no new network egress beyond the documented API
