### PR TITLE
CLI: openbanking partner key generate | fingerprint | answer (after go/v0.4.0)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -37,6 +37,9 @@ go install github.com/open-banking-io/clients/cli@latest
 openbanking login                       # sign in + unlock in the browser — sets up everything
 openbanking login --method github       # skip the picker (or --method pin for an emailed code)
 openbanking key import ./credentials.json   # (fallback) import a key file on a headless machine
+openbanking partner key generate        # partners: make your decryption key pair (recipient-key.json, 0600)
+openbanking partner key fingerprint -   # …print the fingerprint of a key (file, pkcs8 or raw point on stdin)
+openbanking partner key answer --key recipient-key.json <envelope>   # …answer the install challenge
 openbanking accounts                    # list accounts with balances        (alias: acc, ls)
 openbanking use                         # pick a current account (arrow keys) — or: use <account-id>
 openbanking transactions                # the current account's statement     (alias: tx)

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,7 +3,7 @@ module github.com/open-banking-io/clients/cli
 go 1.25.0
 
 require (
-	github.com/open-banking-io/clients/go v0.3.0
+	github.com/open-banking-io/clients/go v0.4.1
 	golang.org/x/term v0.45.0
 )
 

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,5 +1,5 @@
-github.com/open-banking-io/clients/go v0.3.0 h1:TKdpWDvPvUE99JTC39kv31AXc6yaIRP6hfYN7nldJ0k=
-github.com/open-banking-io/clients/go v0.3.0/go.mod h1:DOqVT2pmX1aHGLXG5t4E0uqRYedPJ8nXvW9UiGCObZI=
+github.com/open-banking-io/clients/go v0.4.1 h1:agbQsaXziuerQqOCh/hd/bse71h/fpNfTRNDYFm8J6U=
+github.com/open-banking-io/clients/go v0.4.1/go.mod h1:DOqVT2pmX1aHGLXG5t4E0uqRYedPJ8nXvW9UiGCObZI=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=

