### PR TITLE
chore(go): 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,14 +29,16 @@ Detailed, auto-generated notes for every release live on the
 
 ### 2026-09
 
-- Node 1.2.0, Go 0.4.0, CLI: every partner now holds its own decryption key on open-banking.io,
+- Node 1.2.0, Go 0.4.1, CLI: every partner now holds its own decryption key on open-banking.io,
   and the relay carries an empty `privateKey` for its users. `parseRelay` takes
   `expectPrivateKey: "optional"` (the default stays `"required"`), `RelayError.reason` names the
   two partner-side refusals (`partner_key_missing`, `partner_suspended`), and
   `generateRecipientKeyPair`, `recipientKeyFingerprint`, `recipientPublicKey` and
   `answerRecipientKeyChallenge` cover the key itself. Go exports `DecryptEnvelope`/`DecryptTo`;
   the CLI gains `openbanking partner key generate|fingerprint|answer`. A new fixture,
-  `recipient-key-challenge.json`, pins the possession challenge for every SDK.
+  `recipient-key-challenge.json`, pins the possession challenge for every SDK. (Go `v0.4.0` was
+  tagged on the commit before these exports and is already in the module proxy, so it is
+  identical to 0.3.0; use 0.4.1.)
 
 ### 2026-08
 

--- a/go/client.go
+++ b/go/client.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Version is the released version of this client. It should track the release tag.
-const Version = "0.4.0"
+const Version = "0.4.1"
 
 // Client is a decrypting client for the open-banking.io API. Authenticates with an API key
 // (X-Api-Key) and decrypts the zero-knowledge data envelopes locally with the exported private key.


### PR DESCRIPTION
go/v0.4.0 was tagged on the commit before #187's exports landed, and proxy.golang.org and sum.golang.org already recorded it, so that version is immutable and identical to 0.3.0. The exports (DecryptEnvelope, DecryptTo) ship as go/v0.4.1: the cosmetic Version const and the changelog say so. Tag go/v0.4.1 on this merge.