--- a/cli/internal/app/commands.go
+++ b/cli/internal/app/commands.go
@@ -24,6 +24,7 @@ func (a *App) commands() []command {
 		{name: "connections", aliases: []string{"conn"}, short: "List your bank connections", run: (*App).connections},
 		{name: "banks", short: "List banks available to connect (--country)", run: (*App).banks},
 		{name: "key", short: "Import your encryption key (key import [<file>])", run: (*App).key},
+		{name: "partner", short: "Partner tooling: your decryption key (partner key generate|fingerprint|answer)", run: (*App).partner},
 		{name: "completion", short: "Output a shell completion script (bash|zsh|fish)", run: (*App).completion},
 		{name: "version", aliases: []string{"--version", "-v"}, short: "Print the openbanking version", run: (*App).versionCmd, hidden: true},
 		{name: "help", aliases: []string{"-h", "--help"}, short: "Show this help", run: (*App).helpCmd, hidden: true},

--- a/cli/internal/app/partner.go
+++ b/cli/internal/app/partner.go
@@ -1,0 +1,225 @@
+package app
+
+import (
+	"crypto/ecdh"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	openbanking "github.com/open-banking-io/clients/go"
+)
+
+const partnerKeyUsage = "usage: openbanking partner key generate [--out FILE] [--print-private] | fingerprint [<file>|-] | answer --key FILE [<envelope>|-]"
+
+// partner is the tooling a partner (not an end user) needs: its own decryption key. The install
+// itself stays on the partner page — the endpoints take a signed-in owner session, not an API key.
+func (a *App) partner(args []string) error {
+	if len(args) < 2 || args[0] != "key" {
+		return errors.New(partnerKeyUsage)
+	}
+	switch args[1] {
+	case "generate":
+		return a.partnerKeyGenerate(args[2:])
+	case "fingerprint":
+		return a.partnerKeyFingerprint(args[2:])
+	case "answer":
+		return a.partnerKeyAnswer(args[2:])
+	default:
+		return fmt.Errorf("unknown partner key subcommand %q (%s)", args[1], partnerKeyUsage)
+	}
+}
+
+// recipientKeyFile is the bundle the partner page downloads and `partner key generate` writes:
+// the same shape as a credentials bundle's encryptionKey, so the other key readers accept it.
+type recipientKeyFile struct {
+	Service       string                    `json:"service"`
+	Kind          string                    `json:"kind"`
+	Fingerprint   string                    `json:"fingerprint"`
+	EncryptionKey openbanking.EncryptionKey `json:"encryptionKey"`
+	CreatedAt     string                    `json:"createdAt"`
+}
+
+func (a *App) partnerKeyGenerate(args []string) error {
+	fs := flag.NewFlagSet("partner key generate", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	out := fs.String("out", "recipient-key.json", "file to write the key pair to (created 0600, never overwritten)")
+	printPrivate := fs.Bool("print-private", false, "also print the private half to stdout")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	priv, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("could not generate a key: %w", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return fmt.Errorf("could not encode the key: %w", err)
+	}
+	privateB64 := base64.StdEncoding.EncodeToString(der)
+	publicRaw := priv.PublicKey().Bytes()
+	publicB64 := base64.StdEncoding.EncodeToString(publicRaw)
+	fp := recipientKeyFingerprint(publicRaw)
+
+	enc := encryptionKeyFor(privateB64)
+	enc.PublicKey = publicB64
+	file := recipientKeyFile{Service: "open-banking.io", Kind: "partner-recipient-key", Fingerprint: fp, EncryptionKey: enc, CreatedAt: time.Now().UTC().Format(time.RFC3339)}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(*out, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("%s already exists — a key file is never overwritten; pass --out to write elsewhere", *out)
+		}
+		return fmt.Errorf("could not create %s: %w", *out, err)
+	}
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("could not write %s: %w", *out, err)
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(a.stdout(), "Private key written to %s (keep it where your deployment can read it; it cannot be recovered)\n", *out)
+	fmt.Fprintf(a.stdout(), "Public key (install this on your partner page):\n%s\n", publicB64)
+	fmt.Fprintf(a.stdout(), "Fingerprint: %s\n", fp)
+	if *printPrivate {
+		fmt.Fprintf(a.stdout(), "Private key (PKCS#8, base64):\n%s\n", privateB64)
+	}
+	return nil
+}
+
+func (a *App) partnerKeyFingerprint(args []string) error {
+	fs := flag.NewFlagSet("partner key fingerprint", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	raw, err := a.readInput(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	publicRaw, err := publicPointFrom(raw)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(a.stdout(), recipientKeyFingerprint(publicRaw))
+	return nil
+}
+
+func (a *App) partnerKeyAnswer(args []string) error {
+	fs := flag.NewFlagSet("partner key answer", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	keyPath := fs.String("key", "", "the key file (from `partner key generate` or the partner page download), or a bare PKCS#8 key")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *keyPath == "" {
+		return errors.New("--key is required: the file holding the private half of the key being installed")
+	}
+	keyRaw, err := os.ReadFile(*keyPath)
+	if err != nil {
+		return fmt.Errorf("could not read the key file: %w", err)
+	}
+	enc, err := parseEncryptionKey(keyRaw)
+	if err != nil {
+		return err
+	}
+	envelopeText := fs.Arg(0)
+	if envelopeText == "" || envelopeText == "-" {
+		piped, err := io.ReadAll(a.stdin())
+		if err != nil {
+			return fmt.Errorf("could not read stdin: %w", err)
+		}
+		envelopeText = string(piped)
+	}
+	envelope := strings.Join(strings.Fields(envelopeText), "")
+	if envelope == "" {
+		return errors.New("no envelope given: pass it as the argument, or pipe it on stdin")
+	}
+	var payload struct {
+		Nonce string `json:"nonce"`
+	}
+	ok, err := openbanking.DecryptTo(enc.PrivateKey, envelope, &payload)
+	if err != nil {
+		return fmt.Errorf("could not open the challenge with this key — is it the private half of the key you are installing? (%w)", err)
+	}
+	if !ok || payload.Nonce == "" {
+		return errors.New("the envelope opened but carries no nonce; it is not a recipient-key challenge")
+	}
+	fmt.Fprintln(a.stdout(), payload.Nonce)
+	return nil
+}
+
+// readInput reads a file argument, or stdin when the argument is empty or "-".
+func (a *App) readInput(arg string) ([]byte, error) {
+	if arg == "" || arg == "-" {
+		data, err := io.ReadAll(a.stdin())
+		if err != nil {
+			return nil, fmt.Errorf("could not read stdin: %w", err)
+		}
+		return data, nil
+	}
+	data, err := os.ReadFile(arg)
+	if err != nil {
+		return nil, fmt.Errorf("could not read %s: %w", arg, err)
+	}
+	return data, nil
+}
+
+// publicPointFrom accepts a key file, a bare PKCS#8 private key, or the raw base64 public point
+// itself, and returns the 65-byte uncompressed point the fingerprint is computed over.
+func publicPointFrom(raw []byte) ([]byte, error) {
+	trimmed := strings.Join(strings.Fields(string(raw)), "")
+	if !strings.HasPrefix(trimmed, "{") {
+		if b, err := base64.StdEncoding.DecodeString(trimmed); err == nil && len(b) == 65 && b[0] == 0x04 {
+			return b, nil
+		}
+	}
+	enc, err := parseEncryptionKey(raw)
+	if err != nil {
+		return nil, err
+	}
+	der, err := base64.StdEncoding.DecodeString(enc.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base64 private key: %w", err)
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(der)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PKCS#8 key: %w", err)
+	}
+	ecKey, ok := parsed.(interface {
+		ECDH() (*ecdh.PrivateKey, error)
+	})
+	if !ok {
+		return nil, errors.New("key is not an EC key")
+	}
+	priv, err := ecKey.ECDH()
+	if err != nil {
+		return nil, fmt.Errorf("key is not usable for ECDH: %w", err)
+	}
+	if priv.Curve() != ecdh.P256() {
+		return nil, errors.New("key is not on the P-256 curve")
+	}
+	return priv.PublicKey().Bytes(), nil
+}
+
+// recipientKeyFingerprint is what the partner page and the admin show: SHA-256 of the raw
+// 65-byte point, lowercase hex, first 16 characters.
+func recipientKeyFingerprint(publicRaw []byte) string {
+	sum := sha256.Sum256(publicRaw)
+	return hex.EncodeToString(sum[:])[:16]
+}

--- a/cli/internal/app/partner_key_test.go
+++ b/cli/internal/app/partner_key_test.go
@@ -1,0 +1,173 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func repoFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "fixtures", name))
+	if err != nil {
+		t.Fatalf("fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func fixtureKeypair(t *testing.T) (private, public string) {
+	t.Helper()
+	var kp struct {
+		Private string `json:"privateKeyPkcs8B64"`
+		Public  string `json:"publicKeyRawB64"`
+	}
+	if err := json.Unmarshal(repoFixture(t, "keypair.json"), &kp); err != nil {
+		t.Fatal(err)
+	}
+	return kp.Private, kp.Public
+}
+
+func TestPartnerKeyGenerate_WritesA0600File_PrintsThePublicHalf_AndKeepsThePrivateOneOffStdout(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "recipient-key.json")
+	var stdout, stderr bytes.Buffer
+	app := &App{Stdout: &stdout, Stderr: &stderr}
+	if err := app.Run([]string{"partner", "key", "generate", "--out", out}); err != nil {
+		t.Fatalf("generate: %v\nstderr: %s", err, stderr.String())
+	}
+
+	info, err := os.Stat(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %o, want 0600", info.Mode().Perm())
+	}
+	var file recipientKeyFile
+	data, _ := os.ReadFile(out)
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatal(err)
+	}
+	if file.Kind != "partner-recipient-key" || file.EncryptionKey.PrivateKey == "" || file.EncryptionKey.PublicKey == "" {
+		t.Errorf("file = %+v, want a partner-recipient-key with both halves", file)
+	}
+	if !strings.Contains(stdout.String(), file.EncryptionKey.PublicKey) || !strings.Contains(stdout.String(), file.Fingerprint) {
+		t.Errorf("stdout should show the public half and the fingerprint:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), file.EncryptionKey.PrivateKey) {
+		t.Errorf("stdout must not show the private half without --print-private:\n%s", stdout.String())
+	}
+	if len(file.Fingerprint) != 16 {
+		t.Errorf("fingerprint %q is not 16 hex characters", file.Fingerprint)
+	}
+
+	// The file is never overwritten: a second run must refuse rather than replace a key in use.
+	stdout.Reset()
+	if err := app.Run([]string{"partner", "key", "generate", "--out", out}); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("second generate: err = %v, want a refusal to overwrite", err)
+	}
+	after, _ := os.ReadFile(out)
+	if !bytes.Equal(after, data) {
+		t.Error("the existing key file changed")
+	}
+
+	// --print-private shows it, once, for the person who is about to paste it into a secret store.
+	stdout.Reset()
+	other := filepath.Join(t.TempDir(), "k.json")
+	if err := app.Run([]string{"partner", "key", "generate", "--out", other, "--print-private"}); err != nil {
+		t.Fatal(err)
+	}
+	var second recipientKeyFile
+	d2, _ := os.ReadFile(other)
+	_ = json.Unmarshal(d2, &second)
+	if !strings.Contains(stdout.String(), second.EncryptionKey.PrivateKey) {
+		t.Errorf("--print-private should print the private half:\n%s", stdout.String())
+	}
+}
+
+func TestPartnerKeyFingerprint_MatchesThePartnerPage_ForEveryInputShape(t *testing.T) {
+	private, public := fixtureKeypair(t)
+	// Written out by hand for the committed fixtures/keypair.json.
+	const want = "91fa2aea473dbab6\n"
+
+	for name, input := range map[string]string{
+		"raw public point": public,
+		"bare pkcs8":       private,
+		"key file":         `{"encryptionKey":{"privateKey":"` + private + `"}}`,
+	} {
+		var stdout, stderr bytes.Buffer
+		app := &App{Stdin: strings.NewReader(input), Stdout: &stdout, Stderr: &stderr}
+		if err := app.Run([]string{"partner", "key", "fingerprint", "-"}); err != nil {
+			t.Fatalf("%s: %v\nstderr: %s", name, err, stderr.String())
+		}
+		if stdout.String() != want {
+			t.Errorf("%s: fingerprint = %q, want %q", name, stdout.String(), want)
+		}
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Stdin: strings.NewReader("aGVsbG8="), Stdout: &stdout, Stderr: &stdout}
+	if err := app.Run([]string{"partner", "key", "fingerprint"}); err == nil {
+		t.Error("a non-key should be refused")
+	}
+}
+
+func TestPartnerKeyAnswer_PrintsOnlyTheNonce_AndOnlyForTheRightKey(t *testing.T) {
+	private, _ := fixtureKeypair(t)
+	var ch struct {
+		Nonce    string `json:"nonce"`
+		Envelope string `json:"envelope"`
+	}
+	if err := json.Unmarshal(repoFixture(t, "recipient-key-challenge.json"), &ch); err != nil {
+		t.Fatal(err)
+	}
+	keyFile := filepath.Join(t.TempDir(), "recipient-key.json")
+	if err := os.WriteFile(keyFile, []byte(`{"encryptionKey":{"privateKey":"`+private+`"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := &App{Stdout: &stdout, Stderr: &stderr}
+	if err := app.Run([]string{"partner", "key", "answer", "--key", keyFile, ch.Envelope}); err != nil {
+		t.Fatalf("answer: %v\nstderr: %s", err, stderr.String())
+	}
+	if stdout.String() != ch.Nonce+"\n" {
+		t.Errorf("stdout = %q, want the nonce alone", stdout.String())
+	}
+
+	// From stdin too, with the whitespace a terminal paste adds.
+	stdout.Reset()
+	app = &App{Stdin: strings.NewReader("  " + ch.Envelope + "\n"), Stdout: &stdout, Stderr: &stderr}
+	if err := app.Run([]string{"partner", "key", "answer", "--key", keyFile}); err != nil {
+		t.Fatal(err)
+	}
+	if stdout.String() != ch.Nonce+"\n" {
+		t.Errorf("stdin: stdout = %q", stdout.String())
+	}
+
+	// A stranger's key opens nothing.
+	strangerOut := filepath.Join(t.TempDir(), "stranger.json")
+	if err := (&App{Stdout: &bytes.Buffer{}, Stderr: &stderr}).Run([]string{"partner", "key", "generate", "--out", strangerOut}); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	app = &App{Stdout: &stdout, Stderr: &stderr}
+	if err := app.Run([]string{"partner", "key", "answer", "--key", strangerOut, ch.Envelope}); err == nil {
+		t.Error("a different key answered the challenge")
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("nothing must be printed on failure, got %q", stdout.String())
+	}
+
+	// A data envelope is not a challenge.
+	var env struct {
+		UID string `json:"uid"`
+	}
+	_ = json.Unmarshal(repoFixture(t, "envelopes.json"), &env)
+	app = &App{Stdout: &stdout, Stderr: &stderr}
+	if err := app.Run([]string{"partner", "key", "answer", "--key", keyFile, env.UID}); err == nil || !strings.Contains(err.Error(), "nonce") {
+		t.Errorf("a data envelope should be refused as carrying no nonce, got %v", err)
+	}
+}

--- a/cli/internal/app/ux_test.go
+++ b/cli/internal/app/ux_test.go
@@ -172,7 +172,7 @@ func TestCompletionScripts(t *testing.T) {
 		if err := app.Run([]string{"completion", shell}); err != nil {
 			t.Fatalf("completion %s: %v", shell, err)
 		}
-		for _, want := range []string{"openbanking", "accounts", "tx"} {
+		for _, want := range []string{"openbanking", "accounts", "tx", "partner"} {
 			if !strings.Contains(out.String(), want) {
 				t.Errorf("completion %s missing %q:\n%s", shell, want, out.String())
 			}


### PR DESCRIPTION
The CLI half of #187, split out because the CLI release build runs with `GOWORK=off` against the **published** Go SDK: `partner key answer` calls the `DecryptTo` that #187 exports, so this cannot build until `go/v0.4.0` is tagged. `cli/go.mod` already points at `v0.4.0`.

**Order:** merge #187 → tag `node/v1.2.0` and `go/v0.4.0` → this PR goes green → merge → tag `cli/v*`.

`openbanking partner key generate [--out FILE] [--print-private]` writes `recipient-key.json` (0600, never overwrites) and prints the public half and fingerprint; `partner key fingerprint [<file>|-]` accepts a key file, a bare PKCS#8 key or the raw point; `partner key answer --key FILE [<envelope>|-]` prints the nonce alone. Installing the key stays on the partner page (signed-in owner session, not an API key). Tests pin the committed fixture's fingerprint `91fa2aea473dbab6` by hand.